### PR TITLE
refactor: remove derivative crate and update impls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,7 +1255,6 @@ dependencies = [
  "clap",
  "crossbeam",
  "ctrlc",
- "derivative",
  "enum_dispatch",
  "flate2",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ base64 = "0.22.1"
 # tui
 async-trait = "0.1.80"
 chrono = "0.4.38"
-derivative = "2.2"
 enum_dispatch = "0.3.13"
 fuzzy-matcher = "0.3.7"
 ratatui = "0.28.0"

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 
+#[derive(Debug)]
 pub struct Clipboard;
 
 impl Clipboard {

--- a/src/features/network/kube/description/gateway/v1/related_resource/httproute.rs
+++ b/src/features/network/kube/description/gateway/v1/related_resource/httproute.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeSet;
 
 use anyhow::{Context, Result};
-use derivative::Derivative;
 use futures::future::{join_all, try_join_all};
 use k8s_openapi::{
     api::core::v1::Namespace, apimachinery::pkg::apis::meta::v1::LabelSelector, Resource as _,
@@ -21,21 +20,36 @@ use crate::{
 pub type RelatedHTTPRoutes = Vec<RelatedHTTPRoute>;
 
 /// RelatedResourceHTTPRouteのための
-#[derive(Derivative, Debug, Clone, Serialize, Deserialize)]
-#[derivative(PartialEq, Eq, Ord)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RelatedHTTPRoute {
     pub name: String,
 
     pub namespace: String,
 
-    #[derivative(PartialEq = "ignore", PartialOrd = "ignore", Ord = "ignore")]
     #[serde(skip)]
     pub resource: HTTPRoute,
+}
+
+impl Eq for RelatedHTTPRoute {}
+
+impl Ord for RelatedHTTPRoute {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        // nameとnamespaceが同じであれば同じリソースとして扱う
+        self.name
+            .cmp(&other.name)
+            .then_with(|| self.namespace.cmp(&other.namespace))
+    }
 }
 
 impl PartialOrd for RelatedHTTPRoute {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for RelatedHTTPRoute {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name && self.namespace == other.namespace
     }
 }
 

--- a/src/features/network/kube/description/gateway/v1/related_resource/service.rs
+++ b/src/features/network/kube/description/gateway/v1/related_resource/service.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use derivative::Derivative;
 use futures::StreamExt as _;
 use k8s_openapi::{api::core::v1::Service, Resource};
 use kube::{Api, Client, ResourceExt};
@@ -14,8 +13,7 @@ use super::httproute::RelatedHTTPRoute;
 
 pub type RelatedServices = Vec<RelatedService>;
 
-#[derive(Derivative, Debug, Clone, Serialize, Deserialize)]
-#[derivative(PartialEq, Eq, Ord)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RelatedService {
     /// Service Name
     pub name: String,
@@ -26,9 +24,27 @@ pub struct RelatedService {
     /// HTTPRoute Name
     pub httproute: String,
 
-    #[derivative(PartialEq = "ignore", PartialOrd = "ignore", Ord = "ignore")]
     #[serde(skip)]
     pub resource: Service,
+}
+
+impl Eq for RelatedService {}
+
+impl Ord for RelatedService {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.name
+            .cmp(&other.name)
+            .then_with(|| self.namespace.cmp(&other.namespace))
+            .then_with(|| self.httproute.cmp(&other.httproute))
+    }
+}
+
+impl PartialEq for RelatedService {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+            && self.namespace == other.namespace
+            && self.httproute == other.httproute
+    }
 }
 
 impl PartialOrd for RelatedService {

--- a/src/features/network/kube/description/httproute/v1/related_resource/service.rs
+++ b/src/features/network/kube/description/httproute/v1/related_resource/service.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use derivative::Derivative;
 use futures::StreamExt as _;
 use k8s_openapi::{api::core::v1::Service, Resource};
 use kube::{Api, Client, ResourceExt};
@@ -13,8 +12,7 @@ use crate::{
 
 pub type RelatedServices = Vec<RelatedService>;
 
-#[derive(Derivative, Debug, Clone, Serialize, Deserialize)]
-#[derivative(PartialEq, Eq, Ord)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RelatedService {
     /// Service Name
     pub name: String,
@@ -22,9 +20,24 @@ pub struct RelatedService {
     /// Service Namespace
     pub namespace: String,
 
-    #[derivative(PartialEq = "ignore", PartialOrd = "ignore", Ord = "ignore")]
     #[serde(skip)]
     pub resource: Service,
+}
+
+impl Eq for RelatedService {}
+
+impl Ord for RelatedService {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.name
+            .cmp(&other.name)
+            .then_with(|| self.namespace.cmp(&other.namespace))
+    }
+}
+
+impl PartialEq for RelatedService {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name && self.namespace == other.namespace
+    }
 }
 
 impl PartialOrd for RelatedService {

--- a/src/features/network/kube/description/httproute/v1beta1/related_resource/service.rs
+++ b/src/features/network/kube/description/httproute/v1beta1/related_resource/service.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use derivative::Derivative;
 use futures::StreamExt as _;
 use k8s_openapi::{api::core::v1::Service, Resource};
 use kube::{Api, Client, ResourceExt};
@@ -13,8 +12,7 @@ use crate::{
 
 pub type RelatedServices = Vec<RelatedService>;
 
-#[derive(Derivative, Debug, Clone, Serialize, Deserialize)]
-#[derivative(PartialEq, Eq, Ord)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RelatedService {
     /// Service Name
     pub name: String,
@@ -22,9 +20,24 @@ pub struct RelatedService {
     /// Service Namespace
     pub namespace: String,
 
-    #[derivative(PartialEq = "ignore", PartialOrd = "ignore", Ord = "ignore")]
     #[serde(skip)]
     pub resource: Service,
+}
+
+impl Eq for RelatedService {}
+
+impl Ord for RelatedService {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.name
+            .cmp(&other.name)
+            .then_with(|| self.namespace.cmp(&other.namespace))
+    }
+}
+
+impl PartialEq for RelatedService {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name && self.namespace == other.namespace
+    }
 }
 
 impl PartialOrd for RelatedService {

--- a/src/ui/callback.rs
+++ b/src/ui/callback.rs
@@ -11,6 +11,12 @@ macro_rules! define_callback {
                 $scope closure: std::rc::Rc<dyn [<$cb_name Fn>]>
             }
 
+            impl std::fmt::Debug for $cb_name {
+                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    write!(f, "{} {{ closure: _ }}", stringify!($cb_name))
+                }
+            }
+
             impl $cb_name {
                 $scope fn new<F>(cb: F) -> $cb_name
                 where

--- a/src/ui/widget/input.rs
+++ b/src/ui/widget/input.rs
@@ -1,6 +1,5 @@
 use std::time::{Duration, Instant};
 
-use derivative::Derivative;
 use ratatui::{
     crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent},
     layout::{Constraint, Direction, Layout, Rect},
@@ -198,14 +197,12 @@ impl Content {
     }
 }
 
