### PR TITLE
fix(table): keep all columns visible in narrow panes

### DIFF
--- a/src/ui/widget/table/item.rs
+++ b/src/ui/widget/table/item.rs
@@ -311,16 +311,18 @@ impl Digits {
         let spacing = COLUMN_SPACING as usize * digits.len().saturating_sub(1);
         let content_budget = max_width.saturating_sub(spacing);
 
-        // Shrink the widest column first, down to MIN_COLUMN_WIDTH if needed,
-        // before touching the next-widest. This truncates long values
-        // (typically the NAME column) first while keeping shorter columns at
-        // their natural width as long as possible. A column is never reduced to
-        // 0 (which would make it vanish), and the total always fits the budget
-        // (so ratatui does not clip a whole column off the right edge).
+        // Shrink the column that is currently the widest by one each step,
+        // until the total fits the budget. The widest column changes as we
+        // shrink, so once two columns are tied at the top they shrink together
+        // (water-fill / leveling). This truncates long values (typically NAME)
+        // first while keeping the column readable as long as possible, and
+        // only starts trimming shorter columns once the long one has caught
+        // down to their level. No column is reduced below MIN_COLUMN_WIDTH
+        // (it would vanish), and the total always fits the budget (so ratatui
+        // does not clip a whole column off the right edge).
         const MIN_COLUMN_WIDTH: usize = 1;
 
-        let mut overflow = digits.iter().sum::<usize>().saturating_sub(content_budget);
-        while overflow > 0 {
+        while digits.iter().sum::<usize>() > content_budget {
             let Some(idx) = digits
                 .iter()
                 .enumerate()
@@ -328,15 +330,12 @@ impl Digits {
                 .max_by_key(|(_, &w)| w)
                 .map(|(i, _)| i)
             else {
-                // Every column is already at the minimum width; the pane is too
-                // narrow to fit them all and nothing more can be shrunk.
+                // Every column is already at the minimum width; the pane is
+                // too narrow to fit them all and nothing more can be shrunk.
                 break;
             };
 
-            let reducible = digits[idx] - MIN_COLUMN_WIDTH;
-            let reduce = reducible.min(overflow);
-            digits[idx] -= reduce;
-            overflow -= reduce;
+            digits[idx] -= 1;
         }
 
         Self(digits)
@@ -445,17 +444,22 @@ mod tests {
         }
 
         #[test]
-        fn 縮小は最長列から行い短い列は可能な限り残す() {
+        fn 縮小は常に現在の最長列から行い最小列は他列が並ぶまで保たれる() {
             let h = header(&["NAME", "ZONE", "STATUS"]);
             let it = items(&["gke-very-long-node-name-0123456789", "", "Ready"]);
 
             let digits = Digits::new(&it, &h, 20);
 
             // 最長の NAME 列が縮められ、自然幅(34)より小さくなる。
-            assert!(digits[0] < 34, "最長列が縮小されること: {:?}", *digits);
-            // 短い列(ZONE=4, STATUS=6)は最長列より先に削られない。
-            assert_eq!(digits[1], 4, "ZONE は保持: {:?}", *digits);
-            assert_eq!(digits[2], 6, "STATUS は保持: {:?}", *digits);
+            assert!(digits[0] < 34, "NAME は縮小される: {:?}", *digits);
+            // ZONE(=4) は最も短いので、他列が ZONE と同等以下に下がるまで保たれる。
+            assert_eq!(
+                digits[1], 4,
+                "ZONE は他列が ZONE と並ぶまで保たれる: {:?}",
+                *digits
+            );
+            // STATUS は ZONE 以上の幅を保つ（他列が ZONE 以下になっていない）。
+            assert!(digits[2] >= digits[1], "STATUS >= ZONE: {:?}", *digits);
             assert!(total(&digits) <= 20);
         }
     }

--- a/src/ui/widget/table/item.rs
+++ b/src/ui/widget/table/item.rs
@@ -306,32 +306,37 @@ impl Digits {
             }
         }
 
-        let sum_width = digits.iter().sum::<usize>()
-            + (COLUMN_SPACING as usize * digits.len().saturating_sub(1));
+        // Width available for cell content, i.e. excluding the spacing drawn
+        // between columns.
+        let spacing = COLUMN_SPACING as usize * digits.len().saturating_sub(1);
+        let content_budget = max_width.saturating_sub(spacing);
 
-        if max_width < sum_width {
-            let index_of_longest_digits = digits
+        // Shrink the widest column first, down to MIN_COLUMN_WIDTH if needed,
+        // before touching the next-widest. This truncates long values
+        // (typically the NAME column) first while keeping shorter columns at
+        // their natural width as long as possible. A column is never reduced to
+        // 0 (which would make it vanish), and the total always fits the budget
+        // (so ratatui does not clip a whole column off the right edge).
+        const MIN_COLUMN_WIDTH: usize = 1;
+
+        let mut overflow = digits.iter().sum::<usize>().saturating_sub(content_budget);
+        while overflow > 0 {
+            let Some(idx) = digits
                 .iter()
                 .enumerate()
-                .max_by_key(|(_, l)| *l)
-                .unwrap_or((0, &0))
-                .0;
+                .filter(|(_, &w)| w > MIN_COLUMN_WIDTH)
+                .max_by_key(|(_, &w)| w)
+                .map(|(i, _)| i)
+            else {
+                // Every column is already at the minimum width; the pane is too
+                // narrow to fit them all and nothing more can be shrunk.
+                break;
+            };
 
-            let sum_width: usize = digits
-                .iter()
-                .enumerate()
-                .filter_map(|(i, w)| {
-                    if i == index_of_longest_digits {
-                        None
-                    } else {
-                        Some(w)
-                    }
-                })
-                .sum();
-
-            digits[index_of_longest_digits] = max_width.saturating_sub(
-                (COLUMN_SPACING as usize * digits.len().saturating_sub(1)) + sum_width,
-            );
+            let reducible = digits[idx] - MIN_COLUMN_WIDTH;
+            let reduce = reducible.min(overflow);
+            digits[idx] -= reduce;
+            overflow -= reduce;
         }
 
         Self(digits)
@@ -386,6 +391,72 @@ mod tests {
             let actual = item.filtered_index();
 
             assert_eq!(actual, 0);
+        }
+    }
+
+    mod digits {
+        use super::*;
+        use pretty_assertions::assert_eq;
+
+        fn items(cells: &[&str]) -> Vec<TableItem> {
+            vec![TableItem::new(
+                cells.iter().map(ToString::to_string).collect::<Vec<_>>(),
+                None,
+            )]
+        }
+
+        fn header(cols: &[&str]) -> Vec<String> {
+            cols.iter().map(ToString::to_string).collect()
+        }
+
+        fn total(digits: &Digits) -> usize {
+            digits.iter().sum::<usize>() + COLUMN_SPACING as usize * digits.len().saturating_sub(1)
+        }
+
+        #[test]
+        fn 十分な幅では自然幅をそのまま使う() {
+            let h = header(&["NAME", "ZONE", "STATUS"]);
+            let it = items(&["node-abcdefgh", "", "Ready"]);
+
+            let digits = Digits::new(&it, &h, usize::MAX);
+
+            // NAME=13, ZONE=ヘッダ4, STATUS=ヘッダ6
+            assert_eq!(*digits, vec![13, 4, 6]);
+        }
+
+        #[test]
+        fn 狭い幅でもどの列も0に潰れずクリップされない() {
+            let h = header(&["NAME", "ZONE", "STATUS"]);
+            let it = items(&["gke-very-long-node-name-0123456789", "", "Ready"]);
+
+            let digits = Digits::new(&it, &h, 16);
+
+            assert!(
+                digits.iter().all(|&w| w >= 1),
+                "どの列も0幅にならないこと: {:?}",
+                *digits
+            );
+            assert!(
+                total(&digits) <= 16,
+                "合計が max_width に収まること: total={} digits={:?}",
+                total(&digits),
+                *digits
+            );
+        }
+
+        #[test]
+        fn 縮小は最長列から行い短い列は可能な限り残す() {
+            let h = header(&["NAME", "ZONE", "STATUS"]);
+            let it = items(&["gke-very-long-node-name-0123456789", "", "Ready"]);
+
+            let digits = Digits::new(&it, &h, 20);
+
+            // 最長の NAME 列が縮められ、自然幅(34)より小さくなる。
+            assert!(digits[0] < 34, "最長列が縮小されること: {:?}", *digits);
+            // 短い列(ZONE=4, STATUS=6)は最長列より先に削られない。
+            assert_eq!(digits[1], 4, "ZONE は保持: {:?}", *digits);
+            assert_eq!(digits[2], 6, "STATUS は保持: {:?}", *digits);
+            assert!(total(&digits) <= 20);
         }
     }
 }


### PR DESCRIPTION
## Summary

Fix a column-layout bug in the shared `Table` widget that made columns disappear in narrow panes. Affects every table view (Pod, Config, Network, Event, API, Node).

## Root cause

`Digits::new` (`src/ui/widget/table/item.rs`) handled overflow by shrinking **only the single widest column**:

```rust
digits[longest] = max_width - spacing - sum_of_other_columns;
```

When the other columns plus spacing already met or exceeded `max_width`:

1. `saturating_sub` drove the widest column to **width 0**, so it vanished entirely (header and data).
2. Even at 0, the remaining columns still overflowed `max_width`, so ratatui clipped the **rightmost** column(s) off the edge.

In kubetui's intended small panes (tmux splits, floating windows), this is easy to hit — e.g. a long GKE node name plus a couple of extra columns.

## Fix

Water-fill the overflow: while the total exceeds the budget, shrink whichever column is **currently the widest** by one, and repeat. Once two columns are tied at the top they shrink together. No column is reduced below a 1-cell minimum, so nothing vanishes, and the total always fits, so ratatui never clips a whole column.

**Behavior comparison** for `[NAME=34, ZONE=4 (empty label), STATUS=6]`:

| Available width | Before (single-column shrink) | After (water-fill) |
|---|---|---|
| ≥ 40 | `[34, 4, 6]` | `[34, 4, 6]` |
| 30 | `[14, 4, 6]` | `[14, 4, 6]` |
| 24 | `[8, 4, 6]` | `[8, 4, 6]` |
| 20 | `[ 4, 4, 6]` (NAME at 4) | `[5, 4, 5]` |
| 18 | `[ 2, 4, 6]` | `[4, 4, 4]` |
| 16 | `[ 1, 4, 5]` (was `[0, 4, 6]` → ZONE clipped off!) | `[4, 3, 3]` |

In moderately narrow panes only the long column (typically NAME) truncates. In very narrow panes the long column stops shrinking once it ties the next, and they level together — so NAME stays readable a bit longer at the cost of slightly trimming the shorter columns that have caught up.

## Verification

- New `Digits::new` tests: natural-width pass-through; narrow pane (no collapse / fits budget); water-fill order (smallest column preserved until others catch down to it).
- `cargo test` — all pass.
- `cargo clippy --all-targets` — no new warnings.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

