### PR TITLE
fix(ui/single_select): resolve stack overflow crash in SelectForm

### DIFF
--- a/src/ui/widget/single_select/select.rs
+++ b/src/ui/widget/single_select/select.rs
@@ -60,8 +60,11 @@ impl SelectFormBuilder {
         list_widget = list_widget.widget_base(self.widget_base);
 
         SelectForm {
+            list_items: BTreeSet::new(),
             list_widget: list_widget.build(),
-            ..Default::default()
+            filter: "".to_string(),
+            chunk: Rect::default(),
+            matcher: SkimMatcherV2::default(),
         }
     }
 }


### PR DESCRIPTION
Fixed a stack overflow crash in SelectForm by initializing new fields: list_items, filter, chunk, and matcher. This prevents recursive calls from causing an infinite loop.