### PR TITLE
docs: add jmespath filter to query syntax documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ QUERY = POD
         | LABEL
         | FIELD
         | JQ
+        | JMESPATH
         | SPECIFIED_RESOURCE
 
 POD = ( "pods" | "pod" | "po" | "p" ) ":" REGEX
@@ -369,6 +370,8 @@ FIELD = ( "fields" | "field" ) ":" SELECTOR
 SELECTOR = QUOTED_STRING | UNQUOTED_STRING
 
 JQ = "jq" ":" EXPR
+
+JMESPATH = ( "jmespath" | "jmes" | "jm" ) ":" EXPR
 
 EXPR = QUOTED_STRING | UNQUOTED_STRING
 


### PR DESCRIPTION
## Summary

This PR fixes a documentation gap in PR #852 by adding the missing JMESPATH grammar definition to the Query Syntax section in README.md.

## Background

PR #852 added the `jmespath:` filter syntax to the log query feature and updated the "Supported Queries" table in the README. However, the formal grammar definition in the "Query Syntax" section was not updated to include the JMESPATH rule.

## Changes

- Add `JMESPATH` to the `QUERY` definition (line 353)
- Add `JMESPATH` grammar rule with all three aliases: `jmespath`, `jmes`, and `jm` (line 374)

## Related

- Fixes documentation gap in #852

🤖 Generated with [Claude Code](https://claude.com/claude-code)