### PR TITLE
fix: prevent API resources tab panic with non-zero priority columns

### DIFF
--- a/src/features/api_resources/kube/styled_table.rs
+++ b/src/features/api_resources/kube/styled_table.rs
@@ -69,7 +69,8 @@ impl Display for StyledTable<'_> {
 
         let header_str = header
             .iter()
-            .map(|(i, hdr)| format!("{:<digit$}", hdr.to_uppercase(), digit = digits[*i]))
+            .zip(digits.iter())
+            .map(|((_, hdr), &width)| format!("{:<width$}", hdr.to_uppercase()))
             .collect::<Vec<String>>()
             .join(WIDTH_PADDING);
 
@@ -139,6 +140,66 @@ mod tests {
                 },
                 TableRow {
                     cells: ["Bob", "30"].into_iter().map(|s| s.into()).collect(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        let styled_table = StyledTable::new(
+            &table,
+            Style::default().fg(Color::DarkGray),
+            Style::default().fg(Color::White),
+        );
+
+        let expected = indoc! {"
+            \x1b[90mNAME    AGE\x1b[39m
+            \x1b[37mAlice   20 \x1b[39m
+            \x1b[37mBob     30 \x1b[39m
+        "};
+
+        assert_eq!(styled_table.to_string(), expected.trim_end());
+    }
+
+    // priorityが0でない列が間に混在していても、priority=0の列だけを表示する
+    #[test]
+    fn when_table_has_non_zero_priority_columns_then_display_only_priority_zero_columns() {
+        let table = Table {
+            column_definitions: vec![
+                TableColumnDefinition {
+                    name: "Name".into(),
+                    priority: 0,
+                    ..Default::default()
+                },
+                TableColumnDefinition {
+                    name: "Wide1".into(),
+                    priority: 1,
+                    ..Default::default()
+                },
+                TableColumnDefinition {
+                    name: "Wide2".into(),
+                    priority: 1,
+                    ..Default::default()
+                },
+                TableColumnDefinition {
+                    name: "Age".into(),
+                    priority: 0,
+                    ..Default::default()
+                },
+            ],
+            rows: vec![
+                TableRow {
+                    cells: ["Alice", "w1a", "w2a", "20"]
+                        .into_iter()
+                        .map(|s| s.into())
+                        .collect(),
+                    ..Default::default()
+                },
+                TableRow {
+                    cells: ["Bob", "w1b", "w2b", "30"]
+                        .into_iter()
+                        .map(|s| s.into())
+                        .collect(),
                     ..Default::default()
                 },
             ],


### PR DESCRIPTION
## Summary
- `StyledTable` filtered headers down to `priority == 0` columns but still indexed the `digits` width array with the original `column_definitions` index, so any resource that interleaves `priority != 0` columns (e.g. cert-manager `Certificate`) panicked when opened in the API resources tab.
- Zip `header` with `digits` directly so the width lookup no longer depends on the pre-filter column index.
- Added a regression test that mixes `priority != 0` columns into a `StyledTable` (reproduces the panic on the previous implementation).

## Repro
```
panicked at src/features/api_resources/kube/styled_table.rs:72:85:
index out of bounds: the len is 3 but the index is 3
```

## Test plan
- [x] `cargo test --all` (530 passed / 0 failed)
- [x] New test `when_table_has_non_zero_priority_columns_then_display_only_priority_zero_columns` panics on the old code and passes after the fix
- [x] Verify against a live cluster that opening resources with `priority != 0` columns (e.g. cert-manager `Certificate`) no longer crashes the API resources tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)