-#[derive(Derivative)]
-#[derivative(Debug, Default)]
+#[derive(Debug, Default)]
 pub struct InputFormBuilder {
     id: String,
     widget_base: WidgetBase,
     prefix: Line<'static>,
     suffix: Line<'static>,
-    #[derivative(Debug = "ignore")]
     actions: Vec<(UserEvent, Callback)>,
 }
 
@@ -254,8 +251,7 @@ impl InputFormBuilder {
 
 /// 検索・フィルタリング用の入力フォーム
 /// 複数行は扱わない
-#[derive(Derivative)]
-#[derivative(Debug, Default)]
+#[derive(Debug, Default)]
 pub struct InputForm {
     id: String,
     content: Content,
@@ -267,7 +263,6 @@ pub struct InputForm {
     suffix: Line<'static>,
     widget_base: WidgetBase,
     scroll: usize,
-    #[derivative(Debug = "ignore")]
     actions: Vec<(UserEvent, Callback)>,
 }
 

--- a/src/ui/widget/list.rs
+++ b/src/ui/widget/list.rs
@@ -8,8 +8,6 @@ use ratatui::{
     Frame,
 };
 
-use derivative::*;
-
 use super::{base::WidgetBase, Item, LiteralItem, RenderTrait, SelectedItem, WidgetTrait};
 
 use crate::{
@@ -74,8 +72,8 @@ define_callback!(pub OnSelectCallback, Fn(&mut Window, &LiteralItem) -> EventRes
 define_callback!(pub RenderBlockInjection, Fn(&List, bool) -> Block<'static>);
 
 use inner_item::InnerItem;
-#[derive(Derivative)]
-#[derivative(Debug, Default)]
+
+#[derive(Debug, Default)]
 pub struct List<'a> {
     id: String,
     widget_base: WidgetBase,
@@ -83,22 +81,17 @@ pub struct List<'a> {
     state: ListState,
     chunk: Rect,
     inner_chunk: Rect,
-    #[derivative(Debug = "ignore")]
     on_select: Option<OnSelectCallback>,
-    #[derivative(Debug = "ignore")]
     block_injection: Option<RenderBlockInjection>,
 }
 
-#[derive(Derivative)]
-#[derivative(Debug, Default)]
+#[derive(Debug, Default)]
 pub struct ListBuilder {
     id: String,
     widget_base: WidgetBase,
     items: Vec<LiteralItem>,
     state: ListState,
-    #[derivative(Debug = "ignore")]
     on_select: Option<OnSelectCallback>,
-    #[derivative(Debug = "ignore")]
     block_injection: Option<RenderBlockInjection>,
 }
 

--- a/src/ui/widget/multiple_select.rs
+++ b/src/ui/widget/multiple_select.rs
@@ -4,8 +4,6 @@ mod select;
 
 use std::rc::Rc;
 
-use derivative::*;
-
 use ratatui::{
     crossterm::event::{KeyCode, KeyEvent, MouseEvent},
     layout::{Constraint, Direction, Layout, Rect},
@@ -28,14 +26,12 @@ pub use select::SelectForm;
 
 define_callback!(pub RenderBlockInjection, Fn(&MultipleSelect, bool) -> Block<'static>);
 
-#[derive(Derivative)]
-#[derivative(Debug, Default)]
+#[derive(Debug, Default)]
 pub struct MultipleSelectBuilder {
     id: String,
     widget_base: WidgetBase,
     select_form: SelectForm<'static>,
     filter_form: FilterForm,
-    #[derivative(Debug = "ignore")]
     block_injection: Option<RenderBlockInjection>,
 }
 
@@ -95,8 +91,7 @@ const LAYOUT_INDEX_FOR_INPUT_FORM: usize = 0;
 const LAYOUT_INDEX_FOR_STATUS: usize = 1;
 const LAYOUT_INDEX_FOR_SELECT_FORM: usize = 2;
 
-#[derive(Derivative)]
-#[derivative(Debug)]
+#[derive(Debug)]
 pub struct MultipleSelect<'a> {
     id: String,
     widget_base: WidgetBase,
@@ -106,7 +101,6 @@ pub struct MultipleSelect<'a> {
     layout: Layout,
     chunk: Rect,
     inner_chunks: Rc<[Rect]>,
-    #[derivative(Debug = "ignore")]
     block_injection: Option<RenderBlockInjection>,
 }
 

--- a/src/ui/widget/multiple_select/select.rs
+++ b/src/ui/widget/multiple_select/select.rs
@@ -1,5 +1,3 @@
-use derivative::*;
-
 use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
 
 use ratatui::{
@@ -136,8 +134,6 @@ impl SelectFormBuilder {
     }
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct SelectForm<'a> {
     items: SelectItems,
     filter: String,
@@ -147,8 +143,23 @@ pub struct SelectForm<'a> {
     active_form_index: usize,
     mouse_over_widget_index: Option<usize>,
     direction: Direction,
-    #[derivative(Debug = "ignore")]
     matcher: SkimMatcherV2,
+}
+
+impl std::fmt::Debug for SelectForm<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SelectForm")
+            .field("items", &self.items)
+            .field("filter", &self.filter)
+            .field("selected_widget", &self.selected_widget)
+            .field("unselected_widget", &self.unselected_widget)
+            .field("chunk", &self.chunk)
+            .field("active_form_index", &self.active_form_index)
+            .field("mouse_over_widget_index", &self.mouse_over_widget_index)
+            .field("direction", &self.direction)
+            .field("matcher", &"SkimMatcherV2")
+            .finish()
+    }
 }
 
 impl Default for SelectForm<'_> {

--- a/src/ui/widget/single_select.rs
+++ b/src/ui/widget/single_select.rs
@@ -10,8 +10,6 @@ use ratatui::{
     Frame,
 };
 
-use derivative::*;
-
 use crate::{
     define_callback,
     message::UserEvent,
@@ -31,16 +29,13 @@ const LAYOUT_INDEX_FOR_SELECT_FORM: usize = 2;
 
 define_callback!(pub RenderBlockInjection, Fn(&SingleSelect, bool) -> Block<'static>);
 
-#[derive(Derivative)]
-#[derivative(Debug, Default)]
+#[derive(Debug, Default)]
 pub struct SingleSelectBuilder {
     id: String,
     widget_base: WidgetBase,
     select_form: SelectForm<'static>,
     filter_form: FilterForm,
-    #[derivative(Debug = "ignore")]
     actions: Vec<(UserEvent, Callback)>,
-    #[derivative(Debug = "ignore")]
     block_injection: Option<RenderBlockInjection>,
 }
 
@@ -105,8 +100,7 @@ impl SingleSelectBuilder {
     }
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
+#[derive(Debug)]
 pub struct SingleSelect<'a> {
     id: String,
     widget_base: WidgetBase,
@@ -116,9 +110,7 @@ pub struct SingleSelect<'a> {
     layout: Layout,
     chunk: Rect,
     inner_chunks: Rc<[Rect]>,
-    #[derivative(Debug = "ignore")]
     callbacks: Vec<(UserEvent, Callback)>,
-    #[derivative(Debug = "ignore")]
     block_injection: Option<RenderBlockInjection>,
 }
 

--- a/src/ui/widget/single_select/select.rs
+++ b/src/ui/widget/single_select/select.rs
@@ -6,8 +6,6 @@ use ratatui::{
     Frame,
 };
 
-use derivative::*;
-
 use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
 
 use crate::ui::{
@@ -19,13 +17,10 @@ use crate::ui::{
     },
 };
 
-#[derive(Derivative)]
-#[derivative(Debug)]
+#[derive(Debug)]
 pub struct SelectFormBuilder {
     widget_base: WidgetBase,
-    #[derivative(Debug = "ignore")]
     on_select: Option<OnSelectCallback>,
-    #[derivative(Debug = "ignore")]
     block_injection: Option<RenderBlockInjection>,
 }
 
@@ -79,15 +74,24 @@ impl Default for SelectFormBuilder {
     }
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct SelectForm<'a> {
     list_items: BTreeSet<LiteralItem>,
     list_widget: List<'a>,
     filter: String,
     chunk: Rect,
-    #[derivative(Debug = "ignore")]
     matcher: SkimMatcherV2,
+}
+
+impl std::fmt::Debug for SelectForm<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SelectForm")
+            .field("list_items", &self.list_items)
+            .field("list_widget", &self.list_widget)
+            .field("filter", &self.filter)
+            .field("chunk", &self.chunk)
+            .field("matcher", &"SkimMatcherV2")
+            .finish()
+    }
 }
 
 impl Default for SelectForm<'_> {

--- a/src/ui/widget/table.rs
+++ b/src/ui/widget/table.rs
@@ -4,7 +4,6 @@ mod item;
 
 use std::rc::Rc;
 
-use derivative::*;
 use filter::FilterForm;
 use ratatui::{
     crossterm::event::{KeyCode, KeyEvent, MouseButton, MouseEvent, MouseEventKind},
@@ -41,8 +40,7 @@ define_callback!(pub OnSelectCallback, Fn(&mut Window, &TableItem) -> EventResul
 define_callback!(pub RenderBlockInjection, Fn(&Table) -> WidgetBase);
 define_callback!(pub RenderHighlightInjection, Fn(Option<&TableItem>) -> Style);
 
-#[derive(Derivative)]
-#[derivative(Debug, Default)]
+#[derive(Debug, Default)]
 pub struct TableBuilder {
     id: String,
     widget_base: WidgetBase,
@@ -52,13 +50,9 @@ pub struct TableBuilder {
     items: Vec<TableItem>,
     state: TableState,
     filtered_key: String,
-    #[derivative(Debug = "ignore")]
     on_select: Option<OnSelectCallback>,
-    #[derivative(Debug = "ignore")]
     actions: Vec<(UserEvent, Callback)>,
-    #[derivative(Debug = "ignore")]
     block_injection: Option<RenderBlockInjection>,
-    #[derivative(Debug = "ignore")]
     highlight_injection: Option<RenderHighlightInjection>,
 }
 
@@ -205,8 +199,7 @@ impl Mode {
     }
 }
 
-#[derive(Derivative)]
-#[derivative(Debug, Default)]
+#[derive(Debug, Default)]
 pub struct Table<'a> {
     id: String,
     widget_base: WidgetBase,
@@ -219,13 +212,9 @@ pub struct Table<'a> {
     filter_form: FilterForm,
     filtered_key: String,
     mode: Mode,
-    #[derivative(Debug = "ignore")]
     on_select: Option<OnSelectCallback>,
-    #[derivative(Debug = "ignore")]
     actions: Vec<(UserEvent, Callback)>,
-    #[derivative(Debug = "ignore")]
     block_injection: Option<RenderBlockInjection>,
-    #[derivative(Debug = "ignore")]
     highlight_injection: Option<RenderHighlightInjection>,
 }
 

--- a/src/ui/widget/table/item.rs
+++ b/src/ui/widget/table/item.rs
@@ -1,4 +1,3 @@
-use derivative::*;
 use ratatui::{
     style::{Color, Style},
     widgets::{Cell, Row},
@@ -68,8 +67,7 @@ pub struct InnerRow<'a> {
     pub height: usize,
 }
 
-#[derive(Derivative)]
-#[derivative(Debug, Default)]
+#[derive(Debug, Default)]
 pub struct InnerItem<'a> {
     header: Header<'a>,
     original_items: Vec<TableItem>,

--- a/src/ui/widget/text.rs
+++ b/src/ui/widget/text.rs
@@ -5,8 +5,6 @@ mod wrap;
 
 use std::{cell::RefCell, rc::Rc};
 
-use derivative::Derivative;
-
 use ratatui::{
     crossterm::event::{KeyCode, KeyEvent, MouseButton, MouseEvent, MouseEventKind},
     layout::Rect,
@@ -156,8 +154,7 @@ impl Mode {
     }
 }
 
-#[derive(Derivative)]
-#[derivative(Debug, Default)]
+#[derive(Debug, Default)]
 pub struct TextBuilder {
     id: String,
     widget_base: WidgetBase,
@@ -165,11 +162,8 @@ pub struct TextBuilder {
     item: Vec<LiteralItem>,
     wrap: bool,
     follow: bool,
-    #[derivative(Debug = "ignore")]
     block_injection: Option<RenderBlockInjection>,
-    #[derivative(Debug = "ignore")]
     actions: Vec<(UserEvent, Callback)>,
-    #[derivative(Debug = "ignore")]
     clipboard: Option<Rc<RefCell<Clipboard>>>,
 }
 
@@ -247,8 +241,7 @@ impl TextBuilder {
     }
 }
 
-#[derive(Derivative)]
-#[derivative(Debug, Default)]
+#[derive(Debug, Default)]
 pub struct Text {
     id: String,
     widget_base: WidgetBase,
@@ -261,11 +254,8 @@ pub struct Text {
     /// 検索中、検索ワード入力中、オフの3つのモード
     mode: Mode,
     highlight_content: Option<HighlightContent>,
-    #[derivative(Debug = "ignore")]
     block_injection: Option<RenderBlockInjection>,
-    #[derivative(Debug = "ignore")]
     actions: Vec<(UserEvent, Callback)>,
-    #[derivative(Debug = "ignore")]
     clipboard: Option<Rc<RefCell<Clipboard>>>,
 }
 


### PR DESCRIPTION
The `derivative` crate is no longer maintained, so I will stop using it.