### PR TITLE
Add support for pretty-printed JSON logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ It provides an easy-to-use interface for developers and operators to access impo
 
 Kubetui offers the following features to help you monitor and manage your Kubernetes resources:
 
-- **Pods List and Container Logs**: Easily view a list of pods and their container logs.
+- **Pods List and Container Logs**:
+  - View a list of pods and their container logs.
+  - JSON logs display mode switching: toggle between pretty print and single-line display using the <kbd>f</kbd> or <kbd>p</kbd> keys.
 - **ConfigMap and Secret Watching**: Monitor ConfigMaps and secrets, and decode their data.
 - **Network-related Resources**: Explore a list of network-related resources and their descriptions.
 - **Events Watching**: Stay updated with a real-time view of Kubernetes events.
@@ -354,6 +356,13 @@ ESCAPED_CHAR = "\\" | "\"" | "\'"
 | <kbd>Ctrl+w</kbd>                 | Delete text from the cursor to the beginning     |
 | <kbd>Ctrl+k</kbd>                 | Delete text from the cursor to the end           |
 | <kbd>Left</kbd>, <kbd>Right</kbd> | Move the cursor to the previous / next character |
+
+### Container Logs View
+
+| Key                          | Description                                                        |
+| ---------------------------- | ------------------------------------------------------------------ |
+| <kbd>f</kbd>, <kbd>p</kbd>   | Toggle between pretty print and single-line display for JSON logs. |
+| <kbd>Enter</kbd>             | Insert a blank line.                                               |
 
 ## Contributing
 

--- a/src/features/help/dialog.rs
+++ b/src/features/help/dialog.rs
@@ -201,10 +201,16 @@ const RIGHT_HELP_TEXT: &[HelpBlock] = &[
     },
     HelpBlock {
         title: "Log",
-        bindings: &[KeyBindings {
-            keys: &["Enter"],
-            desc: "insert blank line",
-        }],
+        bindings: &[
+            KeyBindings {
+                keys: &["Enter"],
+                desc: "insert blank line",
+            },
+            KeyBindings {
+                keys: &["p"],
+                desc: "toggle json pretty print",
+            },
+        ],
     },
 ];
 

--- a/src/features/help/dialog.rs
+++ b/src/features/help/dialog.rs
@@ -207,7 +207,7 @@ const RIGHT_HELP_TEXT: &[HelpBlock] = &[
                 desc: "insert blank line",
             },
             KeyBindings {
-                keys: &["p"],
+                keys: &["f", "p"],
                 desc: "toggle json pretty print",
             },
         ],

--- a/src/features/pod/kube/log/log_content.rs
+++ b/src/features/pod/kube/log/log_content.rs
@@ -1,0 +1,25 @@
+pub struct LogContent {
+    pub prefix: String,
+    pub content: String,
+}
+
+impl LogContent {
+    pub fn print(&self) -> String {
+        format!("{} {}", self.prefix, self.content)
+    }
+
+    pub fn try_json_pritty_print(&self) -> Vec<String> {
+        let Ok(json) = serde_json::from_str::<serde_json::Value>(&self.content) else {
+            return vec![self.print()];
+        };
+
+        let Ok(pretty) = serde_json::to_string_pretty(&json) else {
+            return vec![self.print()];
+        };
+
+        pretty
+            .lines()
+            .map(|line| format!("{}  {}", self.prefix, line))
+            .collect()
+    }
+}

--- a/src/features/pod/kube/log/log_streamer.rs
+++ b/src/features/pod/kube/log/log_streamer.rs
@@ -22,7 +22,7 @@ use crate::{
     workers::kube::{color::fg::Color, AbortWorker},
 };
 
-use super::log_collector::LogBuffer;
+use super::{log_collector::LogBuffer, log_content::LogContent};
 
 #[derive(Debug, Clone, Copy)]
 pub enum LogPrefixType {
@@ -166,7 +166,10 @@ impl LogStreamer {
                     continue;
                 }
 
-                buf.push(format!("{}{}", prefix, content));
+                buf.push(LogContent {
+                    prefix: prefix.to_string(),
+                    content: content.to_string(),
+                });
 
                 *last_timestamp = Some(dt);
             } else {
@@ -174,7 +177,10 @@ impl LogStreamer {
                     continue;
                 }
 
-                buf.push(format!("{}{}", prefix, line));
+                buf.push(LogContent {
+                    prefix: prefix.to_string(),
+                    content: line.to_string(),
+                });
             }
         }
 
