### PR TITLE
refactor: replace WorkerResult with ChangedContext and rename AbortWorker to InfiniteWorker

### DIFF
--- a/docs/plans/2026-04-07-worker-result-refactoring-design.md
+++ b/docs/plans/2026-04-07-worker-result-refactoring-design.md
@@ -1,0 +1,118 @@
+# WorkerResult リファクタリング設計
+
+## 動機
+
+1. **パニック問題の解消:** 無限ループのポーラーが `Worker<Output = WorkerResult>` を実装しているが、正常に return できないため `tx.send().expect()` でパニックしている
+2. **enum 構造の改善:** `WorkerResult` はバリアントが `ChangedContext` の1つだけで、enum として不自然
+
+## アプローチ
+
+`AbortWorker` を `InfiniteWorker` にリネームし、ポーラーを `InfiniteWorker` に移行。`WorkerResult` enum を `ChangedContext` 構造体に変換する。
+
+## 設計詳細
+
+### 1. trait の変更
+
+`AbortWorker` を `InfiniteWorker` にリネーム。シグネチャの変更はなし。
+
+```rust
+// worker.rs
+pub trait Worker {
+    type Output;
+    async fn run(&self) -> Self::Output;
+    fn spawn(&self) -> JoinHandle<Self::Output>;
+}
+
+pub trait InfiniteWorker {  // AbortWorker → リネーム
+    async fn run(&self);
+    fn spawn(&self) -> AbortHandle;
+}
+```
+
+### 2. `WorkerResult` enum → `ChangedContext` 構造体
+
+```rust
+// 変更前
+#[derive(Clone)]
+pub enum WorkerResult {
+    ChangedContext {
+        target_context: String,
+        target_namespaces: Option<TargetNamespaces>,
+    },
+}
+
+// 変更後
+#[derive(Clone)]
+pub struct ChangedContext {
+    pub target_context: String,
+    pub target_namespaces: Option<TargetNamespaces>,
+}
+```
+
+`EventController` は `Worker<Output = ChangedContext>` を実装。
+
+### 3. ポーラーの trait 移行
+
+対象5つ:
+- `PodPoller` (`src/features/pod/kube/pod.rs`)
+- `EventPoller` (`src/features/event/kube/event.rs`)
+- `ConfigPoller` (`src/features/config/kube/config.rs`)
+- `NetworkPoller` (`src/features/network/kube/network.rs`)
+- `ApiPoller` (`src/features/api_resources/kube/api_resources.rs`)
+
+各ポーラーを `Worker` から `InfiniteWorker` に変更。`tx.send().expect()` を `if let Err(e)` でログ出力後 `return` に置き換え。
+
+```rust
+// 変更前
+#[async_trait]
+impl Worker for PodPoller {
+    type Output = WorkerResult;
+    async fn run(&self) -> Self::Output {
+        loop {
+            tx.send(PodMessage::Poll(pod_info).into())
+                .expect("Failed to Kube::Pod");
+        }
+    }
+}
+
+// 変更後
+#[async_trait]
+impl InfiniteWorker for PodPoller {
+    async fn run(&self) {
+        loop {
+            if let Err(e) = tx.send(PodMessage::Poll(pod_info).into()) {
+                logger!(error, "Failed to send PodMessage::Poll: {}", e);
+                return;
+            }
+        }
+    }
+}
+```
+
+### 4. コントローラーのハンドル管理
+
+ポーラーは `AbortHandle`、`EventController` だけ `JoinHandle<ChangedContext>` で管理。`select_all` が不要になる。
+
+```rust
+// ポーラーは AbortHandle
+let pod_handle: AbortHandle = pod_poller.spawn();
+let config_handle: AbortHandle = config_poller.spawn();
+// ...
+
+// EventController だけ JoinHandle
+let event_controller_handle = event_controller.spawn();
+let result = event_controller_handle.await;
+
+match result {
+    Ok(ChangedContext { target_context, target_namespaces }) => {
+        // ポーラーを abort して、コンテキスト切り替え処理
+    }
+    Err(join_error) => { /* パニック等のハンドリング */ }
+}
+```
+
+### 決定事項
+
+- コンテキスト切り替えフローは現状を維持
+- チャンネル切断時は `if let Err(e)` でログ出力後 `return`（伝搬先がないため）
+- ロギングはプロジェクト既存の `logger!` マクロを使用

