### PR TITLE
feat(ui/event): Support multiline event messages

### DIFF
--- a/src/event/kubernetes/event.rs
+++ b/src/event/kubernetes/event.rs
@@ -96,7 +96,11 @@ async fn get_event_table(client: &KubeClient, namespaces: &[String]) -> Result<V
                 .enumerate()
                 .fold(String::new(), |mut s: String, (i, item)| -> String {
                     if i == v.row.len() - 1 {
-                        s += &format!("\n\x1b[90m> {}\x1b[0m\n ", item);
+                        item.lines()
+                            .for_each(|i| s += &format!("\n\x1b[90m> {}", i));
+
+                        s += "\x1b[0m\n ";
+                        // s += &format!("\n\x1b[90m> {}\x1b[0m\n ", item);
                     } else {
                         s += &format!("{:<4}  ", item);
                     }


### PR DESCRIPTION
Currently,  not highlighted.

<img width="711" alt="スクリーンショット 2023-06-15 16 48 42" src="https://github.com/sarub0b0/kubetui/assets/23615151/7db30463-5f07-4dfe-ad15-1a4e469d6f91">

expect

<img width="717" alt="スクリーンショット 2023-06-15 16 48 34" src="https://github.com/sarub0b0/kubetui/assets/23615151/b06f7de4-76ee-4926-b812-e75cab200026">