@@ -201,7 +207,10 @@ impl LogStreamer {
 
         let mut buf = self.log_buffer.lock().await;
 
-        buf.push(format!("{} {}", sign, self.log_prefix_content()));
+        buf.push(LogContent {
+            prefix: sign,
+            content: self.log_prefix_content(),
+        });
     }
 
     async fn send_finished_message(&self) {
@@ -209,7 +218,10 @@ impl LogStreamer {
 
         let mut buf = self.log_buffer.lock().await;
 
-        buf.push(format!("{} {}", sign, self.log_prefix_content()));
+        buf.push(LogContent {
+            prefix: sign,
+            content: self.log_prefix_content(),
+        });
     }
 
     fn log_prefix_content(&self) -> String {
@@ -251,7 +263,7 @@ impl LogStreamer {
                 let close_bracket = prefix_color.container.wrap("]");
 
                 format!(
-                    "{}{}{} ",
+                    "{}{}{}",
                     open_bracket,
                     self.log_prefix_content(),
                     close_bracket
@@ -261,7 +273,7 @@ impl LogStreamer {
                 let open_bracket = prefix_color.pod.wrap("[");
                 let close_bracket = prefix_color.pod.wrap("]");
                 format!(
-                    "{}{}{} ",
+                    "{}{}{}",
                     open_bracket,
                     self.log_prefix_content(),
                     close_bracket

--- a/src/features/pod/message.rs
+++ b/src/features/pod/message.rs
@@ -8,6 +8,7 @@ use super::kube::LogConfig;
 pub enum LogMessage {
     Request(LogConfig),
     Response(Result<Vec<String>>),
+    ToggleJsonPrettyPrint,
 }
 
 impl From<LogMessage> for Message {

--- a/src/features/pod/view/tab.rs
+++ b/src/features/pod/view/tab.rs
@@ -32,7 +32,7 @@ impl PodTab {
     ) -> Self {
         let pod_widget = pod_widget(tx);
         let log_query_widget = log_query_widget(tx, namespaces);
-        let log_widget = log_widget(clipboard);
+        let log_widget = log_widget(tx, clipboard);
         let log_query_help_widget = log_query_help_widget();
 
         let layout = TabLayout::new(layout, split_direction);

--- a/src/features/pod/view/widgets/log.rs
+++ b/src/features/pod/view/widgets/log.rs
@@ -26,6 +26,10 @@ pub fn log_widget(
         .block_injection(block_injection())
         .action(UserEvent::from(KeyCode::Enter), add_blankline())
         .action(
+            UserEvent::from(KeyCode::Char('f')),
+            toggle_json_pretty_print(tx.clone()),
+        )
+        .action(
             UserEvent::from(KeyCode::Char('p')),
             toggle_json_pretty_print(tx.clone()),
         );

--- a/src/features/pod/view/widgets/log.rs
+++ b/src/features/pod/view/widgets/log.rs
@@ -1,11 +1,12 @@
 use std::{cell::RefCell, rc::Rc};
 
+use crossbeam::channel::Sender;
 use ratatui::{crossterm::event::KeyCode, widgets::Block};
 
 use crate::{
     clipboard::Clipboard,
-    features::component_id::POD_LOG_WIDGET_ID,
-    message::UserEvent,
+    features::{component_id::POD_LOG_WIDGET_ID, pod::message::LogMessage},
+    message::{Message, UserEvent},
     ui::{
         event::EventResult,
         widget::{Item, Text, Widget, WidgetBase, WidgetTrait as _},
@@ -13,14 +14,21 @@ use crate::{
     },
 };
 
-pub fn log_widget(clipboard: &Option<Rc<RefCell<Clipboard>>>) -> Widget<'static> {
+pub fn log_widget(
+    tx: &Sender<Message>,
+    clipboard: &Option<Rc<RefCell<Clipboard>>>,
+) -> Widget<'static> {
     let builder = Text::builder()
         .id(POD_LOG_WIDGET_ID)
         .widget_base(WidgetBase::builder().title("Log").build())
         .wrap()
         .follow()
         .block_injection(block_injection())
-        .action(UserEvent::from(KeyCode::Enter), add_blankline());
+        .action(UserEvent::from(KeyCode::Enter), add_blankline())
+        .action(
+            UserEvent::from(KeyCode::Char('p')),
+            toggle_json_pretty_print(tx.clone()),
+        );
 
     if let Some(cb) = clipboard {
         builder.clipboard(cb.clone())
@@ -49,6 +57,19 @@ fn add_blankline() -> impl Fn(&mut Window) -> EventResult {
 
         w.select_last();
         w.append_widget_item(Item::Single(Default::default()));
+
+        EventResult::Nop
+    }
+}
+
+fn toggle_json_pretty_print(tx: Sender<Message>) -> impl Fn(&mut Window) -> EventResult {
+    move |w: &mut Window| {
+        let w = w.find_widget_mut(POD_LOG_WIDGET_ID);
+
+        w.clear();
+
+        tx.send(LogMessage::ToggleJsonPrettyPrint.into())
+            .expect("Failed to send LogMessage::ToggleJsonPrettyPrint");
 
         EventResult::Nop
     }

--- a/src/features/pod/view/widgets/log_query.rs
+++ b/src/features/pod/view/widgets/log_query.rs
@@ -61,7 +61,7 @@ fn exec_query(
             LogPrefixType::PodAndContainer
         };
 
-        let config = LogConfig::new(item, namespaces.to_owned(), prefix_type);
+        let config = LogConfig::new(item, namespaces.to_owned(), prefix_type, false);
 
         tx.send(LogMessage::Request(config).into())
             .expect("Failed to send LogMessage::Request");

--- a/src/features/pod/view/widgets/pod.rs
+++ b/src/features/pod/view/widgets/pod.rs
@@ -72,6 +72,7 @@ fn on_select(tx: Sender<Message>) -> impl Fn(&mut Window, &TableItem) -> EventRe
             format!("pod/{}", name),
             namespaces.to_owned(),
             LogPrefixType::OnlyContainer,
+            false,
         );
 
         tx.send(LogMessage::Request(config).into())


### PR DESCRIPTION
This pull request implements a feature that allows users to toggle pretty print for JSON logs in the log view. By pressing the `p` or `f` key, users can switch between the standard and pretty-printed formats, making it easier to read structured JSON logs.

Related to #652 