--- a/docs/plans/2026-04-07-worker-result-refactoring-plan.md
+++ b/docs/plans/2026-04-07-worker-result-refactoring-plan.md
@@ -1,0 +1,527 @@
+# WorkerResult リファクタリング実装計画
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** `WorkerResult` enum を `ChangedContext` 構造体に変換し、ポーラーを `InfiniteWorker` trait に移行することで、型安全性の向上とパニックの除去を実現する。
+
+**Architecture:** `AbortWorker` を `InfiniteWorker` にリネームし、無限ループのポーラー5つを `Worker` から `InfiniteWorker` に移行。`EventController` のみ `Worker<Output = ChangedContext>` を維持。コントローラーのメインループを `select_all` から `EventController` 単独 await + abort パターンに変更。
+
+**Tech Stack:** Rust, async_trait, tokio, crossbeam channel
+
+---
+
+### Task 1: `AbortWorker` → `InfiniteWorker` リネーム（trait 定義）
+
+**Files:**
+- Modify: `src/workers/kube/worker.rs:21` — trait 名を変更
+
+**Step 1: trait 名をリネーム**
+
+`src/workers/kube/worker.rs` の `AbortWorker` を `InfiniteWorker` に変更:
+
+```rust
+#[async_trait]
+pub trait InfiniteWorker {
+    async fn run(&self);
+
+    fn spawn(&self) -> AbortHandle
+    where
+        Self: Clone + Send + Sync + 'static,
+    {
+        let worker = self.clone();
+        tokio::spawn(async move { worker.run().await }).abort_handle()
+    }
+}
+```
+
+**Step 2: 既存の `AbortWorker` 利用箇所をすべてリネーム**
+
+以下のファイルで `AbortWorker` → `InfiniteWorker` に置換:
+
+- `src/workers/kube/controller.rs:55` — `AbortWorker as _` → `InfiniteWorker as _`
+- `src/features/get/kube/yaml.rs:24` — import
+- `src/features/get/kube/yaml.rs:74` — `impl AbortWorker for GetYamlWorker`
+- `src/features/network/kube/description.rs:20` — import
+- `src/features/network/kube/description.rs:80` — `impl AbortWorker for NetworkDescriptionWorker`
+- `src/features/config/kube/raw_data.rs:12` — import
+- `src/features/config/kube/raw_data.rs:31` — `impl AbortWorker for ConfigsDataWorker`
+- `src/features/yaml/kube/worker.rs:13` — import
+- `src/features/yaml/kube/worker.rs:51` — `impl AbortWorker for YamlWorker`
+- `src/features/pod/kube/log.rs:25` — import
+- `src/features/pod/kube/log.rs:138` — `impl AbortWorker for LogWorker`
+- `src/features/pod/kube/log/pod_watcher.rs:25` — import
+- `src/features/pod/kube/log/log_streamer.rs:22` — import
+- `src/features/pod/kube/log/log_streamer.rs:92` — `impl AbortWorker for LogStreamer`
+
+**Step 3: ビルド確認**
+
+Run: `cargo check 2>&1 | head -30`
+Expected: ビルド成功（警告のみ OK）
+
+**Step 4: コミット**
+
+```bash
+git add -A && git commit -m "refactor: rename AbortWorker to InfiniteWorker"
+```
+
+---
+
+### Task 2: `WorkerResult` enum → `ChangedContext` 構造体
+
+**Files:**
+- Modify: `src/workers/kube/controller.rs:128-137` — enum → struct
+- Modify: `src/workers/kube/controller.rs:471` — `EventController` の `type Output`
+- Modify: `src/workers/kube/controller.rs:641` — `return WorkerResult::ChangedContext {..}` → `return ChangedContext {..}`
+- Modify: `src/workers/kube/controller.rs:361-362` — `select_all` のマッチパターン（Task 3 で `select_all` 自体を削除するため、ここでは型のみ変更）
+
+**Step 1: enum を struct に変換**
+
+`src/workers/kube/controller.rs` の `WorkerResult` を以下に変更:
+
+```rust
+#[derive(Clone)]
+pub struct ChangedContext {
+    /// 切り替え後のコンテキスト
+    pub target_context: String,
+
+    /// 切り替え後のターゲットネームスペース
+    pub target_namespaces: Option<TargetNamespaces>,
+}
+```
+
+**Step 2: `EventController` の Output 型を変更**
+
+`src/workers/kube/controller.rs:471`:
+
+```rust
+impl Worker for EventController {
+    type Output = ChangedContext;
+```
+
+**Step 3: return 箇所を変更**
+
+`src/workers/kube/controller.rs:641`:
+
+```rust
+return ChangedContext {
+    target_context: name.clone(),
+    target_namespaces,
+};
+```
+
+**Step 4: `select_all` のマッチパターンを変更**
+
+`src/workers/kube/controller.rs:361-365`:
+
+```rust
+Ok(ChangedContext {
+    target_context,
+    target_namespaces,
+}) => {
+```
+
+**Step 5: import から `WorkerResult` を削除・利用箇所を更新**
+
+ポーラーのファイルではまだ `WorkerResult` を import しているが、次の Task 3 で `Worker` → `InfiniteWorker` に変更するため、ここではまだ触れない。`controller.rs` 内のみ変更。
+
+**Step 6: ビルド確認**
+
+Run: `cargo check 2>&1 | head -30`
+Expected: ポーラーが `WorkerResult` を参照しているためエラーが出る（期待通り、Task 3 で解消）
+
+**Step 7: コミットしない（Task 3 と合わせてコミット）**
+
+---
+
+### Task 3: ポーラーを `InfiniteWorker` に移行
+
+**Files:**
+- Modify: `src/features/pod/kube/pod.rs:21,81-101`
+- Modify: `src/features/event/kube/event.rs:19,68-93`
+- Modify: `src/features/config/kube/config.rs:11,42-68`
+- Modify: `src/features/network/kube/network.rs:31,267-292`
+- Modify: `src/features/api_resources/kube/api_resources.rs:28-31,273-363`
+
+**Step 1: `PodPoller` を移行**
+
+`src/features/pod/kube/pod.rs`:
+- import: `Worker, WorkerResult` → `InfiniteWorker`
+- `logger` マクロの import を追加（未 import の場合）
+
+```rust
+use crate::{
+    // ...
+    logger,
+    workers::kube::{SharedPodColumns, SharedTargetNamespaces, InfiniteWorker},
+};
+
+#[async_trait]
+impl InfiniteWorker for PodPoller {
+    async fn run(&self) {
+        let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(1));
+
+        let Self { tx, .. } = self;
+
+        loop {
+            interval.tick().await;
+
+            let pod_info = self.get_pod_info().await;
+
+            if let Err(e) = tx.send(PodMessage::Poll(pod_info).into()) {
+                logger!(error, "Failed to send PodMessage::Poll: {}", e);
+                return;
+            }
+        }
+    }
+}
+```
+
+**Step 2: `EventPoller` を移行**
+
+`src/features/event/kube/event.rs`:
+- import: `Worker, WorkerResult` → `InfiniteWorker`
+
+```rust
+use crate::{
+    // ...
+    logger,
+    workers::kube::{message::Kube, SharedTargetNamespaces, InfiniteWorker},
+};
+
+#[async_trait]
+impl InfiniteWorker for EventPoller {
+    async fn run(&self) {
+        let Self {
+            tx,
+            shared_target_namespaces,
+            kube_client,
+            config,
+        } = self;
+
+        let mut interval = tokio::time::interval(time::Duration::from_millis(1000));
+
+        loop {
+            interval.tick().await;
+            let target_namespaces = shared_target_namespaces.read().await;
+
+            let event_list = get_event_table(config, kube_client, &target_namespaces).await;
+
+            if let Err(e) = tx.send(Message::Kube(Kube::Event(event_list))) {
+                logger!(error, "Failed to send Kube::Event: {}", e);
+                return;
+            }
+        }
+    }
+}
+```
+
+**Step 3: `ConfigPoller` を移行**
+
+`src/features/config/kube/config.rs`:
+- import: `Worker, WorkerResult` → `InfiniteWorker`
+
+```rust
+use crate::{
+    // ...
+    logger,
+    workers::kube::{SharedTargetNamespaces, InfiniteWorker},
+};
+
+#[async_trait]
+impl InfiniteWorker for ConfigPoller {
+    async fn run(&self) {
+        let mut interval = tokio::time::interval(time::Duration::from_secs(1));
+
+        let Self {
+            tx,
+            shared_target_namespaces,
+            kube_client,
+        } = self;
+
+        loop {
+            interval.tick().await;
+
+            let target_namespaces = shared_target_namespaces.read().await;
+
+            let table = fetch_configs(kube_client, &target_namespaces).await;
+
+            if let Err(e) = tx.send(ConfigResponse::Table(table).into()) {
+                logger!(error, "Failed to send ConfigResponse::Table: {}", e);
+                return;
+            }
+        }
+    }
+}
+```
+
+**Step 4: `NetworkPoller` を移行**
+
+`src/features/network/kube/network.rs`:
+- import: `Worker, WorkerResult` → `InfiniteWorker`
+
+```rust
+use crate::{
+    // ...
+    logger,
+    workers::kube::{SharedTargetNamespaces, InfiniteWorker},
+};
+
+#[async_trait()]
+impl InfiniteWorker for NetworkPoller {
+    async fn run(&self) {
+        let mut interval = tokio::time::interval(time::Duration::from_secs(1));
+
+        let tx = &self.tx;
+
+        loop {
+            interval.tick().await;
+
+            let target_resources = {
+                let apis = self.api_resources.read().await;
+                target_resources(&apis)
+            };
+
+            let table = self.polling(&target_resources).await;
+
+            if let Err(e) = tx.send(NetworkResponse::List(table).into()) {
+                logger!(error, "Failed to send NetworkResponse::List: {}", e);
+                return;
+            }
+        }
+    }
+}
+```
+
+**Step 5: `ApiPoller` を移行**
+
+`src/features/api_resources/kube/api_resources.rs`:
+- import: `Worker, WorkerResult` → `InfiniteWorker`
+- `ApiPoller` は `send` 箇所が4つあるため、すべて `if let Err(e)` に変更
+
+```rust
+use crate::{
+    // ...
+    logger,
+    workers::kube::{
+        SharedTargetApiResources, SharedTargetNamespaces, TargetApiResources, TargetNamespaces,
+        InfiniteWorker,
+    },
+};
+
+#[async_trait]
+impl InfiniteWorker for ApiPoller {
+    async fn run(&self) {
+        let Self {
+            tx,
+            shared_target_namespaces,
+            kube_client,
+            shared_target_api_resources,
+            shared_api_resources,
+            config,
+        } = self;
+
+        match fetch_api_resources(kube_client).await {
+            Ok(fetched) => {
+                let mut api_resources = shared_api_resources.write().await;
+                *api_resources = fetched;
+            }
+            Err(err) => {
+                if let Err(e) = tx.send(ApiResponse::Poll(Err(err)).into()) {
+                    logger!(error, "Failed to send ApiResponse::Poll: {}", e);
+                    return;
+                }
+            }
+        }
+
+        let mut interval = tokio::time::interval(time::Duration::from_millis(1000));
+
+        let mut last_tick = Instant::now();
+        let tick_rate = time::Duration::from_secs(10);
+
+        let mut is_error = false;
+
+        loop {
+            interval.tick().await;
+
+            if tick_rate < last_tick.elapsed() {
+                last_tick = Instant::now();
+
+                match fetch_api_resources(kube_client).await {
+                    Ok(fetched) => {
+                        let mut api_resources = shared_api_resources.write().await;
+                        *api_resources = fetched;
+
+                        if is_error {
+                            is_error = false;
+                            if let Err(e) = tx.send(ApiResponse::Poll(Ok(Default::default())).into()) {
+                                logger!(error, "Failed to send ApiResponse::Poll: {}", e);
+                                return;
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        if let Err(e) = tx.send(ApiResponse::Poll(Err(err)).into()) {
+                            logger!(error, "Failed to send ApiResponse::Poll: {}", e);
+                            return;
+                        }
+                        is_error = true;
+                        continue;
+                    }
+                }
+            }
+
+            let target_namespaces = shared_target_namespaces.read().await;
+            let target_api_resources = shared_target_api_resources.read().await;
+
+            if target_api_resources.is_empty() {
+                continue;
+            }
+
+            let result = FetchTargetApiResources::new(
+                kube_client,
+                &target_api_resources,
+                &target_namespaces,
+                config,
+            )
+            .fetch_table()
+            .await;
+
+            if let Err(e) = tx.send(ApiResponse::Poll(result).into()) {
+                logger!(error, "Failed to send ApiResponse::Poll: {}", e);
+                return;
+            }
+        }
+    }
+}
+```
+
+**Step 6: ビルド確認**
+
+Run: `cargo check 2>&1 | head -30`
+Expected: ビルド成功（controller.rs のハンドル型不整合は Task 4 で解消するかもしれないが、ここで確認）
+
+**Step 7: コミット（Task 2 の変更と合わせて）**
+
+```bash
+git add -A && git commit -m "refactor: replace WorkerResult enum with ChangedContext struct and migrate pollers to InfiniteWorker"
+```
+
+---
+
+### Task 4: コントローラーのハンドル管理を変更
+
+**Files:**
+- Modify: `src/workers/kube/controller.rs:305-403` — メインループを `select_all` から `EventController` 単独 await に変更
+
+**Step 1: import の整理**
+
+`src/workers/kube/controller.rs` の import から不要なものを削除:
+- `futures::future::select_all` を削除
+- `JoinHandle` は `EventController` で引き続き使うため残す
+
+**Step 2: ハンドル管理パターンを変更**
+
+ポーラーの `spawn()` は `AbortHandle` を返すようになったので、`Vec<JoinHandle>` に入れられない。
+`EventController` の `JoinHandle` だけ `await` し、ポーラーは `AbortHandle` で管理:
+
+```rust
+let event_controller_handle = EventController::new(event_controller_args).spawn();
+
+let pod_handle = PodPoller::new(/* ... */).spawn();
+let config_handle = ConfigPoller::new(/* ... */).spawn();
+let network_handle = NetworkPoller::new(/* ... */).spawn();
+let event_handle = EventPoller::new(/* ... */).spawn();
+let api_handle = ApiPoller::new(/* ... */).spawn();
+
+let abort_handles = vec![
+    pod_handle,
+    config_handle,
+    network_handle,
+    event_handle,
+    api_handle,
+];
+
+let result = event_controller_handle.await;
+
+match result {
+    Ok(ChangedContext {
+        target_context,
+        target_namespaces,
+    }) => {
+        for h in &abort_handles {
+            h.abort();
+        }
+
+        let shared_target_namespaces = shared_target_namespaces.read().await;
+        let shared_api_resources = shared_target_api_resources.read().await;
+
+        store.insert(
+            context.to_string(),
+            KubeState::new(
+                client.clone(),
+                shared_target_namespaces.to_vec(),
+                shared_api_resources.to_vec(),
+            ),
+        );
+
+        context = target_context;
+
+        if let Some(ns) = target_namespaces {
+            override_namespaces = Some(ns);
+        }
+    }
+    Err(e) => {
+        for h in &abort_handles {
+            h.abort();
+        }
+        tx.send(Message::Error(NotifyError::from_anyhow(
+            ErrorSource::Worker,
+            &anyhow::Error::from(e).context("KubeProcess Error"),
+        )))?;
+    }
+}
+```
+
+**Step 3: `Self::abort` メソッドの更新**
+
+`Self::abort` は `&[JoinHandle<T>]` を受け取っていたが、`AbortHandle` 用に変更するか、直接 for ループで abort する。上のコードで直接 for ループを使っているため、`Self::abort` メソッドが不要なら削除。`EventController` 内でも `Self::abort` 相当のことをしているか確認して判断する。
+
+**Step 4: ビルド確認**
+
+Run: `cargo check 2>&1 | head -30`
+Expected: ビルド成功
+
+**Step 5: コミット**
+
+```bash
+git add -A && git commit -m "refactor: simplify controller handle management by awaiting EventController only"
+```
+
+---
+
+### Task 5: 最終確認・クリーンアップ
+
+**Files:**
+- 全体
+
+**Step 1: テスト実行**
+
+Run: `cargo test 2>&1 | tail -20`
+Expected: 全テスト PASS
+
+**Step 2: clippy 確認**
+
+Run: `cargo clippy 2>&1 | head -30`
+Expected: エラーなし
+
+**Step 3: 不要な import・未使用コードの確認**
+
+- `WorkerResult` への参照が完全に除去されていることを確認
+- `select_all` の import が除去されていることを確認
+- `Self::abort` メソッドが不要なら削除されていることを確認
+
+**Step 4: 修正があればコミット**
+
+```bash
+git add -A && git commit -m "refactor: clean up unused imports and dead code"
+```

