### PR TITLE
fix: allow uppercase input in InputForm widget

### DIFF
--- a/src/ui/widget/input.rs
+++ b/src/ui/widget/input.rs
@@ -485,7 +485,7 @@ impl InputForm {
                 self.back_cursor();
             }
 
-            KeyCode::Char(c) if key.modifiers == KeyModifiers::NONE => {
+            KeyCode::Char(c) if !key.modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) => {
                 self.insert_char(c);
             }
             _ => {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Fixed an issue where uppercase input (Shift+key combinations) was blocked in the InputForm widget
- This regression was introduced in PR #853 when adding Ctrl+Space support with strict modifier key checking
- While Kubernetes resource names use lowercase only, this fix ensures the UI component behaves as expected for general text input

## Changes

- Changed key modifier check from `key.modifiers == KeyModifiers::NONE` to `!key.modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)`
- This allows Shift key combinations while still blocking Control and Alt key shortcuts

## Test plan

- [x] All existing unit tests pass (6 tests in `input::tests`)
- [x] Build succeeds
- [x] Manual test: Verify uppercase characters can be input in text fields
- [x] Manual test: Confirm existing shortcuts (Ctrl+W, Ctrl+K) still work
- [x] Manual test: Verify Ctrl+Space functionality from PR #853 is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)