--- a/src/features/api_resources/kube/api_resources.rs
+++ b/src/features/api_resources/kube/api_resources.rs
@@ -23,11 +23,12 @@ use crate::{
         table::insert_ns,
         KubeClient, KubeClientRequest as _,
     },
+    logger,
     message::Message,
     ui::widget::ansi_color::style_to_ansi,
     workers::kube::{
         SharedTargetApiResources, SharedTargetNamespaces, TargetApiResources, TargetNamespaces,
-        Worker, WorkerResult,
+        InfiniteWorker,
     },
 };
 
@@ -271,10 +272,8 @@ impl ApiPoller {
 }
 
 #[async_trait]
-impl Worker for ApiPoller {
-    type Output = WorkerResult;
-
-    async fn run(&self) -> Self::Output {
+impl InfiniteWorker for ApiPoller {
+    async fn run(&self) {
         let Self {
             tx,
             shared_target_namespaces,
@@ -290,11 +289,10 @@ impl Worker for ApiPoller {
                 *api_resources = fetched;
             }
             Err(err) => {
-                // TODO: Worker trait の改善時に、チャンネル切断を graceful に処理する。
-                // 現状は Worker::run() が WorkerResult を返す設計で、チャンネル切断時の
-                // 適切な戻り値がないため、パニックで対応している。
-                tx.send(ApiResponse::Poll(Err(err)).into())
-                    .expect("Failed to send ApiResponse::Poll");
+                if let Err(e) = tx.send(ApiResponse::Poll(Err(err)).into()) {
+                    logger!(error, "Failed to send ApiResponse::Poll: {}", e);
+                    return;
+                }
             }
         }
 
@@ -316,22 +314,19 @@ impl Worker for ApiPoller {
                         let mut api_resources = shared_api_resources.write().await;
                         *api_resources = fetched;
 
-                        // Clear error
                         if is_error {
                             is_error = false;
-                            // TODO: Worker trait の改善時に、チャンネル切断を graceful に処理する。
-                            // 現状は Worker::run() が WorkerResult を返す設計で、チャンネル切断時の
-                            // 適切な戻り値がないため、パニックで対応している。
-                            tx.send(ApiResponse::Poll(Ok(Default::default())).into())
-                                .expect("Failed to send ApiResponse::Poll");
+                            if let Err(e) = tx.send(ApiResponse::Poll(Ok(Default::default())).into()) {
+                                logger!(error, "Failed to send ApiResponse::Poll: {}", e);
+                                return;
+                            }
                         }
                     }
                     Err(err) => {
-                        // TODO: Worker trait の改善時に、チャンネル切断を graceful に処理する。
-                        // 現状は Worker::run() が WorkerResult を返す設計で、チャンネル切断時の
-                        // 適切な戻り値がないため、パニックで対応している。
-                        tx.send(ApiResponse::Poll(Err(err)).into())
-                            .expect("Failed to send ApiResponse::Poll");
+                        if let Err(e) = tx.send(ApiResponse::Poll(Err(err)).into()) {
+                            logger!(error, "Failed to send ApiResponse::Poll: {}", e);
+                            return;
+                        }
                         is_error = true;
                         continue;
                     }
@@ -354,11 +349,10 @@ impl Worker for ApiPoller {
             .fetch_table()
             .await;
 
-            // TODO: Worker trait の改善時に、チャンネル切断を graceful に処理する。
-            // 現状は Worker::run() が WorkerResult を返す設計で、チャンネル切断時の
-            // 適切な戻り値がないため、パニックで対応している。
-            tx.send(ApiResponse::Poll(result).into())
-                .expect("Failed to send ApiResponse::Poll");
+            if let Err(e) = tx.send(ApiResponse::Poll(result).into()) {
+                logger!(error, "Failed to send ApiResponse::Poll: {}", e);
+                return;
+            }
         }
     }
 }

--- a/src/features/config/kube/config.rs
+++ b/src/features/config/kube/config.rs
@@ -7,8 +7,9 @@ use crate::{
         table::{get_resource_per_namespace, insert_ns, KubeTable, KubeTableRow},
         KubeClient,
     },
+    logger,
     message::Message,
-    workers::kube::{SharedTargetNamespaces, Worker, WorkerResult},
+    workers::kube::{SharedTargetNamespaces, InfiniteWorker},
 };
 
 use anyhow::Result;
@@ -40,10 +41,8 @@ impl ConfigPoller {
 }
 
 #[async_trait]
-impl Worker for ConfigPoller {
-    type Output = WorkerResult;
-
-    async fn run(&self) -> Self::Output {
+impl InfiniteWorker for ConfigPoller {
+    async fn run(&self) {
         let mut interval = tokio::time::interval(time::Duration::from_secs(1));
 
         let Self {
@@ -59,11 +58,10 @@ impl Worker for ConfigPoller {
 
             let table = fetch_configs(kube_client, &target_namespaces).await;
 
-            // TODO: Worker trait の改善時に、チャンネル切断を graceful に処理する。
-            // 現状は Worker::run() が WorkerResult を返す設計で、チャンネル切断時の
-            // 適切な戻り値がないため、パニックで対応している。
-            tx.send(ConfigResponse::Table(table).into())
-                .expect("Failed to send ConfigResponse::Table");
+            if let Err(e) = tx.send(ConfigResponse::Table(table).into()) {
+                logger!(error, "Failed to send ConfigResponse::Table: {}", e);
+                return;
+            }
         }
     }
 }

--- a/src/features/config/kube/raw_data.rs
+++ b/src/features/config/kube/raw_data.rs
@@ -9,7 +9,7 @@ use crate::{
     features::config::message::{ConfigData, ConfigRequest, ConfigResponse, RequestData},
     kube::KubeClient,
     message::Message,
-    workers::kube::AbortWorker,
+    workers::kube::InfiniteWorker,
 };
 
 use self::{configmap::ConfigMapDataWorker, secret::SecretDataWorker};
@@ -28,7 +28,7 @@ impl ConfigsDataWorker {
 }
 
 #[async_trait]
-impl AbortWorker for ConfigsDataWorker {
+impl InfiniteWorker for ConfigsDataWorker {
     async fn run(&self) {
         let ret = match &self.req {
             ConfigRequest::ConfigMap(_) => self.fetch_description::<ConfigMapDataWorker>().await,

--- a/src/features/event/kube/event.rs
+++ b/src/features/event/kube/event.rs
@@ -14,9 +14,10 @@ use crate::{
         table::{get_resource_per_namespace, insert_ns, KubeTableRow},
         KubeClient,
     },
+    logger,
     message::Message,
     ui::widget::ansi_color::style_to_ansi,
-    workers::kube::{message::Kube, SharedTargetNamespaces, Worker, WorkerResult},
+    workers::kube::{message::Kube, SharedTargetNamespaces, InfiniteWorker},
 };
 
 #[derive(Default, Debug, Clone)]
@@ -66,9 +67,8 @@ impl EventPoller {
 }
 
 #[async_trait]
-impl Worker for EventPoller {
-    type Output = WorkerResult;
-    async fn run(&self) -> Self::Output {
+impl InfiniteWorker for EventPoller {
+    async fn run(&self) {
         let Self {
             tx,
             shared_target_namespaces,
@@ -84,11 +84,10 @@ impl Worker for EventPoller {
 
             let event_list = get_event_table(config, kube_client, &target_namespaces).await;
 
-            // TODO: Worker trait の改善時に、チャンネル切断を graceful に処理する。
-            // 現状は Worker::run() が WorkerResult を返す設計で、チャンネル切断時の
-            // 適切な戻り値がないため、パニックで対応している。
-            tx.send(Message::Kube(Kube::Event(event_list)))
-                .expect("Failed to send Kube::Event");
+            if let Err(e) = tx.send(Message::Kube(Kube::Event(event_list))) {
+                logger!(error, "Failed to send Kube::Event: {}", e);
+                return;
+            }
         }
     }
 }

--- a/src/features/get/kube/yaml.rs
+++ b/src/features/get/kube/yaml.rs
@@ -21,7 +21,7 @@ use crate::{
     },
     logger,
     message::Message,
-    workers::kube::AbortWorker,
+    workers::kube::InfiniteWorker,
 };
 
 #[derive(Debug, Clone)]
@@ -71,7 +71,7 @@ impl GetYamlWorker {
 }
 
 #[async_trait::async_trait]
-impl AbortWorker for GetYamlWorker {
+impl InfiniteWorker for GetYamlWorker {
     async fn run(&self) {
         let mut interval = tokio::time::interval(std::time::Duration::from_secs(3));
 

--- a/src/features/network/kube/description.rs
+++ b/src/features/network/kube/description.rs
@@ -17,7 +17,7 @@ use crate::{
     kube::KubeClientRequest,
     logger,
     message::Message,
-    workers::kube::AbortWorker,
+    workers::kube::InfiniteWorker,
 };
 
 use self::{
@@ -77,7 +77,7 @@ where
 }
 
 #[async_trait]
-impl<C> AbortWorker for NetworkDescriptionWorker<C>
+impl<C> InfiniteWorker for NetworkDescriptionWorker<C>
 where
     C: KubeClientRequest,
 {

--- a/src/features/network/kube/network.rs
+++ b/src/features/network/kube/network.rs
@@ -28,7 +28,7 @@ use crate::{
     },
     logger,
     message::Message,
-    workers::kube::{SharedTargetNamespaces, Worker, WorkerResult},
+    workers::kube::{SharedTargetNamespaces, InfiniteWorker},
 };
 
 #[derive(Debug, Default, Clone)]
@@ -265,10 +265,8 @@ fn target_resources(api_resources: &ApiResources) -> Vec<TargetResource> {
 }
 
 #[async_trait()]
-impl Worker for NetworkPoller {
-    type Output = WorkerResult;
-
-    async fn run(&self) -> Self::Output {
+impl InfiniteWorker for NetworkPoller {
+    async fn run(&self) {
         let mut interval = tokio::time::interval(time::Duration::from_secs(1));
 
         let tx = &self.tx;
@@ -283,11 +281,10 @@ impl Worker for NetworkPoller {
 
             let table = self.polling(&target_resources).await;
 
-            // TODO: Worker trait の改善時に、チャンネル切断を graceful に処理する。
-            // 現状は Worker::run() が WorkerResult を返す設計で、チャンネル切断時の
-            // 適切な戻り値がないため、パニックで対応している。
-            tx.send(NetworkResponse::List(table).into())
-                .expect("Failed to send NetworkResponse::List");
+            if let Err(e) = tx.send(NetworkResponse::List(table).into()) {
+                logger!(error, "Failed to send NetworkResponse::List: {}", e);
+                return;
+            }
         }
     }
 }

--- a/src/features/pod/kube/log.rs
+++ b/src/features/pod/kube/log.rs
@@ -22,7 +22,7 @@ use crate::{
     kube::{context::Namespace, KubeClient},
     logger,
     message::Message,
-    workers::kube::{AbortWorker, Worker},
+    workers::kube::{InfiniteWorker, Worker},
 };
 
 pub use self::log_streamer::LogPrefixType;
@@ -135,7 +135,7 @@ impl LogWorker {
 }
 
 #[async_trait]
-impl AbortWorker for LogWorker {
+impl InfiniteWorker for LogWorker {
     async fn run(&self) {
         match Filter::parse(&self.config.query) {
             Ok(filter) => {

--- a/src/features/pod/kube/log/log_streamer.rs
+++ b/src/features/pod/kube/log/log_streamer.rs
@@ -19,7 +19,7 @@ use tokio::time;
 use crate::{
     kube::KubeClient,
     logger,
-    workers::kube::{color::fg::Color, AbortWorker},
+    workers::kube::{color::fg::Color, InfiniteWorker},
 };
 
 use super::{log_collector::LogBuffer, log_content::LogContent};
@@ -89,7 +89,7 @@ pub struct LogStreamer {
 }
 
 #[async_trait]
-impl AbortWorker for LogStreamer {
+impl InfiniteWorker for LogStreamer {
     async fn run(&self) {
         let mut interval = tokio::time::interval(time::Duration::from_secs(3));
 

--- a/src/features/pod/kube/log/pod_watcher.rs
+++ b/src/features/pod/kube/log/pod_watcher.rs
@@ -22,7 +22,7 @@ use crate::{
     kube::KubeClient,
     logger,
     message::Message,
-    workers::kube::{AbortWorker, Worker},
+    workers::kube::{InfiniteWorker, Worker},
 };
 
 use super::{

--- a/src/features/pod/kube/pod.rs
+++ b/src/features/pod/kube/pod.rs
@@ -16,9 +16,10 @@ use crate::{
         table::{get_resource_per_namespace, insert_ns, KubeTable, KubeTableRow},
         KubeClient,
     },
+    logger,
     message::Message,
     ui::widget::ansi_color::style_to_ansi,
-    workers::kube::{SharedPodColumns, SharedTargetNamespaces, Worker, WorkerResult},
+    workers::kube::{SharedPodColumns, SharedTargetNamespaces, InfiniteWorker},
 };
 
 #[derive(Debug, Clone)]
@@ -79,10 +80,8 @@ impl PodPoller {
 }
 
 #[async_trait]
-impl Worker for PodPoller {
-    type Output = WorkerResult;
-
-    async fn run(&self) -> Self::Output {
+impl InfiniteWorker for PodPoller {
+    async fn run(&self) {
         let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(1));
 
         let Self { tx, .. } = self;
@@ -92,11 +91,10 @@ impl Worker for PodPoller {
 
             let pod_info = self.get_pod_info().await;
 
-            // TODO: Worker trait の改善時に、チャンネル切断を graceful に処理する。
-            // 現状は Worker::run() が WorkerResult を返す設計で、チャンネル切断時の
-            // 適切な戻り値がないため、パニックで対応している。
-            tx.send(PodMessage::Poll(pod_info).into())
-                .expect("Failed to Kube::Pod");
+            if let Err(e) = tx.send(PodMessage::Poll(pod_info).into()) {
+                logger!(error, "Failed to send PodMessage::Poll: {}", e);
+                return;
+            }
         }
     }
 }

--- a/src/features/yaml/kube/worker.rs
+++ b/src/features/yaml/kube/worker.rs
@@ -10,7 +10,7 @@ use crate::{
     kube::KubeClientRequest,
     logger,
     message::Message,
-    workers::kube::AbortWorker,
+    workers::kube::InfiniteWorker,
 };
 
 #[derive(Debug, Clone)]
@@ -48,7 +48,7 @@ impl<C: KubeClientRequest> YamlWorker<C> {
 }
 
 #[async_trait::async_trait]
-impl<C: KubeClientRequest> AbortWorker for YamlWorker<C> {
+impl<C: KubeClientRequest> InfiniteWorker for YamlWorker<C> {
     async fn run(&self) {
         let mut interval = tokio::time::interval(std::time::Duration::from_secs(3));
 

--- a/src/workers/kube/controller.rs
+++ b/src/workers/kube/controller.rs
@@ -52,7 +52,7 @@ use super::{
     config::{read_kubeconfig, Context, KubeWorkerConfig},
     store::{KubeState, KubeStore},
     worker::Worker,
-    AbortWorker as _,
+    InfiniteWorker as _,
 };
 
 pub type TargetNamespaces = Vec<String>;

--- a/src/workers/kube/controller.rs
+++ b/src/workers/kube/controller.rs
@@ -378,9 +378,6 @@ impl KubeController {
                     }
                 }
                 Err(e) => {
-                    for h in &poller_handles {
-                        h.abort();
-                    }
                     tx.send(Message::Error(NotifyError::from_anyhow(
                         ErrorSource::Worker,
                         &anyhow::Error::from(e).context("KubeProcess Error"),
@@ -389,7 +386,6 @@ impl KubeController {
             }
         }
     }
-
 }
 
 struct EventControllerArgs {

--- a/src/workers/kube/controller.rs
+++ b/src/workers/kube/controller.rs
@@ -3,13 +3,12 @@ use std::{sync::Arc, time::Duration};
 use anyhow::{Context as _, Result};
 use async_trait::async_trait;
 use crossbeam::channel::{Receiver, Sender};
-use futures::future::select_all;
 use k8s_openapi::api::core::v1::Namespace;
 use kube::{api::ListParams, config::Kubeconfig, Api, ResourceExt as _};
 use ratatui::style::{Color, Style};
 use tokio::{
     sync::RwLock,
-    task::{self, AbortHandle, JoinHandle},
+    task::{self, AbortHandle},
 };
 
 use crate::{
@@ -126,14 +125,12 @@ async fn fetch_all_namespaces(client: KubeClient) -> Result<Vec<String>> {
 }
 
 #[derive(Clone)]
-pub enum WorkerResult {
-    ChangedContext {
-        /// 切り替え後のコンテキスト
-        target_context: String,
+pub struct ChangedContext {
+    /// 切り替え後のコンテキスト
+    pub target_context: String,
 
-        /// 切り替え後のターゲットネームスペース
-        target_namespaces: Option<TargetNamespaces>,
-    },
+    /// 切り替え後のターゲットネームスペース
+    pub target_namespaces: Option<TargetNamespaces>,
 }
 
 pub struct KubeController {
@@ -343,8 +340,7 @@ impl KubeController {
             )
             .spawn();
 
-            let mut handles = vec![
-                event_controller_handle,
+            let poller_handles = vec![
                 pod_handle,
                 config_handle,
                 network_handle,
@@ -352,55 +348,48 @@ impl KubeController {
                 api_handle,
             ];
 
-            while !handles.is_empty() {
-                let (result, _, vec) = select_all(handles).await;
+            let result = event_controller_handle.await;
 
-                handles = vec;
+            for h in &poller_handles {
+                h.abort();
+            }
 
-                match result {
-                    Ok(ret) => match ret {
-                        WorkerResult::ChangedContext {
-                            target_context,
-                            target_namespaces,
-                        } => {
-                            Self::abort(&handles);
+            match result {
+                Ok(ChangedContext {
+                    target_context,
+                    target_namespaces,
+                }) => {
+                    let shared_target_namespaces = shared_target_namespaces.read().await;
+                    let shared_api_resources = shared_target_api_resources.read().await;
 
-                            let shared_target_namespaces = shared_target_namespaces.read().await;
-                            let shared_api_resources = shared_target_api_resources.read().await;
+                    store.insert(
+                        context.to_string(),
+                        KubeState::new(
+                            client.clone(),
+                            shared_target_namespaces.to_vec(),
+                            shared_api_resources.to_vec(),
+                        ),
+                    );
 
-                            store.insert(
-                                context.to_string(),
-                                KubeState::new(
-                                    client.clone(),
-                                    shared_target_namespaces.to_vec(),
-                                    shared_api_resources.to_vec(),
-                                ),
-                            );
+                    context = target_context;
 
-                            context = target_context;
-
-                            if let Some(ns) = target_namespaces {
-                                override_namespaces = Some(ns);
-                            }
-                        }
-                    },
-                    Err(e) => {
-                        Self::abort(&handles);
-                        tx.send(Message::Error(NotifyError::from_anyhow(
-                            ErrorSource::Worker,
-                            &anyhow::Error::from(e).context("KubeProcess Error"),
-                        )))?;
+                    if let Some(ns) = target_namespaces {
+                        override_namespaces = Some(ns);
                     }
+                }
+                Err(e) => {
+                    for h in &poller_handles {
+                        h.abort();
+                    }
+                    tx.send(Message::Error(NotifyError::from_anyhow(
+                        ErrorSource::Worker,
+                        &anyhow::Error::from(e).context("KubeProcess Error"),
+                    )))?;
                 }
             }
         }
     }
 
-    fn abort<T>(handlers: &[JoinHandle<T>]) {
-        for h in handlers {
-            h.abort()
-        }
-    }
 }
 
 struct EventControllerArgs {
@@ -468,7 +457,7 @@ impl LogHandle {
 
 #[async_trait]
 impl Worker for EventController {
-    type Output = WorkerResult;
+    type Output = ChangedContext;
 
     async fn run(&self) -> Self::Output {
         let mut log_handler: Option<LogHandle> = None;
@@ -638,7 +627,7 @@ impl Worker for EventController {
                                 None
                             };
 
-                            return WorkerResult::ChangedContext {
+                            return ChangedContext {
                                 target_context: name.clone(),
                                 target_namespaces,
                             };

--- a/src/workers/kube/worker.rs
+++ b/src/workers/kube/worker.rs
@@ -18,7 +18,7 @@ pub trait Worker {
 }
 
 #[async_trait]
-pub trait AbortWorker {
+pub trait InfiniteWorker {
     async fn run(&self);
 
     fn spawn(&self) -> AbortHandle


### PR DESCRIPTION
## Summary
- Rename `AbortWorker` trait to `InfiniteWorker` to better express the trait's intent (workers that run indefinitely until externally aborted)
- Convert single-variant `WorkerResult` enum into `ChangedContext` struct
- Migrate 5 pollers (Pod, Event, Config, Network, ApiResources) from `Worker` to `InfiniteWorker`, replacing `tx.send().expect()` panics with `if let Err(e)` + logger for graceful return
- Simplify controller handle management from `select_all` to direct `EventController` await + abort pattern

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` — all 526 tests pass
- [x] `cargo clippy` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)