### PR TITLE
feat(table): pluggable filter framework via TableFilterApplicator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@
 # AI tools
 /.claude/
 /.serena/
+/.superpowers/
 
 /assets/*
 !/assets/demo*.webp

--- a/docs/superpowers/plans/2026-05-27-node-filter-applicator.md
+++ b/docs/superpowers/plans/2026-05-27-node-filter-applicator.md
@@ -1,0 +1,1595 @@
+# Node Filter Applicator Implementation Plan (PR B)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the Node tab's column-aware filter using the `TableFilterApplicator` framework shipped in PR A, replacing the Plan 5 standalone dialog widget.
+
+**Architecture:** Build a nom-based parser that produces `TableFilterPredicate` directly (no Node-specific predicate type). Wire `node_filter_applicator()` into `Table::builder().filter_applicator(...)`. Drop the standalone `node_filter` dialog widget. Reduce `NodeFilterMessage::Apply` payload to `Option<String>` (only `labelSelector` needs to reach the server; client-side regex matching is handled by `TableFilterPredicate::matches`). Update help dialog content for the new `<col>:<val>` syntax.
+
+**Tech Stack:** Rust 2021, nom 7 (parser), regex, ratatui (widgets), crossbeam (channels), tokio (poller). Builds on PR A's `TableFilterApplicator` / `TableFilterPredicate` / `ApplyStrategy::EnterToConfirm` / `define_callback!(OnFilterApply)`.
+
+**Spec:** `docs/superpowers/specs/2026-05-27-table-filter-redesign.md` §Node タブのフィルタ実装 (lines 305–371).
+
+**Reference implementation (NOT cherry-picked; copy logic only):** `920-node-filter` branch, Plan 5 commits:
+- `f64f9483` feat(node): NodeFilter AST and nom-based parser
+- `dabeda86` feat(node): thread SharedNodeFilter through controller and poller
+- `3692753a` feat(node): apply NodeFilter in poller (labelSelector + name regex)
+- `a0a257cb` feat(node): NodeFilterMessage::Apply and controller handler
+- `b5351dd9` feat(node): add node_filter input dialog (/ to open, Enter to apply)
+- `871abe79` feat(node): add node_filter help dialog (type ? in filter input)
+- `19dfe5c6` feat(node): show current filter and match counts in table title
+- `9e55a7e6` chore(node): allow dead_code on NodeFilter::is_empty
+
+These are NOT cherry-picked. The plan reproduces the relevant logic as fresh commits adapted to the PR A framework so the resulting PR has a clean, focused diff.
+
+---
+
+## Prerequisites and branch state
+
+PR B depends on two parallel stacks both reaching the same base:
+
+1. **PR A (#982)** — `feat/table-filter-applicator`, which adds `TableFilterApplicator` / `TableFilterPredicate` / `substring_applicator`. Currently OPEN, stacked on `feat/table-optional-filter` (#980).
+2. **Node stack** — `920-add-node-tab` (#972) → `920-node-columns-dialog` (#974) → `920-node-label-columns` (#975) → `920-node-detail-pane` (#979). All OPEN.
+
+Plan 5 was the next layer on this stack (`920-node-filter`) but is being replaced by PR B. **PR B itself depends on the Plan 4 head AND PR A.** Practical paths to a viable branch state for execution:
+
+- **Path X (preferred):** Both stacks merged to `main` first → PR B branches off `main`.
+- **Path Y:** Create an integration branch from PR A's head (`feat/table-filter-applicator`) and merge `920-node-detail-pane` into it → PR B is built on that integration branch.
+
+The plan assumes whichever path produced a working tree where:
+- `src/features/node/{kube,view,message.rs,node_columns.rs}` exists (from Plan 1–4).
+- `src/ui/widget/table/filter_applicator.rs` exports `TableFilterApplicator`, `TableFilterPredicate`, `ApplyStrategy`, `OnFilterApply`, `TableFilterParser` (from PR A).
+- `Table::builder()` has `.filter_applicator(...)` and `.filter_form(...)` (from PR A).
+
+Task 0 verifies this concretely before any code is written.
+
+---
+
+## File structure
+
+### New files
+
+- **`src/features/node/filter.rs`** — replaces Plan 5's `NodeFilter` module. Contains the `node_filter_applicator()` factory only; re-exports parser as needed.
+- **`src/features/node/filter/parser.rs`** — replaces Plan 5's parser. nom-based, returns `Result<TableFilterPredicate, String>`. Knows the set of valid column names (built from `label_registry` plus the builtin column headers).
+
+### Modified files
+
+- **`src/features/node/view/widgets/node.rs`** — switch widget construction from `.action('/', open_node_filter_dialog())` to `.filter_form(FilterForm::default()).filter_applicator(node_filter_applicator(label_registry, tx))`. Re-introduce title block_injection that reads `TableFilterPredicate.raw` from `Table.filter_state()`.
+- **`src/features/node/view/widgets/node_filter_help.rs`** — rewrite `content()` for the new `<col>:` / `!<col>:` / `label:` syntax (Plan 5 wording was `node:` / `!node:` / `label:`).
+- **`src/features/node/message.rs`** — change `NodeFilterMessage::Apply` payload from `Option<NodeFilter>` to `Option<String>` (only `label_selector` reaches the server).
+- **`src/features/node/kube/node.rs`** — drop `matches_name` client-side filtering; `SharedNodeFilter = Arc<RwLock<Option<String>>>`; URL construction takes `Option<&str>` (label selector).
+- **`src/workers/kube/controller.rs`** — `NodeFilterMessage::Apply(Option<String>)` handler writes to `SharedNodeFilter`.
+- **`src/features/node/view/tab.rs`** — remove standalone `node_filter` dialog registration; keep `NODE_FILTER_HELP_DIALOG_ID` registration. Thread `label_registry` and `tx` into `node_widget()`.
+
+### Deleted files
+
+- **`src/features/node/view/widgets/node_filter.rs`** — the standalone dialog widget. Its UX role is taken over by the inline `FilterForm` on the Table widget.
+
+### Component ID changes (`src/features/component_id.rs`)
+
+- Remove `NODE_FILTER_WIDGET_ID`.
+- Keep `NODE_FILTER_HELP_DIALOG_ID` (the help dialog is dispatched via `TableFilterApplicator::with_help_dialog(NODE_FILTER_HELP_DIALOG_ID)`).
+
+---
+
+## Parser syntax (recap from spec)
+
+| Input | Effect |
+|---|---|
+| `foo` | bare value → `NAME` column include (regex `foo`) |
+| `foo bar` | two bare values → `NAME` includes `foo` OR `bar` (column-internal OR) |
+| `NAME:gke.*worker` | `NAME` include (regex) |
+| `STATUS:Ready` | `STATUS` include |
+| `STATUS:Ready STATUS:Pending` | same column → OR |
+| `STATUS:Ready NAME:nginx` | cross-column → AND |
+| `!NS:kube-system` | `NAMESPACE` exclude |
+| `label:role=worker` | server-side labelSelector (last-wins if multiple) |
+
+Column names: case-insensitive; canonical form is lowercase (stored as lowercase in `TableFilterPredicate::column_includes` keys). `cell_of` in PR A already case-insensitively matches column headers.
+
+Unknown column name → **parse error** (e.g. `STATUSU:Ready` → `"unknown column 'STATUSU'"`). Validation set = builtin column display names + `label_registry` headers, all lowercased.
+
+---
+
+## Tasks
+
+### Task 0: Verify branch prerequisites
+
+**Purpose:** Confirm the working tree has both PR A's framework and Plans 1–4's Node code before any new commits. Surfaces issues at minute zero rather than mid-implementation.
+
+**Files (read-only):** working tree introspection only.
+
+- [ ] **Step 1: Verify PR A framework presence**
+
+Run:
+```bash
+test -f src/ui/widget/table/filter_applicator.rs && \
+  grep -q 'pub struct TableFilterApplicator' src/ui/widget/table/filter_applicator.rs && \
+  grep -q 'pub struct TableFilterPredicate' src/ui/widget/table/filter_applicator.rs && \
+  grep -q 'pub enum ApplyStrategy' src/ui/widget/table/filter_applicator.rs && \
+  echo "PR A: OK" || echo "PR A: MISSING"
+```
+Expected: `PR A: OK`. If `MISSING`, stop and merge/integrate PR A first.
+
+- [ ] **Step 2: Verify Plans 1–4 Node code presence**
+
+Run:
+```bash
+test -d src/features/node && \
+  test -f src/features/node/view/widgets/node.rs && \
+  test -f src/features/node/node_columns.rs && \
+  test -f src/features/node/message.rs && \
+  test -f src/features/node/kube/node.rs && \
+  echo "Node base: OK" || echo "Node base: MISSING"
+```
+Expected: `Node base: OK`. If `MISSING`, the integration branch has not been prepared.
+
+- [ ] **Step 3: Verify NodeLabelColumn is in scope**
+
+Run:
+```bash
+grep -n 'pub struct NodeLabelColumn' src/features/node/node_columns.rs
+```
+Expected: a line like `pub struct NodeLabelColumn` is printed. This is the type the parser will use to validate label-column names.
+
+- [ ] **Step 4: Confirm Plan 5 artifacts to remove are still present**
+
+Run:
+```bash
+ls src/features/node/filter.rs src/features/node/filter/parser.rs \
+   src/features/node/view/widgets/node_filter.rs \
+   src/features/node/view/widgets/node_filter_help.rs 2>&1 | head
+```
+- If all four exist (integrated from `920-node-filter`): the plan replaces / deletes them in later tasks.
+- If only `node_filter_help.rs` exists (Plan 5 partially integrated): adjust later tasks to skip the deletes.
+- If none of them exist (Plans 1–4 only, no Plan 5): later "delete" steps become no-ops; "rewrite" steps become "create from scratch."
+
+Record observed state in a scratch note (you will need it for Tasks 5, 9, 10).
+
+- [ ] **Step 5: Confirm baseline build is green**
+
+Run:
+```bash
+cargo build 2>&1 | tail -3 && cargo test --all 2>&1 | tail -3
+```
+Expected: both succeed with no errors. If anything is red on the prerequisite branch, **stop and fix that first** — PR B must start from a green tree.
+
+- [ ] **Step 6: Decide branch name and create**
+
+Run (replace `<base>` with the actual branch you started from, e.g. the integration branch name):
+```bash
+git checkout -b feat/node-filter-applicator
+git status
+```
+Expected: clean working tree, on `feat/node-filter-applicator`.
+
+No commit at this task.
+
+---
+
+### Task 1: Parser skeleton — bare values default to NAME (TDD)
+
+**Purpose:** Establish the parser's module shape and the simplest happy path (bare tokens map to `NAME` column includes). Subsequent tasks layer syntax on top.
+
+**Files:**
+- Create: `src/features/node/filter/parser.rs`
+- Create: `src/features/node/filter.rs`
+- Modify: `src/features/node/mod.rs` (or wherever the node module lists submodules) — add `pub mod filter;` if not present
+
+Reference for parser shape: `920-node-filter:src/features/node/filter/parser.rs` (the AST/nom structure; the new code returns a different output type).
+
+- [ ] **Step 1: Add `nom` dependency check**
+
+Run:
+```bash
+grep -n '"nom"' Cargo.toml
+```
+Expected: a `nom = "..."` entry. If absent, add `nom = "7"` to `[dependencies]` in `Cargo.toml`. (Plan 5 already added it on `920-node-filter`, so on the integration branch this is usually a no-op.)
+
+- [ ] **Step 2: Stub `src/features/node/filter.rs`**
+
+Write the file:
+
+```rust
+//! Node tab filter: parser + `TableFilterApplicator` factory.
+//!
+//! The parser produces a `TableFilterPredicate` directly (no Node-specific
+//! predicate type). The factory wires the parser into the Table widget's
+//! filter framework with `ApplyStrategy::EnterToConfirm`, a help-dialog
+//! dispatch, and an `on_apply` callback that forwards the parsed
+//! `labelSelector` to the Node poller via `NodeFilterMessage::Apply`.
+
+mod parser;
+
+pub use parser::parse_node_filter;
+```
+
+- [ ] **Step 3: Stub `src/features/node/filter/parser.rs`**
+
+Write the file:
+
+```rust
+use std::collections::HashMap;
+
+use regex::Regex;
+
+use crate::{
+    features::node::node_columns::NodeLabelColumn,
+    ui::widget::TableFilterPredicate,
+};
+
+/// Parse a Node-filter input string into a `TableFilterPredicate`.
+///
+/// `label_registry` supplies the set of valid label-column headers (in
+/// addition to the builtin Node column headers). Unknown column names
+/// produce a parse error.
+pub fn parse_node_filter(
+    input: &str,
+    label_registry: &[NodeLabelColumn],
+) -> Result<TableFilterPredicate, String> {
+    let _ = label_registry; // used by later tasks
+    let trimmed = input.trim();
+
+    let mut column_includes: HashMap<String, Vec<Regex>> = HashMap::new();
+    if !trimmed.is_empty() {
+        let regexes: Result<Vec<Regex>, _> = trimmed
+            .split_whitespace()
+            .map(Regex::new)
+            .collect();
+        let regexes = regexes.map_err(|e| format!("invalid regex: {}", e))?;
+        column_includes.insert("name".to_string(), regexes);
+    }
+
+    Ok(TableFilterPredicate {
+        column_includes,
+        column_excludes: HashMap::new(),
+        label_selector: None,
+        raw: trimmed.to_string(),
+    })
+}
+```
+
+- [ ] **Step 4: Write failing tests**
+
+Append to `src/features/node/filter/parser.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    fn no_label_cols() -> Vec<NodeLabelColumn> {
+        Vec::new()
+    }
+
+    #[test]
+    fn empty_input_yields_empty_predicate() {
+        let p = parse_node_filter("", &no_label_cols()).unwrap();
+        assert!(p.column_includes.is_empty());
+        assert!(p.column_excludes.is_empty());
+        assert_eq!(p.label_selector, None);
+        assert_eq!(p.raw, "");
+    }
+
+    #[test]
+    fn whitespace_only_input_yields_empty_predicate() {
+        let p = parse_node_filter("   \t  ", &no_label_cols()).unwrap();
+        assert!(p.column_includes.is_empty());
+        assert_eq!(p.raw, "");
+    }
+
+    #[test]
+    fn single_bare_value_becomes_name_include() {
+        let p = parse_node_filter("worker", &no_label_cols()).unwrap();
+        assert_eq!(p.column_includes.len(), 1);
+        let patterns = p.column_includes.get("name").expect("name column");
+        assert_eq!(patterns.len(), 1);
+        assert!(patterns[0].is_match("gke-worker-1"));
+        assert!(!patterns[0].is_match("gke-control-1"));
+        assert_eq!(p.raw, "worker");
+    }
+
+    #[test]
+    fn multiple_bare_values_become_name_or() {
+        let p = parse_node_filter("foo bar", &no_label_cols()).unwrap();
+        let patterns = p.column_includes.get("name").expect("name column");
+        assert_eq!(patterns.len(), 2);
+        assert_eq!(p.raw, "foo bar");
+    }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass against the stub**
+
+Run:
+```bash
+cargo test --bin kubetui features::node::filter::parser::tests 2>&1 | tail -15
+```
+Expected: 4 tests pass. (The stub already handles bare values correctly.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Cargo.toml src/features/node/filter.rs src/features/node/filter/parser.rs
+git status  # confirm src/features/node/mod.rs is registered if needed
+git commit -m "feat(node): parser skeleton — bare values map to NAME column includes
+
+Introduce src/features/node/filter/{,parser}.rs as the home for the new
+column-aware Node filter parser. The skeleton handles empty input and
+bare whitespace-separated tokens (which become regex includes on the
+NAME column, matching the spec's bare-value alias). Column-prefixed
+syntax (NAME:.., !COL:.., label:..) lands in subsequent tasks.
+
+label_registry is accepted in the signature but not yet consumed; it
+becomes load-bearing in Task 5 (unknown-column validation)."
+```
+
+---
+
+### Task 2: Parser — `<col>:<val>` include syntax (TDD)
+
+**Purpose:** Add explicit column-include syntax. Same-column repeats accumulate (OR); different columns coexist in the predicate (AND across columns is handled by `TableFilterPredicate::matches` in PR A).
+
+**Files:**
+- Modify: `src/features/node/filter/parser.rs`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to the existing `tests` module:
+
+```rust
+    #[test]
+    fn explicit_column_include_creates_column_entry() {
+        let p = parse_node_filter("status:Ready", &no_label_cols()).unwrap();
+        assert_eq!(p.column_includes.len(), 1);
+        let patterns = p.column_includes.get("status").expect("status column");
+        assert_eq!(patterns.len(), 1);
+        assert!(patterns[0].is_match("Ready"));
+        assert_eq!(p.raw, "status:Ready");
+    }
+
+    #[test]
+    fn column_names_are_case_insensitive_canonicalized_lowercase() {
+        let p = parse_node_filter("STATUS:Ready Name:worker", &no_label_cols()).unwrap();
+        assert!(p.column_includes.contains_key("status"));
+        assert!(p.column_includes.contains_key("name"));
+    }
+
+    #[test]
+    fn same_column_includes_accumulate_in_order() {
+        let p = parse_node_filter("status:Ready status:Pending", &no_label_cols()).unwrap();
+        let patterns = p.column_includes.get("status").expect("status column");
+        assert_eq!(patterns.len(), 2);
+        assert!(patterns[0].is_match("Ready"));
+        assert!(patterns[1].is_match("Pending"));
+    }
+
+    #[test]
+    fn different_columns_coexist_in_predicate() {
+        let p = parse_node_filter("status:Ready name:worker", &no_label_cols()).unwrap();
+        assert_eq!(p.column_includes.len(), 2);
+    }
+
+    #[test]
+    fn bare_and_column_includes_mix() {
+        // `foo status:Ready` → NAME has `foo`, STATUS has `Ready`
+        let p = parse_node_filter("foo status:Ready", &no_label_cols()).unwrap();
+        assert_eq!(p.column_includes.len(), 2);
+        assert_eq!(p.column_includes.get("name").unwrap().len(), 1);
+        assert_eq!(p.column_includes.get("status").unwrap().len(), 1);
+    }
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+Run:
+```bash
+cargo test --bin kubetui features::node::filter::parser::tests 2>&1 | tail -20
+```
+Expected: the 5 new tests fail (the stub treats every token as a NAME include and would put `status:Ready` literally into NAME).
+
+- [ ] **Step 3: Implement column-aware tokenization**
+
+Replace the body of `parse_node_filter` in `src/features/node/filter/parser.rs`. Add a private helper:
+
+```rust
+use std::collections::HashMap;
+
+use regex::Regex;
+
+use crate::{
+    features::node::node_columns::NodeLabelColumn,
+    ui::widget::TableFilterPredicate,
+};
+
+/// One parsed term from the input.
+#[derive(Debug)]
+enum Term {
+    /// Bare value (no prefix) → defaults to NAME include.
+    Bare(String),
+    /// `<col>:<value>` include.
+    Include { column: String, value: String },
+}
+
+fn parse_term(token: &str) -> Term {
+    if let Some((col, val)) = token.split_once(':') {
+        // Empty column or empty value is treated as Bare so the user sees
+        // a regex error later (or no-op). Stricter validation happens in
+        // Task 5 (column-name validation).
+        if !col.is_empty() && !val.is_empty() {
+            return Term::Include {
+                column: col.to_lowercase(),
+                value: val.to_string(),
+            };
+        }
+    }
+    Term::Bare(token.to_string())
+}
+
+pub fn parse_node_filter(
+    input: &str,
+    label_registry: &[NodeLabelColumn],
+) -> Result<TableFilterPredicate, String> {
+    let _ = label_registry; // consumed in Task 5
+
+    let trimmed = input.trim();
+    let mut column_includes: HashMap<String, Vec<Regex>> = HashMap::new();
+
+    for token in trimmed.split_whitespace() {
+        match parse_term(token) {
+            Term::Bare(v) => {
+                let rx = Regex::new(&v).map_err(|e| format!("invalid regex '{}': {}", v, e))?;
+                column_includes.entry("name".to_string()).or_default().push(rx);
+            }
+            Term::Include { column, value } => {
+                let rx = Regex::new(&value)
+                    .map_err(|e| format!("invalid regex '{}': {}", value, e))?;
+                column_includes.entry(column).or_default().push(rx);
+            }
+        }
+    }
+
+    Ok(TableFilterPredicate {
+        column_includes,
+        column_excludes: HashMap::new(),
+        label_selector: None,
+        raw: trimmed.to_string(),
+    })
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+cargo test --bin kubetui features::node::filter::parser::tests 2>&1 | tail -15
+```
+Expected: all 9 tests pass (4 from Task 1 + 5 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/node/filter/parser.rs
+git commit -m "feat(node): parser — column-prefixed include syntax (COL:val)
+
+Tokens of the form '<col>:<val>' become include entries on the named
+column (column name lowercased). Same-column repeats accumulate as an
+ordered Vec; cross-column entries coexist. Bare and column-prefixed
+tokens can be mixed freely in the same input."
+```
+
+---
+
+### Task 3: Parser — `!<col>:<val>` exclude syntax (TDD)
+
+**Files:**
+- Modify: `src/features/node/filter/parser.rs`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests`:
+
+```rust
+    #[test]
+    fn excludes_prefixed_with_bang_populate_column_excludes() {
+        let p = parse_node_filter("!ns:kube-system", &no_label_cols()).unwrap();
+        assert!(p.column_includes.is_empty());
+        let patterns = p.column_excludes.get("ns").expect("ns column");
+        assert_eq!(patterns.len(), 1);
+        assert!(patterns[0].is_match("kube-system"));
+    }
+
+    #[test]
+    fn includes_and_excludes_coexist() {
+        let p = parse_node_filter("status:Ready !ns:kube-system", &no_label_cols()).unwrap();
+        assert_eq!(p.column_includes.len(), 1);
+        assert_eq!(p.column_excludes.len(), 1);
+    }
+
+    #[test]
+    fn bang_without_colon_is_treated_as_bare_value() {
+        // `!worker` is NOT shorthand for `!name:worker`. The leading `!`
+        // is only meaningful with an explicit column.
+        let p = parse_node_filter("!worker", &no_label_cols()).unwrap();
+        // The literal string `!worker` becomes a regex on NAME. The regex
+        // crate accepts `!worker` as a literal match on `!worker`.
+        let patterns = p.column_includes.get("name").expect("name column");
+        assert_eq!(patterns.len(), 1);
+        assert!(patterns[0].is_match("!worker"));
+        assert!(p.column_excludes.is_empty());
+    }
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+Run:
+```bash
+cargo test --bin kubetui features::node::filter::parser::tests 2>&1 | tail -20
+```
+Expected: the 3 new tests fail.
+
+- [ ] **Step 3: Extend `parse_term` to recognize the `!` prefix**
+
+Modify `src/features/node/filter/parser.rs`:
+
+```rust
+#[derive(Debug)]
+enum Term {
+    Bare(String),
+    Include { column: String, value: String },
+    Exclude { column: String, value: String },
+}
+
+fn parse_term(token: &str) -> Term {
+    if let Some(stripped) = token.strip_prefix('!') {
+        if let Some((col, val)) = stripped.split_once(':') {
+            if !col.is_empty() && !val.is_empty() {
+                return Term::Exclude {
+                    column: col.to_lowercase(),
+                    value: val.to_string(),
+                };
+            }
+        }
+        // Fall through: `!worker` without colon is a bare value.
+    }
+
+    if let Some((col, val)) = token.split_once(':') {
+        if !col.is_empty() && !val.is_empty() {
+            return Term::Include {
+                column: col.to_lowercase(),
+                value: val.to_string(),
+            };
+        }
+    }
+
+    Term::Bare(token.to_string())
+}
+```
+
+And extend the match in `parse_node_filter`:
+
+```rust
+    for token in trimmed.split_whitespace() {
+        match parse_term(token) {
+            Term::Bare(v) => {
+                let rx = Regex::new(&v).map_err(|e| format!("invalid regex '{}': {}", v, e))?;
+                column_includes.entry("name".to_string()).or_default().push(rx);
+            }
+            Term::Include { column, value } => {
+                let rx = Regex::new(&value)
+                    .map_err(|e| format!("invalid regex '{}': {}", value, e))?;
+                column_includes.entry(column).or_default().push(rx);
+            }
+            Term::Exclude { column, value } => {
+                let rx = Regex::new(&value)
+                    .map_err(|e| format!("invalid regex '{}': {}", value, e))?;
+                column_excludes.entry(column).or_default().push(rx);
+            }
+        }
+    }
+```
+
+Add `let mut column_excludes: HashMap<String, Vec<Regex>> = HashMap::new();` near the `column_includes` declaration, and pass `column_excludes` into the returned `TableFilterPredicate`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+cargo test --bin kubetui features::node::filter::parser::tests 2>&1 | tail -15
+```
+Expected: all 12 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/node/filter/parser.rs
+git commit -m "feat(node): parser — '!COL:val' exclude syntax
+
+Tokens starting with '!' followed by 'COL:value' populate column_excludes.
+A bare '!worker' (no colon) is treated as a literal NAME regex, not as
+shorthand for '!name:worker' — the bang is only meaningful with an
+explicit column prefix."
+```
+
+---
+
+### Task 4: Parser — `label:<sel>` server-side selector with last-wins (TDD)
+
+**Files:**
+- Modify: `src/features/node/filter/parser.rs`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests`:
+
+```rust
+    #[test]
+    fn label_selector_is_captured_verbatim() {
+        let p = parse_node_filter("label:role=worker", &no_label_cols()).unwrap();
+        assert_eq!(p.label_selector.as_deref(), Some("role=worker"));
+        assert!(p.column_includes.is_empty());
+        assert!(p.column_excludes.is_empty());
+    }
+
+    #[test]
+    fn label_selector_supports_kubectl_comma_and() {
+        let p = parse_node_filter("label:role=worker,zone=us-west", &no_label_cols()).unwrap();
+        assert_eq!(
+            p.label_selector.as_deref(),
+            Some("role=worker,zone=us-west")
+        );
+    }
+
+    #[test]
+    fn multiple_label_terms_keep_the_last() {
+        // The k8s API accepts only one labelSelector value; spec requires
+        // last-wins to match the Pod log query convention.
+        let p = parse_node_filter("label:a=1 label:b=2", &no_label_cols()).unwrap();
+        assert_eq!(p.label_selector.as_deref(), Some("b=2"));
+    }
+
+    #[test]
+    fn label_and_column_terms_coexist() {
+        let p = parse_node_filter(
+            "status:Ready label:role=worker !ns:kube-system",
+            &no_label_cols(),
+        )
+        .unwrap();
+        assert_eq!(p.column_includes.len(), 1);
+        assert_eq!(p.column_excludes.len(), 1);
+        assert_eq!(p.label_selector.as_deref(), Some("role=worker"));
+    }
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+Run:
+```bash
+cargo test --bin kubetui features::node::filter::parser::tests 2>&1 | tail -20
+```
+Expected: 4 new tests fail (the parser currently puts `label:foo` into the `label` column as an include).
+
+- [ ] **Step 3: Add `Label` term recognized BEFORE generic `<col>:<val>`**
+
+Modify `parse_term` in `src/features/node/filter/parser.rs` so the `label:` case is detected first:
+
+```rust
+#[derive(Debug)]
+enum Term {
+    Bare(String),
+    Include { column: String, value: String },
+    Exclude { column: String, value: String },
+    Label(String),
+}
+
+fn parse_term(token: &str) -> Term {
+    if let Some(sel) = token.strip_prefix("label:") {
+        if !sel.is_empty() {
+            return Term::Label(sel.to_string());
+        }
+    }
+
+    if let Some(stripped) = token.strip_prefix('!') {
+        if let Some((col, val)) = stripped.split_once(':') {
+            if !col.is_empty() && !val.is_empty() {
+                return Term::Exclude {
+                    column: col.to_lowercase(),
+                    value: val.to_string(),
+                };
+            }
+        }
+    }
+
+    if let Some((col, val)) = token.split_once(':') {
+        if !col.is_empty() && !val.is_empty() {
+            return Term::Include {
+                column: col.to_lowercase(),
+                value: val.to_string(),
+            };
+        }
+    }
+
+    Term::Bare(token.to_string())
+}
+```
+
+Extend the match in `parse_node_filter` and add `let mut label_selector: Option<String> = None;`:
+
+```rust
+            Term::Label(sel) => {
+                label_selector = Some(sel);
+            }
+```
+
+And pass `label_selector` into the returned `TableFilterPredicate`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+cargo test --bin kubetui features::node::filter::parser::tests 2>&1 | tail -15
+```
+Expected: all 16 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/node/filter/parser.rs
+git commit -m "feat(node): parser — 'label:<selector>' k8s labelSelector
+
+'label:<value>' is captured verbatim into TableFilterPredicate.label_selector
+(the value is passed unchanged to the kube API as ?labelSelector=). When
+multiple label: terms appear, the last value wins, matching the Pod log
+query convention and the underlying k8s API which accepts only one
+labelSelector value."
+```
+
+---
+
+### Task 5: Parser — unknown column name produces parse error (TDD)
+
+**Purpose:** Implement the column-name validation against the union of builtin Node column headers and the configured `label_registry`. Typos like `STATUSU:Ready` surface as a clear error in the Table's `filter_error` overlay.
+
+**Files:**
+- Modify: `src/features/node/filter/parser.rs`
+
+**Background:** Valid column names = lowercased headers of every `NodeColumn` builtin (e.g. `name`, `status`, `roles`, `age`, `version`, `internal-ip`, `external-ip`, `os-image`, `kernel-version`, `container-runtime`) plus lowercased `header` of every `NodeLabelColumn` in the registry. The exact builtin list depends on Plans 1–3 of the Node stack — verify by reading `src/features/node/node_columns.rs` and reusing whatever enumerates builtin columns.
+
+- [ ] **Step 1: Identify the builtin-column enumeration**
+
+Run:
+```bash
+grep -n 'enum NodeColumn\|impl NodeColumn\|fn display' src/features/node/node_columns.rs
+```
+Expected: a `NodeColumn` enum with a `display()` (or similarly named) method that returns the column header. Note the method name; the next step uses it.
+
+- [ ] **Step 2: Write failing tests**
+
+Append to `tests` in `src/features/node/filter/parser.rs`:
+
+```rust
+    fn registry_with(name: &str, header: &str) -> Vec<NodeLabelColumn> {
+        vec![NodeLabelColumn {
+            name: name.to_string(),
+            key: "irrelevant.example.com/key".to_string(),
+            header: header.to_string(),
+        }]
+    }
+
+    #[test]
+    fn unknown_column_produces_parse_error() {
+        let err = parse_node_filter("statusu:Ready", &no_label_cols()).unwrap_err();
+        assert!(
+            err.contains("unknown column") && err.contains("statusu"),
+            "error should mention the bad column: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn unknown_column_in_exclude_also_errors() {
+        let err = parse_node_filter("!agee:1h", &no_label_cols()).unwrap_err();
+        assert!(
+            err.contains("unknown column") && err.contains("agee"),
+            "error should mention the bad column: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn builtin_columns_are_accepted() {
+        // `name` and `status` are builtin headers — must not error.
+        assert!(parse_node_filter("name:n status:s", &no_label_cols()).is_ok());
+    }
+
+    #[test]
+    fn registered_label_column_header_is_accepted() {
+        let regs = registry_with("zone", "ZONE");
+        let p = parse_node_filter("zone:us-west", &regs).unwrap();
+        assert!(p.column_includes.contains_key("zone"));
+    }
+
+    #[test]
+    fn label_keyword_is_not_treated_as_a_column_lookup() {
+        // 'label:role=worker' must NOT trigger unknown-column validation
+        // (it's the special-cased k8s labelSelector path).
+        assert!(parse_node_filter("label:role=worker", &no_label_cols()).is_ok());
+    }
+```
+
+- [ ] **Step 3: Run tests to confirm they fail**
+
+Run:
+```bash
+cargo test --bin kubetui features::node::filter::parser::tests 2>&1 | tail -20
+```
+Expected: 4 new tests fail (unknown-column ones); the two acceptance tests already pass.
+
+- [ ] **Step 4: Build the valid-column set and validate**
+
+Modify `src/features/node/filter/parser.rs`. Add imports and a helper:
+
+```rust
+use std::collections::HashSet;
+
+use crate::features::node::node_columns::{NodeColumn, NodeLabelColumn};
+use strum::IntoEnumIterator;
+
+fn valid_columns(label_registry: &[NodeLabelColumn]) -> HashSet<String> {
+    let mut set: HashSet<String> = NodeColumn::iter()
+        .map(|c| c.display().to_lowercase())
+        .collect();
+    for lc in label_registry {
+        set.insert(lc.header.to_lowercase());
+    }
+    set
+}
+```
+
+(If the actual builtin-display method is not called `display()`, substitute the real name observed in Step 1. If `NodeColumn` does not implement `IntoEnumIterator` via `strum`, look for an explicit `pub const ALL: &[NodeColumn]` or similar slice and iterate that instead.)
+
+Wire validation into `parse_node_filter`:
+
+```rust
+    let valid = valid_columns(label_registry);
+
+    for token in trimmed.split_whitespace() {
+        match parse_term(token) {
+            Term::Bare(v) => {
+                let rx = Regex::new(&v).map_err(|e| format!("invalid regex '{}': {}", v, e))?;
+                column_includes.entry("name".to_string()).or_default().push(rx);
+            }
+            Term::Include { column, value } => {
+                if !valid.contains(&column) {
+                    return Err(format!("unknown column '{}'", column));
+                }
+                let rx = Regex::new(&value)
+                    .map_err(|e| format!("invalid regex '{}': {}", value, e))?;
+                column_includes.entry(column).or_default().push(rx);
+            }
+            Term::Exclude { column, value } => {
+                if !valid.contains(&column) {
+                    return Err(format!("unknown column '{}'", column));
+                }
+                let rx = Regex::new(&value)
+                    .map_err(|e| format!("invalid regex '{}': {}", value, e))?;
+                column_excludes.entry(column).or_default().push(rx);
+            }
+            Term::Label(sel) => {
+                label_selector = Some(sel);
+            }
+        }
+    }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run:
+```bash
+cargo test --bin kubetui features::node::filter::parser::tests 2>&1 | tail -15
+```
+Expected: all 21 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/node/filter/parser.rs
+git commit -m "feat(node): parser — validate column names against registry
+
+Builtin Node columns (NodeColumn::iter().display()) plus headers in the
+configured label_registry form the set of acceptable column names.
+Typos like 'STATUSU:Ready' produce a parse error 'unknown column
+\"statusu\"', which the Table widget renders via filter_error
+(body-replacement overlay). The 'label:' keyword bypasses validation —
+it is the special-cased server-side k8s labelSelector path, not a
+client-side column lookup."
+```
+
+---
+
+### Task 6: `node_filter_applicator()` factory (TDD)
+
+**Purpose:** Wire the parser into a `TableFilterApplicator` configured for the Node tab: `EnterToConfirm` strategy, help-dialog dispatch on `?`, `on_apply` that forwards the parsed `labelSelector` to the Node poller.
+
+**Files:**
+- Modify: `src/features/node/filter.rs`
+
+- [ ] **Step 1: Write the factory**
+
+Replace `src/features/node/filter.rs` body:
+
+```rust
+//! Node tab filter: parser + `TableFilterApplicator` factory.
+
+mod parser;
+
+use crossbeam::channel::Sender;
+
+use crate::{
+    features::{
+        component_id::NODE_FILTER_HELP_DIALOG_ID,
+        node::{message::NodeFilterMessage, node_columns::NodeLabelColumn},
+    },
+    message::Message,
+    ui::widget::{ApplyStrategy, TableFilterApplicator, TableFilterParser},
+};
+
+pub use parser::parse_node_filter;
+
+/// Build the Node tab's filter applicator.
+///
+/// `label_registry` is captured by value and used by the parser for
+/// column-name validation. `tx` is used by `on_apply` to send
+/// `NodeFilterMessage::Apply(label_selector)` to the Node poller; the
+/// poller updates its `?labelSelector=` URL parameter on the next tick.
+pub fn node_filter_applicator(
+    label_registry: Vec<NodeLabelColumn>,
+    tx: Sender<Message>,
+) -> TableFilterApplicator {
+    let parser: TableFilterParser = (move |input: &str| {
+        parse_node_filter(input, &label_registry)
+    })
+    .into();
+
+    TableFilterApplicator::new(parser, ApplyStrategy::EnterToConfirm)
+        .with_help_dialog(NODE_FILTER_HELP_DIALOG_ID)
+        .with_on_apply(move |predicate, _window| {
+            tx.send(NodeFilterMessage::Apply(predicate.label_selector.clone()).into())
+                .expect("Failed to send NodeFilterMessage::Apply");
+        })
+}
+```
+
+- [ ] **Step 2: Write a smoke test that exercises the factory**
+
+Append to `src/features/node/filter.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossbeam::channel;
+
+    #[test]
+    fn applicator_constructs_without_panic() {
+        let (tx, _rx) = channel::bounded(1);
+        // Simply constructing the applicator exercises all the closure
+        // wiring; this catches type / capture errors that would otherwise
+        // only surface at first user keystroke.
+        let _ = node_filter_applicator(Vec::new(), tx);
+    }
+
+    #[test]
+    fn applicator_on_apply_sends_label_selector_via_tx() {
+        let (tx, rx) = channel::bounded(1);
+        let app = node_filter_applicator(Vec::new(), tx);
+
+        // Build a predicate as if parser produced it
+        let pred = parse_node_filter("label:role=worker", &[]).unwrap();
+        let on_apply = app.on_apply.as_ref().expect("on_apply must be set");
+
+        // The callback expects (&TableFilterPredicate, &mut Window). We
+        // don't have a Window here; this test asserts the message is
+        // sent via the captured Sender. Since on_apply is `Rc<dyn Fn>`,
+        // we have to construct a dummy Window. Skip this assertion if
+        // Window has no `Default` impl and the test cannot compile —
+        // the construction-only test above still covers the wiring.
+        //
+        // If Window has a constructor we can use, call on_apply and
+        // expect Ok(NodeFilterMessage::Apply(Some("role=worker"))) on rx.
+        let _ = (pred, on_apply, rx);
+    }
+}
+```
+
+Note: depending on whether `Window` is constructible in tests, the second test may need to be skipped or rewritten. Verify before committing — if `Window::builder().build()` works in tests elsewhere in the codebase (`grep -rn 'Window::builder' src/`), use that. Otherwise delete the second test and rely on the construction-only smoke test plus parser-level coverage.
+
+- [ ] **Step 3: Run tests to verify they pass**
+
+Run:
+```bash
+cargo test --bin kubetui features::node::filter::tests 2>&1 | tail -15
+```
+Expected: 1 or 2 tests pass (depending on the second test's fate).
+
+- [ ] **Step 4: Verify the file builds cleanly**
+
+Run:
+```bash
+cargo build 2>&1 | tail -5
+```
+Expected: clean build.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/node/filter.rs
+git commit -m "feat(node): node_filter_applicator factory
+
+Wire the column-aware parser into a TableFilterApplicator configured for
+the Node tab: ApplyStrategy::EnterToConfirm (avoid spamming the kube API
+mid-typing), help-dialog dispatch via NODE_FILTER_HELP_DIALOG_ID, and
+on_apply that forwards the parsed labelSelector to the Node poller via
+NodeFilterMessage::Apply.
+
+Client-side regex matching is fully handled by TableFilterPredicate::matches
+(from PR A), so on_apply only needs to send the label_selector — the
+rest of the predicate lives in Table.filter_state and is consulted by
+the widget render path."
+```
+
+---
+
+### Task 7: Reduce `NodeFilterMessage::Apply` payload to `Option<String>` and ripple through controller/poller
+
+**Purpose:** The framework now owns the client-side filter state. The kube side only needs `labelSelector`. Trim the message type and adjust the controller/poller plumbing.
+
+**Files:**
+- Modify: `src/features/node/message.rs`
+- Modify: `src/workers/kube/controller.rs` (or wherever `NodeFilterMessage::Apply` is handled)
+- Modify: `src/features/node/kube/node.rs` (`SharedNodeFilter` type and URL builder)
+
+- [ ] **Step 1: Change the message variant**
+
+Edit `src/features/node/message.rs`. Replace the `Apply(Option<super::filter::NodeFilter>)` variant with:
+
+```rust
+/// Messages for changing the active Node-list filter.
+#[derive(Debug)]
+pub enum NodeFilterMessage {
+    /// Replace the active labelSelector value. `None` clears it (the
+    /// poller stops sending ?labelSelector= in its request URL).
+    Apply(Option<String>),
+}
+```
+
+Remove any `use super::filter::NodeFilter` import that becomes unused.
+
+- [ ] **Step 2: Change `SharedNodeFilter` type**
+
+Edit `src/features/node/kube/node.rs`. Replace:
+
+```rust
+pub type SharedNodeFilter = Arc<RwLock<Option<NodeFilter>>>;
+```
+
+with:
+
+```rust
+pub type SharedNodeFilter = Arc<RwLock<Option<String>>>;
+```
+
+Remove the now-unused `use crate::features::node::filter::NodeFilter` import.
+
+- [ ] **Step 3: Simplify the URL builder**
+
+Still in `src/features/node/kube/node.rs`, replace the existing helper:
+
+```rust
+fn node_request_path(filter: Option<&NodeFilter>) -> String {
+    let base = Node::url_path(&(), None);
+    match filter.and_then(|f| f.label_selector.as_deref()) {
+        Some(sel) if !sel.is_empty() => format!("{}?labelSelector={}", base, sel),
+        _ => base,
+    }
+}
+```
+
+with:
+
+```rust
+fn node_request_path(label_selector: Option<&str>) -> String {
+    let base = Node::url_path(&(), None);
+    match label_selector {
+        Some(sel) if !sel.is_empty() => format!("{}?labelSelector={}", base, sel),
+        _ => base,
+    }
+}
+```
+
+Update its single call site in the poller `run()` loop. The call previously read the lock once and passed the `Option<NodeFilter>` reference; now read the lock once and pass `selector.as_deref()`.
+
+- [ ] **Step 4: Remove the client-side `matches_name` filtering pass**
+
+Still in `src/features/node/kube/node.rs`, locate the iterator chain that does:
+
+```rust
+.filter(|r| {
+    filter
+        .as_ref()
+        .map(|f| f.matches_name(&r.name))
+        .unwrap_or(true)
+})
+.collect();
+```
+
+Delete the entire `.filter(...)` call (the rows now flow straight through; client-side filtering is the UI's job).
+
+- [ ] **Step 5: Adjust the controller handler**
+
+In `src/workers/kube/controller.rs`, find the `NodeFilterMessage::Apply` arm. Replace its body with:
+
+```rust
+NodeFilterMessage::Apply(label_selector) => {
+    let mut guard = self.shared_node_filter.write().await;
+    *guard = label_selector;
+}
+```
+
+(If the existing handler uses sync `RwLock`, drop the `.await`. Match the surrounding style.)
+
+- [ ] **Step 6: Update poller and URL builder tests**
+
+In `src/features/node/kube/node.rs`'s `tests` module, replace the `node_request_path` tests so they pass `Option<&str>` directly:
+
+```rust
+        #[test]
+        fn label_selector_is_appended_as_query() {
+            assert_eq!(
+                node_request_path(Some("role=worker,zone=us-west")),
+                "/api/v1/nodes?labelSelector=role=worker,zone=us-west"
+            );
+        }
+
+        #[test]
+        fn empty_selector_produces_base_path() {
+            assert_eq!(node_request_path(None), "/api/v1/nodes");
+            assert_eq!(node_request_path(Some("")), "/api/v1/nodes");
+        }
+```
+
+Delete any leftover tests that construct `NodeFilter { label_selector: Some(...), .. }`.
+
+- [ ] **Step 7: Build and run tests**
+
+Run:
+```bash
+cargo build 2>&1 | tail -5
+cargo test --bin kubetui 2>&1 | tail -5
+```
+Expected: clean build, all tests pass. The `NodeFilter` struct itself may still exist at this point; it is deleted in Task 9.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/features/node/message.rs src/features/node/kube/node.rs src/workers/kube/controller.rs
+git commit -m "refactor(node): NodeFilterMessage payload is Option<String> (label selector only)
+
+Client-side regex filtering moved to TableFilterPredicate (PR A). The
+Node poller now only needs the k8s labelSelector value, so:
+
+  - NodeFilterMessage::Apply(Option<String>) replaces Apply(Option<NodeFilter>)
+  - SharedNodeFilter = Arc<RwLock<Option<String>>>
+  - node_request_path takes Option<&str>
+  - the poller's .filter(|r| f.matches_name(&r.name)) pass is dropped;
+    rows flow straight through to the UI, which filters via Table.filter_state
+
+NodeFilter (the struct) is not removed yet — Task 9 deletes it once the
+last reference is gone."
+```
+
+---
+
+### Task 8: Switch `node.rs` widget to `filter_form` + `node_filter_applicator`
+
+**Purpose:** Replace the `.action('/', open_node_filter_dialog())` shortcut with the inline filter form on the Table widget. Re-introduce the title block_injection that displays the active filter raw text and match counts, reading from `Table.filter_state` (which now holds `TableFilterPredicate`).
+
+**Files:**
+- Modify: `src/features/node/view/widgets/node.rs`
+- Modify: `src/features/node/view/tab.rs` (caller side — pass `label_registry` and `tx`)
+
+- [ ] **Step 1: Identify how callers obtain `label_registry`**
+
+Run:
+```bash
+grep -n 'label_registry\|NodeLabelColumn' src/features/node/view/tab.rs src/workers/render/window.rs 2>&1
+```
+Note the existing path that supplies the `NodeLabelColumn` registry to the Node tab (Plans 1–3). The applicator needs the same value — usually it is already passed into `NodeTab::new` or is reachable from a shared `Rc<RefCell<NodeColumns>>` via a snapshot.
+
+- [ ] **Step 2: Update `node_widget()` signature and body**
+
+Edit `src/features/node/view/widgets/node.rs`. Change the signature to accept `label_registry: Vec<NodeLabelColumn>`:
+
+```rust
+use crate::features::node::{
+    filter::node_filter_applicator,
+    message::NodeDetailMessage,
+    node_columns::NodeLabelColumn,
+};
+use crate::ui::widget::{FilterForm, TableFilterPredicate};
+```
+
+Replace the `Table::builder()` chain. Drop both `.filtered_key("NAME")` (already gone in PR A — verify) and `.action('/', open_node_filter_dialog())`. Add `.filter_form(...)` and `.filter_applicator(...)`:
+
+```rust
+pub fn node_widget(
+    tx: Sender<Message>,
+    label_registry: Vec<NodeLabelColumn>,
+    theme: WidgetThemeConfig,
+) -> Widget<'static> {
+    let widget_theme = WidgetTheme::from(theme.clone());
+    let table_theme = TableTheme::from(theme.clone());
+
+    let widget_base = WidgetBase::builder()
+        .title("Node")
+        .theme(widget_theme)
+        .build();
+
+    Table::builder()
+        .id(NODE_WIDGET_ID)
+        .widget_base(widget_base)
+        .theme(table_theme)
+        .filter_form(FilterForm::default())
+        .filter_applicator(node_filter_applicator(label_registry, tx.clone()))
+        .action('t', open_node_columns_dialog())
+        .on_select(on_select(tx))
+        .block_injection(block_injection())
+        .build()
+        .into()
+}
+```
+
+- [ ] **Step 3: Rewrite `block_injection` to read from `Table.filter_state()`**
+
+In the same file, replace the prior `block_injection` (which took a `NodeFilterTitleState` written by the standalone dialog) with one that reads the new `Table.filter_state()` accessor:
+
+```rust
+fn block_injection() -> impl Fn(&Table) -> WidgetBase {
+    |table: &Table| {
+        let mut base = table.widget_base().clone();
+
+        let title = match table.filter_state() {
+            Some(pred) if !pred.raw.is_empty() => {
+                let matched = table.items().len();
+                format!("Node [{}/{}]", matched, table.original_items_len())
+                    .into() // adjust if WidgetBase::title takes &str
+            }
+            _ => "Node".into(),
+        };
+
+        // Use whichever WidgetBase setter your code base exposes for title.
+        base.set_title(title);
+        base
+    }
+}
+```
+
+Note: the exact `WidgetBase` mutation API may differ — `grep -n 'fn title\|pub fn set_title' src/ui/widget/base.rs` to confirm. The intent is: when a filter is active, render `Node [matched/total]` plus optionally the raw filter text; otherwise plain `Node`. Adjust the format string if there is a project convention you can mirror (Pod tab title is a good reference).
+
+Also: `Table::filter_state()` accessor and `Table::original_items_len()` may need to be added to PR A's surface if not present. Check with:
+
+```bash
+grep -n 'fn filter_state\|original_items_len' src/ui/widget/table.rs
+```
+
+If absent, add public accessors in a small follow-up to PR A (or include the accessor addition as part of this task — a single read-only getter is low-risk). Don't reach into private fields.
+
+- [ ] **Step 4: Remove obsolete `NodeFilterTitleState` references**
+
+Search and remove:
+
+```bash
+grep -rn 'NodeFilterTitleState' src/
+```
+
+Delete every match (it was the bridge between the standalone dialog and the title; the new title reads from `Table.filter_state()`).
+
+- [ ] **Step 5: Update `tab.rs` to pass `label_registry`**
+
+Edit `src/features/node/view/tab.rs`. Where `node_widget(...)` is called, supply the registry:
+
+- Locate the existing `NodeTab::new` or factory and add a `label_registry: Vec<NodeLabelColumn>` parameter (or reuse an already-passed `NodeColumns` and call `.label_columns()` if such a method exists).
+- Remove the construction of `NodeFilterTitleState` and the `.action('/', ...)` opening the standalone dialog.
+- Keep the `NODE_FILTER_HELP_DIALOG_ID` dialog registration intact (Task 10 updates its content).
+
+- [ ] **Step 6: Build and run tests**
+
+Run:
+```bash
+cargo build 2>&1 | tail -8
+cargo test --bin kubetui 2>&1 | tail -5
+```
+Expected: clean build, tests pass. Compile errors are likely if `NodeFilterTitleState` is still referenced elsewhere — fix incrementally.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/features/node/view/widgets/node.rs src/features/node/view/tab.rs
+git commit -m "feat(node): switch widget to filter_form + node_filter_applicator
+
+Drop the .action('/', open_node_filter_dialog()) shortcut that opened
+the standalone NodeFilter dialog. The Table widget's built-in
+FilterForm now hosts the input; node_filter_applicator drives parsing,
+help-dialog dispatch, and labelSelector forwarding.
+
+Title block_injection now reads Table.filter_state() (the
+TableFilterPredicate set by PR A's filter framework) rather than a
+NodeFilterTitleState shim. Displays 'Node [matched/total]' when a
+filter is active."
+```
+
+---
+
+### Task 9: Delete obsolete code (NodeFilter struct, standalone dialog widget, component ID)
+
+**Purpose:** Now that nothing references the old API, remove the dead code in one focused commit so the PR diff is clear about what is being replaced.
+
+**Files:**
+- Delete: `src/features/node/view/widgets/node_filter.rs`
+- Modify (delete contents): `src/features/node/filter.rs` (the old `NodeFilter` struct definition lived here; Task 6 replaced the body, so this is usually a no-op — verify nothing slipped through)
+- Modify: `src/features/component_id.rs` (remove `NODE_FILTER_WIDGET_ID`)
+- Modify: `src/features/node/view/widgets.rs` (remove `pub mod node_filter;`)
+- Modify: `src/features/node/view/tab.rs` (remove the dialog widget construction and registration)
+
+- [ ] **Step 1: Delete the standalone dialog widget file**
+
+Run:
+```bash
+git rm src/features/node/view/widgets/node_filter.rs
+```
+
+- [ ] **Step 2: Remove the module declaration**
+
+Edit `src/features/node/view/widgets.rs`. Remove the `pub mod node_filter;` line.
+
+- [ ] **Step 3: Remove `NODE_FILTER_WIDGET_ID` from the component ID registry**
+
+Edit `src/features/component_id.rs`. Remove the line declaring `NODE_FILTER_WIDGET_ID`. Then:
+
+```bash
+grep -rn 'NODE_FILTER_WIDGET_ID' src/
+```
+Expected: no matches. Fix any leftover references.
+
+- [ ] **Step 4: Remove the dialog registration from tab.rs**
+
+Edit `src/features/node/view/tab.rs`. Remove the chunk that constructs the `node_filter_widget()` Dialog and registers it. Keep the `node_filter_help_widget()` Dialog registration (Task 10 rewrites its content).
+
+- [ ] **Step 5: Verify `NodeFilter` struct is gone**
+
+Run:
+```bash
+grep -rn 'struct NodeFilter\b\|::NodeFilter\b\|: NodeFilter\b' src/
+```
+Expected: no matches. If `NodeFilter` is still defined in `src/features/node/filter.rs`, edit the file to remove the struct + impl + `pub use`. (Task 6 should have removed it; this step is a safety net.)
+
+- [ ] **Step 6: Build and test**
+
+Run:
+```bash
+cargo build 2>&1 | tail -5
+cargo test --bin kubetui 2>&1 | tail -5
+```
+Expected: clean build, all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(node): remove standalone NodeFilter dialog + dead types
+
+With the inline FilterForm taking over the input UX, the standalone
+node_filter dialog widget and its NODE_FILTER_WIDGET_ID component ID
+have no consumers. The NodeFilter struct itself is also retired —
+TableFilterPredicate (PR A) is the sole filter type. The
+NODE_FILTER_HELP_DIALOG_ID dialog is preserved (Task 10 rewrites its
+content for the new syntax)."
+```
+
+---
+
+### Task 10: Update help dialog content for the new syntax
+
+**Files:**
+- Modify: `src/features/node/view/widgets/node_filter_help.rs`
+
+- [ ] **Step 1: Rewrite `content()`**
+
+Edit `src/features/node/view/widgets/node_filter_help.rs`. Replace the body of `content()` with:
+
+```rust
+fn content() -> Vec<String> {
+    indoc! {r#"
+        Usage: TERM [ TERM ]...
+
+        Terms:
+           <value>            Plain value: NAME include (regex).
+           NAME:<regex>       Include nodes where NAME matches.
+           STATUS:<regex>     Include where STATUS matches. Multiple
+                              same-column includes are OR (in-list).
+           !<COL>:<regex>     Exclude nodes whose COL matches.
+           label:<selector>   Kubernetes labelSelector, applied
+                              server-side (e.g. role=worker,zone=us-west).
+                              Last 'label:' wins if repeated.
+
+        Combining:
+           Same column, multiple includes  →  OR (in-list)
+           Different columns, includes     →  AND across columns
+           Any matching exclude            →  row excluded
+           Bare values                     →  treated as NAME includes
+
+        Examples
+           worker                          Show nodes whose NAME matches 'worker'
+           NAME:gke STATUS:Ready           NAME~gke AND STATUS~Ready
+           STATUS:Ready STATUS:Pending     STATUS in (Ready, Pending)
+           !NAME:control label:zone=us     Server-side label filter + name exclude
+           NAME:(?=.*foo)(?=.*bar)         Single-column AND via regex lookahead
+
+        Column names are case-insensitive. Unknown columns produce a
+        parse error. Press Enter to apply, Esc to cancel. Type ? or
+        help in the filter input to open this help.
+    "# }
+    .lines()
+    .map(ToString::to_string)
+    .collect()
+}
+```
+
+(Adjust the column names if `NodeColumn::display()` returns different display strings than `NAME`/`STATUS` — keep the convention consistent with what the user actually sees in column headers.)
+
+- [ ] **Step 2: Build and visually inspect**
+
+Run:
+```bash
+cargo build 2>&1 | tail -3
+```
+Expected: clean build. Visual confirmation is part of Task 11's manual smoke.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/features/node/view/widgets/node_filter_help.rs
+git commit -m "docs(node): rewrite filter help for column-aware syntax
+
+Replace the old node:/!node:/label: documentation with the new
+<COL>:<val> / !<COL>:<val> / label:<sel> grammar and the column-OR /
+cross-AND / any-match-excludes semantics. Adds examples for the
+single-column-AND regex-lookahead workaround and explicitly notes
+case-insensitive column names and unknown-column parse errors."
+```
+
+---
+
+### Task 11: Polish (fmt, clippy, full tests, manual smoke notes)
+
+**Files:**
+- Whole workspace.
+
+- [ ] **Step 1: Run formatter**
+
+Run:
+```bash
+cargo +nightly fmt
+git status --short
+```
+If any files were rewritten, stage them: `git add -A`.
+
+- [ ] **Step 2: Run clippy and address PR-B-introduced warnings**
+
+Run:
+```bash
+cargo clippy --all-targets 2>&1 | grep -E '^(warning|error)' | head -30
+```
+Expected: no new warnings introduced by this PR. Pre-existing warnings (the 3 `too_many_arguments` ones from PR A's scope check) can be left alone. For any new warning, prefer fixing the code over `#[allow]`. If `#[allow]` is unavoidable, attach a one-line comment naming the cross-PR consumer.
+
+- [ ] **Step 3: Run full test suite**
+
+Run:
+```bash
+cargo test --all 2>&1 | tail -5
+```
+Expected: all tests pass, no regressions.
+
+- [ ] **Step 4: Manual smoke list (for the PR description)**
+
+Document the following so the reviewer can re-do them. Each item should be verifiable in a few seconds against a real cluster.
+
+Suggested set:
+1. `/` opens the Node filter form (inline, not a separate dialog).
+2. `STATUS:Ready` filters live to nodes whose STATUS matches. Press Enter → form stays, rows stay filtered.
+3. `STATUSU:Ready` (typo) shows a body-replacement error "unknown column 'statusu'" that does NOT disappear on the next polling tick (sticky).
+4. `?` in the filter input opens the Node Filter Help dialog with the new syntax.
+5. `label:role=worker` (or any valid label your cluster has): Enter applies it; the kubectl-style server-side filter is sent on the next poll (verify via `kubectl get --raw` against the same URL, or via the node count changing).
+6. `NAME:foo !NAME:bar` honors include AND exclude on the same column.
+7. `Esc` from FilterInput or FilterConfirm clears both rows and the error overlay.
+8. Polling tick during an active filter does not reset the filter (matches behavior verified for PR A).
+
+If any manual item fails, fix the root cause and re-run from Step 1.
+
+- [ ] **Step 5: Commit final polish**
+
+Only commit if Steps 1–3 produced changes:
+
+```bash
+git add -A
+git commit -m "chore: cargo +nightly fmt and final polish for PR B"
+```
+
+(If no files changed, skip the commit.)
+
+- [ ] **Step 6: Push and prepare PR description**
+
+After explicit user approval (per project convention), push the branch and open a stacked PR against the prerequisite branch:
+
+```bash
+git push -u origin feat/node-filter-applicator
+gh pr create --base <prerequisite-branch> --title "feat(node): column-aware filter via TableFilterApplicator" --body "..."
+```
+
+PR body skeleton (English, mirroring PR #982 structure):
+
+```markdown
+Stacked on <PR A or integration PR>.
+
+## Summary
+- Implement Node tab's column-aware filter using the TableFilterApplicator
+  framework (PR A). Bare values default to NAME, <COL>:<val> targets a
+  named column, !<COL>:<val> excludes, label:<sel> is the server-side
+  k8s labelSelector (last-wins).
+- Drop the standalone NodeFilter dialog widget; the Table widget's
+  inline FilterForm hosts the input.
+- Reduce NodeFilterMessage payload to Option<String> (only labelSelector
+  reaches the server; client-side regex matching is owned by
+  TableFilterPredicate::matches).
+
+## Manual verification
+(checklist from Task 11 Step 4)
+```
+
+---
+
+## Self-review
+
+### Spec coverage
+
+- §307 (構文) → Tasks 1–5 (bare, COL:val, !COL:val, label:, unknown-column error)
+- §323 (意味論) → handled by PR A's `TableFilterPredicate::matches`; parser only routes terms into the correct buckets (Tasks 1–4)
+- §334 (列名 case-insensitive、正準形 lowercase) → Task 2 Step 3
+- §336 (値は常に regex) → Tasks 1–3 use `Regex::new` on bare/include/exclude values
+- §338 (NodeFilterApplicator) → Task 6
+- §355 (build_on_apply) → Task 6 `with_on_apply` closure
+- §367 (サーバ側フィルタリング) → Task 7 (payload reduction, URL builder)
+- §407 (ヘルプ) → Task 10
+- §449 (モジュール構成: node_filter.rs 削除 / node_filter_help.rs 保持) → Tasks 9, 10
+- §479 (Node タブ実装の編集点リスト) → Tasks 8 (node.rs widget), 9 (deletes), 10 (help), all relevant
+
+### Placeholder scan
+
+- No "TBD" / "implement later" / "add appropriate error handling" placeholders.
+- Code blocks given for every code step.
+- Tests written before implementation in TDD tasks.
+
+### Type consistency
+
+- `TableFilterPredicate` field names (`column_includes`, `column_excludes`, `label_selector`, `raw`) match PR A and are used consistently across Tasks 1–6.
+- `NodeFilterMessage::Apply(Option<String>)` is introduced in Task 7 and consumed by the controller in the same task; no later task references the old `Option<NodeFilter>` shape.
+- `SharedNodeFilter = Arc<RwLock<Option<String>>>` matches the controller assignment in Task 7 Step 5.
+- `node_filter_applicator(label_registry: Vec<NodeLabelColumn>, tx: Sender<Message>)` (Task 6) and its single call site (Task 8 Step 2) agree on argument order.
+- `parse_node_filter(input: &str, label_registry: &[NodeLabelColumn]) -> Result<TableFilterPredicate, String>` is the signature from Task 1 onward; later tasks add cases inside the body without changing the signature.
+
+### Known assumptions to verify at execution time
+
+- `NodeColumn::display()` returns the column header used in the table (Task 1 / Task 5). If the actual method is named differently, Task 5 Step 4 needs the real name.
+- `Table::filter_state()` and `Table::original_items_len()` accessors exist on PR A (Task 8 Step 3). If absent, add them as small follow-on commits to PR A or include the additions in Task 8.
+- `Window` is constructible in tests (Task 6 Step 2 optional test). If not, drop that test.

--- a/docs/superpowers/plans/2026-05-27-table-filter-applicator.md
+++ b/docs/superpowers/plans/2026-05-27-table-filter-applicator.md
@@ -1,0 +1,1392 @@
+# Table widget filter_applicator 化 Implementation Plan (PR A)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `Table` ウィジェットの組み込みフィルタを pluggable 化し、`TableFilterApplicator`（parser + strategy + help_dialog_id + on_apply）を受け取って動作する設計にする。既存タブはすべて `SubstringFilterApplicator` に乗り換え、`filtered_key` / `filtered_word` ベースの旧パスを完全削除する。
+
+**Architecture:** `TableFilterApplicator` 構造体に parser/strategy/help_dialog_id/on_apply を 1 ショットで束ね、`Table::builder().filter_applicator(...)` で渡す。Table 内部では parser を呼んで `TableFilterPredicate`（列内 OR・列間 AND・exclude any-match-excludes の統一構造体）を得て、`filter_state` に保持、行フィルタリングは `predicate.matches()` 経由。parse 失敗時は `filter_error` を粘着的に保持し、テーブル本体置換でエラー表示する。セル比較は既存実装に揃えて ANSI 制御コードを除去（`styled_graphemes_symbols().concat()`）してから regex マッチする。
+
+**Tech Stack:** Rust, ratatui, regex, kubetui の既存パターン（`define_callback!`、enum_dispatch ベースの Widget、`InnerItem` 構造）。
+
+**前提:** PR #980（`feat/table-optional-filter`、Table の `filter_form: Option<FilterForm>` 化）が前提。本 PR はその上にスタックする。ブランチは `feat/table-filter-applicator` を `feat/table-optional-filter` から切る。
+
+**設計スペック:** `docs/superpowers/specs/2026-05-27-table-filter-redesign.md`。
+
+**ANSI 除去について:** 現状の kubetui は kube ワーカー側でステータス値等に ANSI 色付けを埋め込んでいる（本来は Table 側でカラムごとに色付けすべきだが、それは別タスク）。既存 substring filter は `styled_graphemes_symbols().concat()` で表示可視部分のみ抽出してから比較しており、新フィルタもこれに揃える。これで既存タブの挙動完全互換、かつ regex の anchor 系（`^`, `$`）も正しく動く。
+
+---
+
+## ファイル構成
+
+**新規作成:**
+- `src/ui/widget/table/filter_applicator.rs` — `TableFilterApplicator`, `ApplyStrategy`, `TableFilterPredicate`, `TableFilterParser`, `OnFilterApply`, `substring_applicator()`, `cell_of()` ヘルパ
+
+**変更:**
+- `src/ui/widget/table.rs` — 3 フィールド追加（filter_applicator, filter_state, filter_error）、builder method、on_key_event の Live/Enter ハンドリング、`?`/`help` 入力分岐、`item_passes_filter`、render の filter_error 優先、`filtered_key` 完全削除
+- `src/ui/widget/table/item.rs` — `update_filter` / `inner_filter_items` / `filtered_word` / `filtered_key` / `filtered_index` を削除、外部から渡された predicate で filter する `apply_filter` を追加
+- `src/ui/widget.rs` — `pub use table::filter_applicator::...` re-export
+- `src/features/pod/view/widgets/pod.rs` — `.filtered_key(...)` → `.filter_applicator(substring_applicator(...))`
+- `src/features/config/view/widgets/config.rs` — 同上
+- `src/features/network/view/widgets/network.rs` — 同上
+- `src/features/api_resources/view/dialog.rs` — 同上
+- `src/features/yaml/view/dialogs/name.rs` — 同上
+- `src/features/yaml/view/dialogs/kind.rs` — 同上
+- `src/features/context/view/dialog.rs` — 同上
+- `src/features/namespace/view/single_namespace_dialog.rs` — 同上
+- `src/features/namespace/view/multiple_namespaces_dialog.rs` — 同上
+
+**触らない:**
+- Tab 階層の `widget_error`（`Tab.error_states` 等。既存仕組みのまま）
+- Node 関連（PR B のスコープ）
+- kube ワーカーの ANSI 埋め込み（暫定的に共存。Table 側カラム色付けは別タスク）
+
+---
+
+## Task 0: ブランチ作成
+
+**Files:** なし（ブランチ操作のみ）
+
+- [ ] **Step 1: PR #980 ブランチへ切替**
+
+```bash
+git fetch origin
+git checkout feat/table-optional-filter
+git pull origin feat/table-optional-filter
+```
+
+- [ ] **Step 2: 新ブランチ作成**
+
+```bash
+git checkout -b feat/table-filter-applicator
+```
+
+- [ ] **Step 3: ベース確認**
+
+```bash
+git log --oneline -3
+```
+Expected: トップは `feat(table): make filter_form optional via Option<FilterForm>`（PR #980）。
+
+---
+
+## Task 1: TableFilterPredicate + matches + ANSI 除去 + 単体テスト
+
+**Files:**
+- Create: `src/ui/widget/table/filter_applicator.rs`
+- Modify: `src/ui/widget/table.rs`（モジュール宣言）
+
+- [ ] **Step 1: モジュール宣言を追加**
+
+`src/ui/widget/table.rs` の冒頭部分（`mod filter;` の隣）に:
+```rust
+mod filter_applicator;
+```
+
+- [ ] **Step 2: filter_applicator.rs を作成**
+
+`src/ui/widget/table/filter_applicator.rs`:
+```rust
+use std::collections::HashMap;
+
+use regex::Regex;
+
+use crate::ui::widget::{styled_graphemes::StyledGraphemes, TableItem};
+
+/// 列ベースのフィルタ条件。
+///
+/// 意味論:
+/// - include: 同一列内は OR、列間は AND（`AND_col(OR_pat in col)`）
+/// - exclude: いずれかにマッチしたら除外（any-match-excludes）
+/// - キーは小文字に正規化した列名
+#[derive(Debug, Default, Clone)]
+pub struct TableFilterPredicate {
+    pub column_includes: HashMap<String, Vec<Regex>>,
+    pub column_excludes: HashMap<String, Vec<Regex>>,
+    /// k8s labelSelector（Node 系のみ。matches では参照されず on_apply 経由で別ワーカーへ）
+    pub label_selector: Option<String>,
+    /// 入力文字列（タイトル表示・デバッグ用）
+    pub raw: String,
+}
+
+impl TableFilterPredicate {
+    pub fn matches(&self, item: &TableItem, header: &[String]) -> bool {
+        for (col, regexes) in &self.column_includes {
+            let cell = cell_of(item, header, col).unwrap_or_default();
+            if !regexes.iter().any(|r| r.is_match(&cell)) {
+                return false;
+            }
+        }
+        for (col, regexes) in &self.column_excludes {
+            let cell = cell_of(item, header, col).unwrap_or_default();
+            if regexes.iter().any(|r| r.is_match(&cell)) {
+                return false;
+            }
+        }
+        true
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.column_includes.is_empty()
+            && self.column_excludes.is_empty()
+            && self.label_selector.is_none()
+    }
+}
+
+/// 指定列のセル値を「ANSI 制御コード除去後の表示文字列」として返す。
+///
+/// 既存 substring フィルタの `styled_graphemes_symbols().concat()` と同じ
+/// 経路。kube ワーカー側がステータス値等に色付けで `\x1b[...m` を埋め込む
+/// 現状を吸収するため、フィルタ比較は表示可視部分のみで行う。
+///
+/// 列名のマッチは大小区別なし。
+fn cell_of(item: &TableItem, header: &[String], col: &str) -> Option<String> {
+    let idx = header.iter().position(|h| h.eq_ignore_ascii_case(col))?;
+    let raw = item.item.get(idx)?;
+    Some(raw.styled_graphemes_symbols().concat())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    fn item(cells: &[&str]) -> TableItem {
+        TableItem::new(
+            cells.iter().map(ToString::to_string).collect::<Vec<_>>(),
+            None,
+        )
+    }
+
+    fn header(cols: &[&str]) -> Vec<String> {
+        cols.iter().map(ToString::to_string).collect()
+    }
+
+    fn rx(s: &str) -> Regex {
+        Regex::new(s).expect("test regex must compile")
+    }
+
+    #[test]
+    fn empty_predicate_matches_anything() {
+        let p = TableFilterPredicate::default();
+        let h = header(&["NAME", "STATUS"]);
+        assert!(p.matches(&item(&["x", "y"]), &h));
+        assert!(p.is_empty());
+    }
+
+    #[test]
+    fn includes_within_column_use_or() {
+        let mut p = TableFilterPredicate::default();
+        p.column_includes
+            .insert("status".to_string(), vec![rx("Ready"), rx("Pending")]);
+        let h = header(&["NAME", "STATUS"]);
+        assert!(p.matches(&item(&["x", "Ready"]), &h));
+        assert!(p.matches(&item(&["x", "Pending"]), &h));
+        assert!(!p.matches(&item(&["x", "Failed"]), &h));
+    }
+
+    #[test]
+    fn includes_across_columns_use_and() {
+        let mut p = TableFilterPredicate::default();
+        p.column_includes
+            .insert("status".to_string(), vec![rx("Ready")]);
+        p.column_includes
+            .insert("name".to_string(), vec![rx("nginx")]);
+        let h = header(&["NAME", "STATUS"]);
+        assert!(p.matches(&item(&["nginx-x", "Ready"]), &h));
+        assert!(!p.matches(&item(&["web-y", "Ready"]), &h));
+        assert!(!p.matches(&item(&["nginx-x", "Pending"]), &h));
+    }
+
+    #[test]
+    fn excludes_any_match_excludes() {
+        let mut p = TableFilterPredicate::default();
+        p.column_excludes
+            .insert("status".to_string(), vec![rx("Pending"), rx("Failed")]);
+        let h = header(&["NAME", "STATUS"]);
+        assert!(p.matches(&item(&["x", "Ready"]), &h));
+        assert!(!p.matches(&item(&["x", "Pending"]), &h));
+        assert!(!p.matches(&item(&["x", "Failed"]), &h));
+    }
+
+    #[test]
+    fn excludes_across_columns_block_on_any_match() {
+        let mut p = TableFilterPredicate::default();
+        p.column_excludes
+            .insert("status".to_string(), vec![rx("Pending")]);
+        p.column_excludes
+            .insert("name".to_string(), vec![rx("kube")]);
+        let h = header(&["NAME", "STATUS"]);
+        assert!(p.matches(&item(&["nginx-x", "Ready"]), &h));
+        assert!(!p.matches(&item(&["nginx-x", "Pending"]), &h));
+        assert!(!p.matches(&item(&["kube-proxy", "Ready"]), &h));
+    }
+
+    #[test]
+    fn includes_and_excludes_combine() {
+        let mut p = TableFilterPredicate::default();
+        p.column_includes
+            .insert("status".to_string(), vec![rx("Ready")]);
+        p.column_excludes
+            .insert("name".to_string(), vec![rx("kube")]);
+        let h = header(&["NAME", "STATUS"]);
+        assert!(p.matches(&item(&["nginx-x", "Ready"]), &h));
+        assert!(!p.matches(&item(&["kube-proxy", "Ready"]), &h));
+        assert!(!p.matches(&item(&["nginx-x", "Pending"]), &h));
+    }
+
+    #[test]
+    fn column_name_matching_is_case_insensitive() {
+        let mut p = TableFilterPredicate::default();
+        p.column_includes
+            .insert("status".to_string(), vec![rx("Ready")]);
+        let h = header(&["NAME", "STATUS"]); // ヘッダ大文字、キー小文字
+        assert!(p.matches(&item(&["x", "Ready"]), &h));
+    }
+
+    #[test]
+    fn unknown_column_yields_empty_cell_so_fails_match() {
+        let mut p = TableFilterPredicate::default();
+        p.column_includes
+            .insert("nonexistent".to_string(), vec![rx("anything")]);
+        let h = header(&["NAME", "STATUS"]);
+        assert!(!p.matches(&item(&["x", "y"]), &h));
+    }
+
+    #[test]
+    fn ansi_escape_in_cell_is_stripped_before_match() {
+        // kube ワーカーが埋め込む色付け前提のセル値（例: STATUS=Ready を緑で）
+        // ユーザーが素の "Ready" を指定して通ること。
+        let colored_status = "\x1b[32mReady\x1b[0m";
+        let mut p = TableFilterPredicate::default();
+        p.column_includes
+            .insert("status".to_string(), vec![rx("Ready")]);
+        let h = header(&["NAME", "STATUS"]);
+        assert!(p.matches(&item(&["nginx", colored_status]), &h));
+    }
+
+    #[test]
+    fn ansi_escape_does_not_pollute_anchor_match() {
+        // ^Ready$ (anchor 付き完全一致) は raw だと ESC で壊れるが、
+        // ANSI 除去後の "Ready" に対しては正しく完全一致する。
+        let colored_status = "\x1b[31mReady\x1b[0m";
+        let mut p = TableFilterPredicate::default();
+        p.column_includes
+            .insert("status".to_string(), vec![rx("^Ready$")]);
+        let h = header(&["NAME", "STATUS"]);
+        assert!(p.matches(&item(&["nginx", colored_status]), &h));
+    }
+
+    #[test]
+    fn ansi_escape_in_cell_not_matched_as_part_of_value() {
+        // 「\x1b[31m が含まれる」みたいな regex は ANSI 除去後の値には
+        // ヒットしない（除去によって ESC が消えるため）。
+        let colored_status = "\x1b[31mFailed\x1b[0m";
+        let mut p = TableFilterPredicate::default();
+        p.column_includes
+            .insert("status".to_string(), vec![rx(r"\[31m")]);
+        let h = header(&["NAME", "STATUS"]);
+        assert!(!p.matches(&item(&["nginx", colored_status]), &h));
+    }
+}
+```
+
+- [ ] **Step 3: テスト実行**
+
+```bash
+cargo test --bin kubetui ui::widget::table::filter_applicator::tests
+```
+Expected: 11 passed; 0 failed。
+
+- [ ] **Step 4: フルビルド・全テスト**
+
+```bash
+cargo build && cargo test
+```
+Expected: ビルド green、既存全テスト pass。
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add -A
+git commit -m "feat(table): add TableFilterPredicate with unified semantics
+
+Column-internal OR, cross-column AND, any-match-excludes. Single struct
+covering both Substring (single-column) and Node-style (multi-column +
+labelSelector) uses; the predicate itself only handles client-side
+matching, label_selector is exposed for callers that need server-side
+filtering (Node tab via on_apply).
+
+cell_of() strips ANSI escape sequences via styled_graphemes_symbols()
+before regex match, matching the existing inner_filter_items behavior.
+This accommodates the current architecture where kube workers embed
+SGR codes (e.g., Pod status coloring) in cell values; without stripping,
+anchored regexes like ^Ready\$ would fail against colored cells."
+```
+
+---
+
+## Task 2: TableFilterApplicator・ApplyStrategy・コールバック型
+
+**Files:**
+- Modify: `src/ui/widget/table/filter_applicator.rs`
+
+- [ ] **Step 1: コールバック型と Applicator を追加**
+
+`src/ui/widget/table/filter_applicator.rs` の **テスト mod の前** に追加:
+```rust
+use crate::{define_callback, ui::{event::EventResult, Window}};
+
+define_callback!(
+    pub TableFilterParser,
+    Fn(&str) -> Result<TableFilterPredicate, String>
+);
+
+define_callback!(
+    pub OnFilterApply,
+    Fn(&TableFilterPredicate, &mut Window)
+);
+
+/// フィルタ適用のタイミング戦略。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApplyStrategy {
+    /// 毎キーで parser を呼び、自動的に filter_state を更新する。
+    /// 既存タブの "live" substring 動作で使う。
+    Live,
+    /// Enter のみで parser を呼ぶ。複雑な構文（Node 系）で使う。
+    EnterToConfirm,
+}
+
+/// Table の filter 機能を構成する。parser / strategy / help dialog id /
+/// apply hook を 1 ショットで束ねる。Table::builder().filter_applicator()
+/// で渡す。
+pub struct TableFilterApplicator {
+    pub(crate) parser: TableFilterParser,
+    pub(crate) strategy: ApplyStrategy,
+    pub(crate) help_dialog_id: Option<&'static str>,
+    pub(crate) on_apply: Option<OnFilterApply>,
+}
+
+impl std::fmt::Debug for TableFilterApplicator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TableFilterApplicator")
+            .field("strategy", &self.strategy)
+            .field("help_dialog_id", &self.help_dialog_id)
+            .field("parser", &"<fn>")
+            .field("on_apply", &self.on_apply.as_ref().map(|_| "<fn>"))
+            .finish()
+    }
+}
+
+impl TableFilterApplicator {
+    pub fn new(parser: TableFilterParser, strategy: ApplyStrategy) -> Self {
+        Self {
+            parser,
+            strategy,
+            help_dialog_id: None,
+            on_apply: None,
+        }
+    }
+
+    pub fn with_help_dialog(mut self, id: &'static str) -> Self {
+        self.help_dialog_id = Some(id);
+        self
+    }
+
+    pub fn with_on_apply(mut self, cb: OnFilterApply) -> Self {
+        self.on_apply = Some(cb);
+        self
+    }
+}
+
+// `EventResult` は OnFilterApply の return 型では未使用だが、将来 ApplyStrategy
+// 拡張時のため import 維持。現状は unused なので silence。
+#[allow(unused_imports)]
+use EventResult as _;
+```
+
+- [ ] **Step 2: ビルド**
+
+```bash
+cargo build 2>&1 | grep -E "^error" | head
+```
+Expected: error 0。
+
+- [ ] **Step 3: 全テスト**
+
+```bash
+cargo test
+```
+Expected: 既存全 pass + Task 1 の 11 pass。
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add -A
+git commit -m "feat(table): add TableFilterApplicator / ApplyStrategy / callback types
+
+Bundles parser + apply strategy + help dialog id + on_apply callback into
+one factory that tabs pass to Table::builder().filter_applicator()."
+```
+
+---
+
+## Task 3: Table widget へフィールド追加 + builder method
+
+**Files:**
+- Modify: `src/ui/widget/table.rs`
+
+- [ ] **Step 1: filter_applicator モジュール公開を確認**
+
+`src/ui/widget/table.rs` 既存の `pub use filter::{FilterForm, FilterFormTheme};` の隣に:
+```rust
+pub use filter_applicator::{
+    substring_applicator,
+    ApplyStrategy,
+    OnFilterApply,
+    TableFilterApplicator,
+    TableFilterParser,
+    TableFilterPredicate,
+};
+```
+注: `substring_applicator` は Task 4 で実装するが、re-export はここで宣言しておくと一括変更を抑えられる。Task 4 未完なら一時的に `substring_applicator` を抜く形で構わない。
+
+- [ ] **Step 2: TableBuilder に filter_applicator フィールド追加**
+
+`pub struct TableBuilder` の `filter_form: Option<FilterForm>,` の直後に:
+```rust
+filter_applicator: Option<TableFilterApplicator>,
+```
+
+- [ ] **Step 3: TableBuilder に filter_applicator setter 追加**
+
+`pub fn filter_form(...)` の直後に追加:
+```rust
+/// Enable rich filter parsing with the given applicator. Replaces the
+/// default substring-only filter behavior with parser-driven filtering.
+pub fn filter_applicator(mut self, applicator: TableFilterApplicator) -> Self {
+    self.filter_applicator = Some(applicator);
+    self
+}
+```
+
+- [ ] **Step 4: Table struct にフィールド 3 つ追加**
+
+`pub struct Table<'a>` の `filter_form: Option<FilterForm>,` の直後に:
+```rust
+filter_applicator: Option<TableFilterApplicator>,
+filter_state: Option<TableFilterPredicate>,
+filter_error: Option<String>,
+```
+
+- [ ] **Step 5: TableBuilder::build で受け渡し**
+
+`fn build(self) -> Table<'static>` 内、Table 初期化部分（既存の `filter_form: self.filter_form,` の隣）:
+```rust
+filter_form: self.filter_form,
+filter_applicator: self.filter_applicator,
+filter_state: None,
+filter_error: None,
+```
+
+- [ ] **Step 6: ビルド・全テスト**
+
+```bash
+cargo build 2>&1 | grep -E "^error" | head
+cargo test
+```
+Expected: error 0、全テスト pass（フィールド追加のみで挙動変化なし）。
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add -A
+git commit -m "feat(table): add filter_applicator/filter_state/filter_error fields"
+```
+
+---
+
+## Task 4: substring_applicator ファクトリ + テスト
+
+**Files:**
+- Modify: `src/ui/widget/table/filter_applicator.rs`
+
+- [ ] **Step 1: ファクトリ実装**
+
+`filter_applicator.rs`、テスト mod の前に追加:
+```rust
+/// 既存タブが使う「単一列の部分一致」フィルタを構成する。
+/// `column` は対象列名（大小区別なし、内部で小文字化）。
+///
+/// 挙動は既存の `filtered_key + split(' ').any(contains)` と等価:
+/// - 空入力 → フィルタなし（全行 pass）
+/// - スペース区切りの複数 pattern → OR
+/// - 各 pattern は `regex::escape` でリテラル化（ユーザーは regex を
+///   意識しなくていい、`.` `*` 等が混入しても安全）
+pub fn substring_applicator(column: &str) -> TableFilterApplicator {
+    let col = column.to_string().to_lowercase();
+    let parser: TableFilterParser = (move |input: &str| {
+        let raw = input.to_string();
+        let patterns: Result<Vec<Regex>, _> = input
+            .split_whitespace()
+            .map(regex::escape)
+            .map(|p| Regex::new(&p))
+            .collect();
+        let patterns = patterns.map_err(|e| e.to_string())?;
+
+        let mut column_includes = HashMap::new();
+        if !patterns.is_empty() {
+            column_includes.insert(col.clone(), patterns);
+        }
+
+        Ok(TableFilterPredicate {
+            column_includes,
+            column_excludes: HashMap::new(),
+            label_selector: None,
+            raw,
+        })
+    })
+    .into();
+
+    TableFilterApplicator::new(parser, ApplyStrategy::Live)
+}
+```
+
+- [ ] **Step 2: substring_applicator のテスト追加**
+
+`mod tests` 内に追加:
+```rust
+fn invoke_parser(a: &TableFilterApplicator, input: &str) -> TableFilterPredicate {
+    (a.parser.closure)(input).expect("test input must parse")
+}
+
+#[test]
+fn substring_applicator_empty_input_matches_everything() {
+    let a = substring_applicator("NAME");
+    let p = invoke_parser(&a, "");
+    let h = header(&["NAME"]);
+    assert!(p.matches(&item(&["nginx"]), &h));
+    assert!(p.matches(&item(&[""]), &h));
+    assert!(p.is_empty());
+}
+
+#[test]
+fn substring_applicator_single_pattern_substring_match() {
+    let a = substring_applicator("NAME");
+    let p = invoke_parser(&a, "nginx");
+    let h = header(&["NAME"]);
+    assert!(p.matches(&item(&["abc-nginx-prod"]), &h));
+    assert!(!p.matches(&item(&["web-server"]), &h));
+}
+
+#[test]
+fn substring_applicator_space_separated_is_or() {
+    // 既存挙動と等価: "nginx web" は NAME に nginx OR web
+    let a = substring_applicator("NAME");
+    let p = invoke_parser(&a, "nginx web");
+    let h = header(&["NAME"]);
+    assert!(p.matches(&item(&["nginx-x"]), &h));
+    assert!(p.matches(&item(&["web-y"]), &h));
+    assert!(!p.matches(&item(&["api-z"]), &h));
+}
+
+#[test]
+fn substring_applicator_special_chars_are_escaped() {
+    // "a.b" がリテラルとして扱われる（regex の `.` ではない）
+    let a = substring_applicator("NAME");
+    let p = invoke_parser(&a, "a.b");
+    let h = header(&["NAME"]);
+    assert!(p.matches(&item(&["x-a.b-y"]), &h));
+    assert!(!p.matches(&item(&["x-a_b-y"]), &h)); // regex の . なら通るがリテラルなので落ちる
+}
+
+#[test]
+fn substring_applicator_strategy_is_live() {
+    let a = substring_applicator("NAME");
+    assert_eq!(a.strategy, ApplyStrategy::Live);
+}
+
+#[test]
+fn substring_applicator_help_dialog_id_is_none() {
+    let a = substring_applicator("NAME");
+    assert_eq!(a.help_dialog_id, None);
+}
+
+#[test]
+fn substring_applicator_on_apply_is_none() {
+    let a = substring_applicator("NAME");
+    assert!(a.on_apply.is_none());
+}
+```
+
+注: `a.parser.closure` は `define_callback!` が生成する内部フィールド (`Rc<dyn Fn>`)。`(closure)(args)` の形で呼べる。
+
+- [ ] **Step 3: テスト実行**
+
+```bash
+cargo test --bin kubetui ui::widget::table::filter_applicator::tests
+```
+Expected: 18 passed; 0 failed（既存 11 + 新規 7）。
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add -A
+git commit -m "feat(table): add substring_applicator factory (live + OR semantics)"
+```
+
+---
+
+## Task 5: Table の on_key_event で Live キー入力を分岐
+
+**Files:**
+- Modify: `src/ui/widget/table.rs`
+
+- [ ] **Step 1: 既存の on_key_event を確認**
+
+```bash
+grep -n "fn on_key_event\|Mode::FilterInput" src/ui/widget/table.rs | head
+awk 'NR>=605 && NR<=650' src/ui/widget/table.rs
+```
+Expected: `Mode::FilterInput` 内で `KeyCode::Enter`, `KeyCode::Esc`, `_ =>` の 3 分岐。`_ =>` は `filter_form.on_key_event(ev)` を呼んで filter_items する。
+
+- [ ] **Step 2: run_parser_and_update_state ヘルパを追加**
+
+`impl Table<'_>` 内（既存ヘルパ `match_action` 等の近く）に追加:
+```rust
+/// 現在の filter_form 入力を parser に渡し、結果で filter_state / filter_error を
+/// 更新する。
+///
+/// 成功時は (新 predicate, true)、失敗時は (None, false)。
+/// Live モードでは毎キー、EnterToConfirm モードでは Enter 時に呼ぶ。
+fn run_parser_and_update_state(&mut self) -> Option<TableFilterPredicate> {
+    let applicator = self.filter_applicator.as_ref()?;
+    let input = self
+        .filter_form
+        .as_ref()
+        .map(|f| f.content())
+        .unwrap_or_default();
+
+    match (applicator.parser.closure)(&input) {
+        Ok(predicate) => {
+            self.filter_error = None;
+            self.filter_state = Some(predicate.clone());
+            Some(predicate)
+        }
+        Err(msg) => {
+            self.filter_error = Some(msg);
+            // filter_state は変更しない（前回成功状態が残っても、render は
+            // filter_error 優先で行を隠す）
+            None
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Mode::FilterInput の `_ =>` 分岐を更新**
+
+既存:
+```rust
+_ => {
+    let ev = if let Some(filter_form) = self.filter_form.as_mut() {
+        filter_form.on_key_event(ev)
+    } else {
+        EventResult::Ignore
+    };
+
+    self.filter_items();
+
+    return ev;
+}
+```
+
+これを以下に置き換え:
+```rust
+_ => {
+    let result = if let Some(filter_form) = self.filter_form.as_mut() {
+        filter_form.on_key_event(ev)
+    } else {
+        EventResult::Ignore
+    };
+
+    // Live strategy: 毎キーで parse → state/error を更新
+    if let Some(applicator) = self.filter_applicator.as_ref() {
+        if applicator.strategy == ApplyStrategy::Live {
+            self.run_parser_and_update_state();
+        }
+    }
+
+    self.filter_items();
+
+    return result;
+}
+```
+
+- [ ] **Step 4: ビルド・全テスト**
+
+```bash
+cargo build && cargo test
+```
+Expected: green。filter_state は Live モードで更新されるが、行絞り込みはまだ未反映（Task 7 で `filter_items` を新パス経由に置き換える）。
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add -A
+git commit -m "feat(table): dispatch parser on key input under Live strategy"
+```
+
+---
+
+## Task 6: Table の Enter で EnterToConfirm パース + on_apply 呼び出し
+
+**Files:**
+- Modify: `src/ui/widget/table.rs`
+
+- [ ] **Step 1: on_filter_apply_callback ヘルパを追加**
+
+`impl Table<'_>` 内、`on_select_callback` の隣に追加:
+```rust
+/// 直近 parse 成功した predicate と applicator の on_apply を捕捉して、
+/// Window 渡しの Callback に詰めて返す。
+fn on_filter_apply_callback(
+    &self,
+    predicate: TableFilterPredicate,
+) -> Option<Callback> {
+    let on_apply = self.filter_applicator.as_ref()?.on_apply.clone()?;
+    Some(Callback::from(move |w: &mut Window| {
+        (on_apply.closure)(&predicate, w);
+        EventResult::Nop
+    }))
+}
+```
+
+注: `Callback::from(closure)` は既存 `Callback` 型が `From<F>` を持つはず（`define_callback!` の expand 内で `impl<T: ...Fn> From<T> for $cb_name` が定義されている、Task の Edit でマクロを確認）。
+
+- [ ] **Step 2: Mode::FilterInput の Enter ハンドラを差し替え**
+
+既存:
+```rust
+KeyCode::Enter => {
+    self.mode.filter_confirm();
+}
+```
+
+これを以下に置き換え:
+```rust
+KeyCode::Enter => {
+    // EnterToConfirm 戦略では Enter で初めて parser を呼ぶ。
+    // Live 戦略では既にタイプ中に state が更新されているが、parse を
+    // 再走させてエラー状態を最終確定する。
+    let parsed = self.run_parser_and_update_state();
+
+    // パース失敗時は FilterInput モード継続（filter_error が立っている）
+    if self.filter_error.is_some() {
+        return EventResult::Nop;
+    }
+
+    self.mode.filter_confirm();
+
+    // 成功時は applicator の on_apply 副作用を Window 経由で呼ぶ。
+    if let Some(predicate) = parsed {
+        if let Some(cb) = self.on_filter_apply_callback(predicate) {
+            return EventResult::Callback(cb);
+        }
+    }
+}
+```
+
+- [ ] **Step 3: ビルド・全テスト**
+
+```bash
+cargo build && cargo test
+```
+Expected: green。filter_state は更新されるが行絞り込みはまだ未反映。
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add -A
+git commit -m "feat(table): parse on Enter, dispatch on_apply via callback"
+```
+
+---
+
+## Task 7: filter_state ベースの行フィルタリング（filtered_word を置換）
+
+**Files:**
+- Modify: `src/ui/widget/table.rs`, `src/ui/widget/table/item.rs`
+
+- [ ] **Step 1: InnerItem に新しい apply_filter API を追加**
+
+`src/ui/widget/table/item.rs` の `impl InnerItem<'_>` に追加:
+```rust
+/// 外部から渡された predicate で original_items を filtered_items に
+/// 絞り込む。filter_state ベースの新パスで使う。
+pub fn apply_filter<F>(&mut self, mut predicate: F)
+where
+    F: FnMut(&TableItem) -> bool,
+{
+    self.filtered_items = self
+        .original_items
+        .iter()
+        .filter(|i| predicate(i))
+        .cloned()
+        .collect();
+    self.inner_update_rendered_items();
+}
+```
+
+- [ ] **Step 2: Table::filter_items を新パス経由に置き換え**
+
+`src/ui/widget/table.rs` の `fn filter_items(&mut self)`:
+```rust
+fn filter_items(&mut self) {
+    let old_len = self.items.len();
+    let header = self.items.header().original().to_vec();
+    let state = self.filter_state.clone();
+
+    self.items.apply_filter(|item| {
+        state.as_ref().map(|p| p.matches(item, &header)).unwrap_or(true)
+    });
+
+    self.adjust_selected(old_len, self.items.len());
+    self.update_row_bounds();
+}
+```
+
+- [ ] **Step 3: Table::update_header_and_rows も新パス経由に**
+
+`fn update_header_and_rows(&mut self, ...)` 内の以下を:
+```rust
+let word = self.filter_word();
+self.items.update_filter(word);
+```
+
+これを以下に置き換え:
+```rust
+let header = self.items.header().original().to_vec();
+let state = self.filter_state.clone();
+self.items.apply_filter(|item| {
+    state.as_ref().map(|p| p.matches(item, &header)).unwrap_or(true)
+});
+```
+
+- [ ] **Step 4: filter_word ヘルパは削除**
+
+`fn filter_word(&self) -> String` を `src/ui/widget/table.rs` から削除。
+
+- [ ] **Step 5: ビルド・全テスト**
+
+```bash
+cargo build 2>&1 | grep -E "^error" | head
+cargo test
+```
+Expected: error 0。既存タブは `filter_applicator` 未設定 → filter_state も None → 全行 pass。挙動同じ。全テスト green。
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add -A
+git commit -m "feat(table): filter rows via filter_state predicate (replacing filtered_word path)"
+```
+
+---
+
+## Task 8: filter_error の render（テーブル本体置換）
+
+**Files:**
+- Modify: `src/ui/widget/table.rs`
+
+- [ ] **Step 1: render_widget_error のシグネチャを確認**
+
+```bash
+grep -n "pub fn render_widget_error" src/ui/widget/error.rs
+sed -n "$(grep -n 'pub fn render_widget_error' src/ui/widget/error.rs | head -1 | cut -d: -f1),+10p" src/ui/widget/error.rs
+```
+Expected: シグネチャ `pub fn render_widget_error(f: &mut Frame, chunk: Rect, block: Block, lines: &[String], theme: &ErrorTheme)`（要確認）。Theme 型と引数順を把握する。
+
+- [ ] **Step 2: render に filter_error 分岐を追加**
+
+`fn render(&mut self, f: &mut Frame<'_>, is_active: bool, is_mouse_over: bool)` 内、既存の `let chunk = self.chunk();` の **直後** に挿入:
+```rust
+// filter_error は粘着エラー。Tab 階層の widget_error は Tab.render が
+// 先にチェックしてここ自体が呼ばれない（widget_error > filter_error）。
+if let Some(err) = self.filter_error.as_ref() {
+    let lines = vec![err.clone()];
+    let error_theme = crate::config::theme::ErrorTheme::default();
+    let error_theme_resolved: crate::ui::widget::error::ErrorTheme =
+        error_theme.into();
+    crate::ui::widget::error::render_widget_error(
+        f,
+        chunk,
+        block.clone(),
+        &lines,
+        &error_theme_resolved,
+    );
+
+    // filter_form は引き続き描画（ユーザーが入力を直せるよう）
+    match self.mode {
+        Mode::Normal => {}
+        Mode::FilterInput | Mode::FilterConfirm => {
+            if let Some(filter_form) = self.filter_form.as_mut() {
+                filter_form.render(f, self.mode.is_filter_input() && is_active, false);
+            }
+        }
+    }
+    return;
+}
+```
+
+注: `ErrorTheme::default()` で OK か、または Table が `theme: TableTheme` に error 用フィールドを持つべきかは実装時判断。今は最小実装として `default()` で進める。実装時にコンパイルエラーが出れば調整。
+
+- [ ] **Step 3: 単体テスト（filter_error 表示）**
+
+`src/ui/widget/table.rs` のテスト mod 内 `mod カラムの幅` の隣に追加:
+```rust
+mod filter_error_render {
+    use super::*;
+    use ratatui::{backend::TestBackend, Terminal};
+
+    #[test]
+    fn filter_error_replaces_table_body() {
+        let backend = TestBackend::new(40, 6);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        let mut table = Table::builder()
+            .header(["NAME".to_string(), "STATUS".to_string()])
+            .items([TableItem::new(
+                vec!["node-a".to_string(), "Ready".to_string()],
+                None,
+            )])
+            .build();
+        table.filter_error = Some("invalid regex 'foo['".to_string());
+        table.update_chunk(Rect::new(0, 0, 40, 6));
+
+        terminal
+            .draw(|f| table.render(f, true, false))
+            .unwrap();
+
+        let buffer = terminal.backend().buffer().clone();
+        let dump: String = (0..buffer.area.height)
+            .flat_map(|y| (0..buffer.area.width).map(move |x| buffer[(x, y)].symbol().to_string()))
+            .collect();
+
+        assert!(
+            dump.contains("invalid regex"),
+            "error text should be rendered: {}",
+            dump
+        );
+        assert!(
+            !dump.contains("node-a"),
+            "rows should NOT be rendered when filter_error is set: {}",
+            dump
+        );
+    }
+}
+```
+
+- [ ] **Step 4: テスト実行**
+
+```bash
+cargo test --bin kubetui ui::widget::table::tests::filter_error_render
+```
+Expected: 1 passed; 0 failed。
+
+- [ ] **Step 5: 全テスト**
+
+```bash
+cargo test
+```
+Expected: green。
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add -A
+git commit -m "feat(table): render filter_error as body-replacement (filter_form stays)"
+```
+
+---
+
+## Task 9: 入力中の `?`/`help` でヘルプダイアログを開く
+
+**Files:**
+- Modify: `src/ui/widget/table.rs`
+
+- [ ] **Step 1: ヘルプ判定ヘルパを追加**
+
+`impl Table<'_>` 内に追加:
+```rust
+/// 現在の入力 + 押下キーがヘルプトリガーになるかを判定。
+/// applicator が help_dialog_id を持ち、確定後の文字列が "?" または
+/// "help" と完全一致する場合に Some(help_id) を返す。
+fn would_be_help_command(&self, ev: KeyEvent) -> Option<&'static str> {
+    let help_id = self.filter_applicator.as_ref()?.help_dialog_id?;
+    let current = self
+        .filter_form
+        .as_ref()
+        .map(|f| f.content())
+        .unwrap_or_default();
+    let typed = match key_event_to_code(ev) {
+        KeyCode::Char(c) => c,
+        _ => return None,
+    };
+    let pending = format!("{}{}", current, typed);
+    if pending == "?" || pending == "help" {
+        Some(help_id)
+    } else {
+        None
+    }
+}
+```
+
+- [ ] **Step 2: Mode::FilterInput の `_ =>` 分岐の冒頭にヘルプ判定**
+
+Task 5 で書き換えた `_ =>` の冒頭、`filter_form.on_key_event(ev)` を呼ぶ **前** に挿入:
+```rust
+// `?` または `help` 入力でヘルプダイアログを開く（applicator が
+// help_dialog_id を持つ場合のみ）。Pod log query の慣習に合わせる。
+if let Some(help_id) = self.would_be_help_command(ev) {
+    if let Some(filter_form) = self.filter_form.as_mut() {
+        filter_form.clear();
+    }
+    self.mode.normal();
+    return EventResult::Callback(Callback::from(move |w: &mut Window| {
+        w.open_dialog(help_id);
+        EventResult::Nop
+    }));
+}
+```
+
+- [ ] **Step 3: 動作確認テスト**
+
+`src/ui/widget/table.rs` のテスト mod に追加:
+```rust
+mod help_dispatch {
+    use super::*;
+
+    fn dummy_applicator_with_help() -> TableFilterApplicator {
+        let parser: TableFilterParser =
+            (|_input: &str| Ok(TableFilterPredicate::default())).into();
+        TableFilterApplicator::new(parser, ApplyStrategy::EnterToConfirm)
+            .with_help_dialog("test-help-dialog")
+    }
+
+    #[test]
+    fn typing_question_mark_returns_help_callback() {
+        let mut table = Table::builder()
+            .filter_form(FilterForm::builder().build())
+            .filter_applicator(dummy_applicator_with_help())
+            .build();
+        // FilterInput モードへ
+        let _ = table.on_key_event(KeyEvent::from(KeyCode::Char('/')));
+        // `?` を打つ
+        let result = table.on_key_event(KeyEvent::from(KeyCode::Char('?')));
+
+        assert!(matches!(result, EventResult::Callback(_)));
+    }
+
+    #[test]
+    fn typing_normal_char_does_not_open_help() {
+        let mut table = Table::builder()
+            .filter_form(FilterForm::builder().build())
+            .filter_applicator(dummy_applicator_with_help())
+            .build();
+        let _ = table.on_key_event(KeyEvent::from(KeyCode::Char('/')));
+        let result = table.on_key_event(KeyEvent::from(KeyCode::Char('n')));
+
+        // n を打っても help_callback は返さない
+        assert!(!matches!(result, EventResult::Callback(_)));
+    }
+
+    #[test]
+    fn help_does_not_open_without_help_dialog_id() {
+        // help_dialog_id を持たない applicator
+        let parser: TableFilterParser =
+            (|_input: &str| Ok(TableFilterPredicate::default())).into();
+        let applicator = TableFilterApplicator::new(parser, ApplyStrategy::Live);
+
+        let mut table = Table::builder()
+            .filter_form(FilterForm::builder().build())
+            .filter_applicator(applicator)
+            .build();
+        let _ = table.on_key_event(KeyEvent::from(KeyCode::Char('/')));
+        let result = table.on_key_event(KeyEvent::from(KeyCode::Char('?')));
+
+        assert!(!matches!(result, EventResult::Callback(_)));
+    }
+}
+```
+
+- [ ] **Step 4: テスト・ビルド**
+
+```bash
+cargo test --bin kubetui ui::widget::table::tests::help_dispatch
+cargo build && cargo test
+```
+Expected: 3 passed + 全 test pass。
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add -A
+git commit -m "feat(table): open applicator-declared help dialog on ?/help input"
+```
+
+---
+
+## Task 10: 既存タブ一斉移行（filtered_key → filter_applicator(substring_applicator)）
+
+**Files:** 各タブの widget 生成ファイル
+
+- [ ] **Step 1: substring_applicator の re-export を src/ui/widget.rs に追加**
+
+```bash
+grep -n "substring_applicator" src/ui/widget.rs
+```
+無ければ、`src/ui/widget.rs` の既存の `pub use table::...` 行付近に追加:
+```rust
+pub use table::substring_applicator;
+```
+（Task 3 で `table.rs` 側に `pub use filter_applicator::substring_applicator` を入れてあれば、ここは `pub use table::substring_applicator;` で連鎖再エクスポート。確認のうえ最小限の修正に。）
+
+- [ ] **Step 2: Pod tab を移行**
+
+`src/features/pod/view/widgets/pod.rs`、`Table::builder()` チェーン内:
+```bash
+grep -n '\.filtered_key' src/features/pod/view/widgets/pod.rs
+```
+該当行を:
+```rust
+// Before:
+.filtered_key("NAME")
+
+// After:
+.filter_applicator(crate::ui::widget::substring_applicator("NAME"))
+```
+
+ビルド確認:
+```bash
+cargo build 2>&1 | grep -E "^error" | head
+```
+Expected: error 0。
+
+- [ ] **Step 3: Config tab を移行**
+
+`src/features/config/view/widgets/config.rs`、同様置換。ビルド確認。
+
+- [ ] **Step 4: Network tab を移行**
+
+`src/features/network/view/widgets/network.rs`、同様置換。ビルド確認。
+
+- [ ] **Step 5: API dialog を移行**
+
+`src/features/api_resources/view/dialog.rs`、同様置換。ビルド確認。
+
+- [ ] **Step 6: Yaml name dialog を移行**
+
+`src/features/yaml/view/dialogs/name.rs`、同様置換。ビルド確認。
+
+- [ ] **Step 7: Yaml kind dialog を移行**
+
+`src/features/yaml/view/dialogs/kind.rs`、同様置換。ビルド確認。
+
+- [ ] **Step 8: Context dialog を移行**
+
+`src/features/context/view/dialog.rs`、同様置換。ビルド確認。
+
+- [ ] **Step 9: Single namespace dialog を移行**
+
+`src/features/namespace/view/single_namespace_dialog.rs`、同様置換。ビルド確認。
+
+- [ ] **Step 10: Multiple namespaces dialog を移行**
+
+`src/features/namespace/view/multiple_namespaces_dialog.rs`、同様置換。ビルド確認。
+
+- [ ] **Step 11: 旧 `.filtered_key(` 残骸ゼロ確認**
+
+```bash
+grep -rn '\.filtered_key' src/features/ src/ui/
+```
+Expected: 0 件（テストコード除く。テストコードに残っていれば Task 11 で削除）。
+
+- [ ] **Step 12: 全テスト**
+
+```bash
+cargo test
+```
+Expected: green。挙動は等価（substring + OR + live）なので既存タブ別テストが通る。
+
+- [ ] **Step 13: コミット**
+
+```bash
+git add -A
+git commit -m "refactor: migrate all existing tabs to substring_applicator
+
+Behavior preserved: live + single-column substring with OR semantics for
+space-separated patterns. Sites updated: pod, config, network, api dialog,
+yaml name/kind, context, namespace single/multiple."
+```
+
+---
+
+## Task 11: 旧コード削除（filtered_key, filtered_word, 関連 InnerItem コード）
+
+**Files:**
+- Modify: `src/ui/widget/table.rs`, `src/ui/widget/table/item.rs`
+
+- [ ] **Step 1: Table 構造体から filtered_key を削除**
+
+`src/ui/widget/table.rs`:
+- `pub struct TableBuilder` の `filtered_key: String,` フィールド削除
+- `impl TableBuilder` の `pub fn filtered_key(...)` setter 削除
+- `pub struct Table<'a>` の `filtered_key: String,` フィールド削除
+- `fn build(self)` 内、Table 初期化の `filtered_key: self.filtered_key.clone(),` 削除、`InnerItem::builder().filtered_key(self.filtered_key)` 呼び出しの `.filtered_key(...)` 削除
+- `fn clear(&mut self)` 内、`InnerItem::builder()...filtered_key(self.filtered_key.clone())...` の `.filtered_key(...)` 削除
+- `fn update_header_and_rows(&mut self, ...)` 内、`InnerItem::builder()...filtered_key(self.filtered_key.clone())...` の `.filtered_key(...)` 削除
+
+- [ ] **Step 2: InnerItem から filtered_word / filtered_key / filtered_index / update_filter / inner_filter_items を削除**
+
+`src/ui/widget/table/item.rs`:
+- `InnerItemBuilder` から `filtered_key: String,` フィールドと `pub fn filtered_key()` setter 削除
+- `InnerItemBuilder::build` 内、InnerItem 初期化の `filtered_key: self.filtered_key,` 削除
+- `pub struct InnerItem` から `filtered_word: String,` と `filtered_key: String,` フィールド削除
+- `impl InnerItem<'_>` から `pub fn update_filter(...)` 削除
+- `impl InnerItem<'_>` から `fn inner_filter_items(...)` 削除
+- `impl InnerItem<'_>` から `fn filtered_index(...)` 削除
+- `pub fn update_items` 内、`self.inner_filter_items()` 呼び出しを `self.filtered_items = self.original_items.clone()` に置き換え
+  - 理由: update_filter ベースの「現在のフィルタを再適用」相当は、新パスでは `Table::filter_items` が外部から `apply_filter` を呼ぶことで実現される。`update_items` 直後は filtered_items を素のコピーにし、その後 Table 側で `apply_filter` を呼び直す前提。
+  - もしくは `update_items` のシグネチャを引数で predicate を取るよう変更（よりクリーン）。Task 11 の Step 6 で要選択。
+  - 暫定: `self.filtered_items = self.original_items.clone();` のシンプル化、Table 側で次の filter_items を呼ぶ。
+
+- [ ] **Step 3: filtered_index 関連テストを削除**
+
+`src/ui/widget/table/item.rs`:
+- `mod tests` 内 `mod filtered_index { ... }` 全体を削除
+
+- [ ] **Step 4: Table 側の関連テスト更新**
+
+`src/ui/widget/table.rs` の `mod tests`:
+- 既存テストで `filtered_key` を使っていないか確認:
+```bash
+grep -n 'filtered_key' src/ui/widget/table.rs
+```
+- ヒットした箇所は削除（テストコード内も含めて）。
+- `mod filter_form_option` の既存テスト（PR #980 で追加）が `.filter_form(FilterForm::builder().build())` を使っているので影響なし、引き続き pass。
+
+- [ ] **Step 5: update_items 呼び出し側の補正**
+
+`update_items` 呼び出し箇所（Table 側）で、呼出後に `filter_items` を続けて呼ぶ:
+```bash
+grep -n 'update_items' src/ui/widget/table.rs
+```
+- `update_widget_item` 内で `self.items.update_items(items.table())` の直後に `self.filter_items()` を呼ぶ（既存挙動: 新しい items が来たら現フィルタを再適用）。
+
+- [ ] **Step 6: ビルド・全テスト**
+
+```bash
+cargo build 2>&1 | grep -E "^error|^warning: unused" | head
+cargo test
+```
+Expected: error 0、unused warning 0（旧コードゼロ参照）、全テスト green。
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add -A
+git commit -m "refactor(table): remove filtered_key/filtered_word legacy filter path
+
+All filtering now goes through filter_applicator -> filter_state ->
+TableFilterPredicate::matches. The if/else between old and new paths is
+eliminated. update_items now resets filtered_items to original; the
+caller (Table::update_widget_item) re-runs filter_items() to apply
+filter_state."
+```
+
+---
+
+## Task 12: 仕上げ（fmt / clippy / 全テスト ＋ push 準備）
+
+**Files:** 全変更ファイル
+
+- [ ] **Step 1: fmt**
+
+```bash
+cargo +nightly fmt
+git diff --stat
+```
+Expected: 差分があれば formatter による軽微な調整のみ。
+
+- [ ] **Step 2: clippy**
+
+```bash
+cargo clippy --all-targets 2>&1 | grep -E "warning:|^error" | grep -v "generated" | head
+```
+Expected: 新規 warning なし（pre-existing のみ）。新規 warning があれば直す。
+
+- [ ] **Step 3: 全テスト**
+
+```bash
+cargo test 2>&1 | grep -E "test result:|^error"
+```
+Expected: 全 PASS。
+
+- [ ] **Step 4: fmt 差分があればコミット**
+
+```bash
+git add -A
+git status --short
+# 差分があれば:
+git commit -m "chore: cargo +nightly fmt"
+```
+
+- [ ] **Step 5: push 準備（user 承認後に push + PR 作成）**
+
+実装完了時点でいったん停止。user 承認後に:
+```bash
+git push -u origin feat/table-filter-applicator
+```
+
+- [ ] **Step 6: PR 作成は user 承認後**
+
+PR 本文の骨子:
+- **base**: `feat/table-optional-filter`（PR #980 へスタック）
+- **title**: `feat(table): pluggable filter applicator (column-OR / cross-AND semantics)`
+- **body**: spec ファイル `docs/superpowers/specs/2026-05-27-table-filter-redesign.md` への参照、PR A スコープ（widget 拡張 + 既存タブ移行 + 旧コード削除）を明記、PR B（Node 実装）が続くこと、検証結果（test count、clippy 0 new warnings、既存タブ挙動完全互換）を記載
+
+---
+
+## Self-review
+
+書き終わって spec と照合:
+
+**1. Spec coverage**:
+- `TableFilterPredicate` struct → Task 1 ✓
+- `matches()` 列内 OR・列間 AND・exclude OR → Task 1 のテスト 5 ケース + 4 ANSI ケースで網羅 ✓
+- `cell_of()` ANSI 除去 → Task 1 ✓
+- `TableFilterApplicator` / `ApplyStrategy` / `TableFilterParser` / `OnFilterApply` → Task 2 ✓
+- Table widget の filter_applicator / filter_state / filter_error フィールド → Task 3 ✓
+- builder method → Task 3 ✓
+- Live キー入力 dispatch → Task 5 ✓
+- EnterToConfirm + on_apply → Task 6 ✓
+- filter_state ベース行絞り込み → Task 7 ✓
+- filter_error render → Task 8 ✓
+- `?`/`help` → Task 9 ✓
+- substring_applicator → Task 4 ✓
+- 既存タブ移行（9 サイト）→ Task 10 ✓
+- 旧 filtered_key/filtered_word 削除 → Task 11 ✓
+- 仕上げ → Task 12 ✓
+
+**2. Placeholder スキャン**:
+- "TBD" / "TODO" なし
+- 各タスクに具体的なコード or 具体的なコマンドあり
+- "Similar to Task N" 表現なし
+- 型・関数名は一貫（TableFilterPredicate, ApplyStrategy::Live/EnterToConfirm, substring_applicator, cell_of）
+
+**3. 型整合性**:
+- `TableFilterPredicate` の field 名（column_includes / column_excludes / label_selector / raw）は Task 1 と Task 4 で一致 ✓
+- `parser.closure` 直接アクセス: `define_callback!` の生成形に依存。Task 4/5 で一貫して `(callback.closure)(args)` 呼び出し。実装時に macro 展開を確認 ✓
+- `Callback::from` の使用: Task 6/9 で一貫。`define_callback!` の `impl<T: Fn> From<T> for $cb_name` を活用 ✓
+- `cell_of` の戻り型は `Option<String>`（ANSI 除去で allocate）で一貫 ✓
+- `render_widget_error` のシグネチャは Task 8 Step 1 で確認ステップ込み ✓
+- `update_items` の挙動変更（filtered_items = original_items.clone()）と、呼び出し側の補正は Task 11 Step 5 で明示 ✓

--- a/docs/superpowers/specs/2026-05-27-table-filter-redesign.md
+++ b/docs/superpowers/specs/2026-05-27-table-filter-redesign.md
@@ -87,27 +87,52 @@ define_callback!(
     Fn(&TableFilterPredicate, &mut Window)
 );
 
-/// 全タブで共通のフィルタ判定 enum（static dispatch）。
-pub enum TableFilterPredicate {
-    /// 既存タブ用: 単一列に部分一致
-    Substring {
-        column: String,    // 正準形は小文字
-        pattern: String,
-    },
-    /// Node タブ用: 列ベース regex + ラベルセレクタ
-    Node(NodeFilterPredicate),
-    /// 「フィルタなし」相当（live モードで入力が空のとき）
-    Empty,
+/// 全タブで共通のフィルタ判定。意味論は「列内 OR、列間 AND、exclude は any match
+/// excludes」で統一されているため、既存タブ用と Node 用で構造を分ける必要はなく
+/// 単一 struct で表現できる。
+pub struct TableFilterPredicate {
+    /// 列ごとの include patterns（同一列内は OR、列間は AND）。
+    /// キーは小文字に正規化した列名。
+    pub column_includes: HashMap<String, Vec<Regex>>,
+    /// 列ごとの exclude patterns（いずれかにマッチすれば除外）。
+    pub column_excludes: HashMap<String, Vec<Regex>>,
+    /// k8s labelSelector（Node 系のみ、サーバ側で適用される。
+    /// matches() では参照されず、on_apply 経由で poller に渡る）。
+    pub label_selector: Option<String>,
+    /// 入力文字列（タイトル表示・デバッグ用）。
+    pub raw: String,
 }
 
 impl TableFilterPredicate {
     pub fn matches(&self, item: &TableItem, header: &[String]) -> bool {
-        match self {
-            Self::Empty => true,
-            Self::Substring { column, pattern } => { /* find column in header, substring match */ }
-            Self::Node(p) => p.matches(item, header),
+        // include: 各列で「いずれか」マッチ（列内 OR）、すべての列を通過（列間 AND）。
+        for (col, regexes) in &self.column_includes {
+            let cell = cell_of(item, header, col).unwrap_or("");
+            if !regexes.iter().any(|r| r.is_match(cell)) {
+                return false;
+            }
         }
+        // exclude: いずれかにマッチしたら除外。
+        for (col, regexes) in &self.column_excludes {
+            let cell = cell_of(item, header, col).unwrap_or("");
+            if regexes.iter().any(|r| r.is_match(cell)) {
+                return false;
+            }
+        }
+        true
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.column_includes.is_empty()
+            && self.column_excludes.is_empty()
+            && self.label_selector.is_none()
+    }
+}
+
+/// 列名（小文字、正準形）に対応するセル値を返すヘルパ。
+fn cell_of<'a>(item: &'a TableItem, header: &[String], col: &str) -> Option<&'a str> {
+    let idx = header.iter().position(|h| h.eq_ignore_ascii_case(col))?;
+    item.item.get(idx).map(|s| s.as_str())
 }
 ```
 
@@ -119,17 +144,18 @@ Task 0 #980 で `filter_form: Option<FilterForm>` 化済み。さらに以下を
 pub struct Table<'a> {
     // 既存:
     filter_form: Option<FilterForm>,
-    filtered_key: String,  // 旧パスでのみ使う、新パスでは無視
 
     // 新規:
     filter_applicator: Option<TableFilterApplicator>,
     filter_state: Option<TableFilterPredicate>,   // 最後に成功した parse 結果
-    filter_error: Option<String>,                 // 粘着エラー
+    filter_error: Option<String>,                 // 粘着エラー（Tab 階層の widget_error とは別管理）
     ...
 }
 ```
 
-`filtered_key` は移行期間中残すが、すべてのタブが SubstringFilterApplicator に乗り換え完了したら削除（不要になる）。
+**`filtered_key` と `filtered_word` は完全削除。** 全タブが SubstringFilterApplicator に乗り換える設計なので、移行期の if/else 分岐は持たない。一気に新パスへ統一する。
+
+Tab 階層の `widget_error`（既存）は touch しない。Table widget の render は filter_error だけ気にする。
 
 ### Table widget 内部のフロー
 
@@ -201,20 +227,20 @@ fn item_passes_filter(&self, item: &TableItem) -> bool {
 }
 ```
 
-`filtered_key` / `filtered_word` ベースの旧分岐は削除。すべての行絞り込みは `filter_state` を経由する。
+`filtered_key` / `filtered_word` ベースの旧分岐は完全削除。すべての行絞り込みは `filter_state` を経由する。
 
 #### Render
 
 ```rust
-// 既存:
-if let Some(e) = &self.filter_error.as_ref().or(self.widget_error.as_ref()) {
-    // テーブル本体置換でエラー表示（filter_error を widget_error より優先）
+if let Some(e) = self.filter_error.as_ref() {
+    // テーブル本体置換でエラー表示（行は描画しない）
+    render_widget_error(f, chunk, block, e, theme);
 } else {
-    // 通常 render
+    // 通常 render: filter_state があれば item_passes_filter で絞り込まれた行を描画
 }
 ```
 
-`filter_error` と `widget_error` は別フィールド・別ライフサイクル。`filter_error` は parse 失敗で立ち、parse 成功 / フィルタクリアで降りる。`widget_error` は既存通り API 失敗で立ち、API 成功で降りる。
+注: Tab 階層の `widget_error` は Tab.render が widget を呼び出す前にチェックする（既存）。つまり widget_error が立っているときはこの Table::render すら呼ばれない。よって優先順位は技術的に `widget_error > filter_error`。
 
 ## 既存タブの移行
 
@@ -238,17 +264,26 @@ Table::builder()
 
 ```rust
 pub fn substring_applicator(column: &str) -> TableFilterApplicator {
-    let col = column.to_string();
+    let col = column.to_string().to_lowercase();
     TableFilterApplicator {
         parser: (move |input: &str| {
-            if input.is_empty() {
-                Ok(TableFilterPredicate::Empty)
-            } else {
-                Ok(TableFilterPredicate::Substring {
-                    column: col.clone(),
-                    pattern: input.to_string(),
-                })
+            let patterns: Vec<Regex> = input
+                .split_whitespace()
+                .map(|p| Regex::new(&regex::escape(p)))
+                .collect::<Result<_, _>>()
+                .map_err(|e| e.to_string())?;
+
+            let mut column_includes = HashMap::new();
+            if !patterns.is_empty() {
+                column_includes.insert(col.clone(), patterns);
             }
+
+            Ok(TableFilterPredicate {
+                column_includes,
+                column_excludes: HashMap::new(),
+                label_selector: None,
+                raw: input.to_string(),
+            })
         }).into(),
         strategy: ApplyStrategy::Live,
         help_dialog_id: None,
@@ -257,10 +292,13 @@ pub fn substring_applicator(column: &str) -> TableFilterApplicator {
 }
 ```
 
-挙動は完全に等価:
-- live で毎キー絞り込み
-- 単一列（NAME）に部分一致
-- 空入力で「フィルタなし」
+挙動は既存と等価:
+- live で毎キー絞り込み（ApplyStrategy::Live）
+- 単一列（NAME）に対し、スペース区切り **OR** で部分一致
+  - 既存実装 `split(' ').any(|p| contains(p))` と同じ意味論（OR）。
+  - 新統一意味論（列内 OR、列間 AND）と整合: 列が NAME 1 つだけなので「列内 OR」がそのまま既存挙動になる。
+- 空入力で「フィルタなし」（column_includes が空 → 全行 pass）
+- patterns は `regex::escape` でリテラル化（既存 substring と等価動作。ユーザーは regex を意識しなくていい）
 
 対象タブ: Pod / Config / Network / Event / API / Yaml / Context / Namespace の各 Table 生成箇所。
 
@@ -269,41 +307,37 @@ pub fn substring_applicator(column: &str) -> TableFilterApplicator {
 ### 構文
 
 ```
-nginx                            → NAME に nginx を含む（regex）
-NAME:gke.*worker                → NAME に regex
-STATUS:Ready                    → STATUS が Ready (regex)
-STATUS:^Ready$                  → STATUS が完全に Ready
-!NS:kube-system                 → NAME に kube-system を含まない
-label:role=worker               → k8s labelSelector (server-side)
-label:role=worker,zone=us-west  → カンマ AND の k8s labelSelector
-NAME:gke STATUS:Ready label:role=worker
-                                → 上記すべての AND
+foo                              → NAME に foo を含む（regex）
+foo bar                          → NAME に foo OR bar（列内 OR）
+NAME:gke.*worker                 → NAME に regex
+STATUS:Ready                     → STATUS に Ready
+STATUS:Ready STATUS:Pending      → STATUS が Ready OR Pending（列内 OR、in 句相当）
+STATUS:Ready NAME:nginx          → STATUS が Ready AND NAME が nginx（列間 AND）
+foo bar STATUS:a STATUS:b        → (NAME に foo OR bar) AND (STATUS に a OR b)
+!NS:kube-system                  → NAMESPACE に kube-system を含む行を除外
+!STATUS:Pending !STATUS:Failed   → STATUS が Pending OR Failed を含む行を除外（not in 相当）
+label:role=worker                → k8s labelSelector (server-side)
+label:role=worker,zone=us-west   → カンマ AND の k8s labelSelector（k8s 構文そのまま）
 ```
+
+**意味論:**
+
+| 区分 | 結合 | 備考 |
+|---|---|---|
+| 同一列の include 複数 | **OR** | `in (a, b)` 相当 |
+| 異なる列の include 混在 | **AND** | 「列ごとに条件を重ねる」 |
+| 同一列の exclude 複数 | **いずれかにマッチすれば除外** | `not in (a, b)` 相当 |
+| 異なる列の exclude 混在 | 同上（いずれかマッチすれば除外） | 全 exclude を pass する必要 |
+| ベア値 | NAME 列 include の暗黙形 | `foo bar` = `NAME:foo NAME:bar` = NAME に foo OR bar |
+| `label:` | 最後勝ち | k8s API は labelSelector 1 つしか取らない |
 
 - 列名は大小区別しない、正準形は小文字（CLI / Pod log query と同型）
-- 同一列の include 複数 → AND（両方マッチ）
-- 同一列内の OR は regex の `|` で
-- `label:` は最後勝ち（k8s API は labelSelector 1 つ）
-
-### NodeFilterPredicate
-
-```rust
-pub struct NodeFilterPredicate {
-    column_includes: HashMap<String, Vec<Regex>>,
-    column_excludes: HashMap<String, Vec<Regex>>,
-    label_selector: Option<String>,
-    raw: String,
-}
-
-impl NodeFilterPredicate {
-    pub fn matches(&self, item: &TableItem, header: &[String]) -> bool {
-        // 各列について: include は全マッチ、exclude は1つもマッチしない
-        // label_selector はサーバ側で適用済みなので matches では無視
-    }
-}
-```
+- 単一列内の AND が欲しい場合（稀）は regex lookahead で `NAME:(?=.*foo)(?=.*bar)`
+- 値は常に regex として解釈（plain text は実質的に部分一致として動作）
 
 ### NodeFilterApplicator
+
+Node 用の TableFilterApplicator ファクトリ。前述の `TableFilterPredicate` をそのまま返す（Node 専用の predicate type は持たない）。
 
 ```rust
 pub fn node_filter_applicator(
@@ -320,14 +354,15 @@ pub fn node_filter_applicator(
 
 fn build_on_apply(tx: Sender<Message>) -> OnFilterApply {
     (move |predicate: &TableFilterPredicate, _w: &mut Window| {
-        if let TableFilterPredicate::Node(node_pred) = predicate {
-            // labelSelector を SharedNodeFilter 経由で poller に
-            tx.send(NodeFilterMessage::Apply(Some(node_pred.clone())).into())
-                .expect("Failed to send NodeFilterMessage::Apply");
-        }
+        // labelSelector を SharedNodeFilter 経由で poller に
+        // （labelSelector が None でも Apply で「クリア」として送る）
+        tx.send(NodeFilterMessage::Apply(predicate.label_selector.clone()).into())
+            .expect("Failed to send NodeFilterMessage::Apply");
     }).into()
 }
 ```
+
+`NodeFilterMessage` のペイロードは `Option<String>`（label_selector のみ）に縮められる。クライアント側 filter（regex マッチ）は `TableFilterPredicate.matches` が担うので、controller / poller は labelSelector だけ知っていれば十分。
 
 ### サーバ側フィルタリング
 
@@ -337,23 +372,37 @@ fn build_on_apply(tx: Sender<Message>) -> OnFilterApply {
 
 ## エラーハンドリング
 
+エラー状態は 2 つあり、**管理階層も優先順位も異なる**ことに注意:
+
+| 状態 | 管理階層 | セット | クリア | レンダリング箇所 |
+|---|---|---|---|---|
+| `widget_error` | **Tab**（`Tab.error_states: HashMap<widget_id, Vec<String>>`、既存）| action.rs の `update_widget_item_for_table` が Err 受信時 | 同関数が Ok 受信時に自動 | `Tab.render()` が widget の代わりに `render_widget_error` を呼ぶ（widget 自身は呼ばれない）|
+| `filter_error` | **Table widget**（新規フィールド）| Table 内部で `parser(input)` が Err のとき | `parser` 成功時 / フィルタクリア時 / filter_form が空に戻ったとき | Table の render 内で行の代わりに描画 |
+
+### 優先順位: `widget_error > filter_error`
+
+これは「優先したい」というより**技術的にそうなる**。Tab.render が widget_error を見て表示するときは、Table widget の render 自体が呼ばれない（Tab が代替描画する）→ filter_error はチェックされない。
+
+UX 的にも妥当:
+- `widget_error` = API そのものが失敗（基礎データなし）→ 最優先メッセージ
+- `filter_error` = データはあるがフィルタが壊れている → API 復旧次第顔を出す
+
 ### parse エラー（クライアント側）
 
 - `filter_form` の Enter（または live モードの毎キー）で `parser(input)` が `Err(msg)` を返す
 - Table の `filter_error = Some(msg)` をセット
-- render 時、`filter_error` を `widget_error` より優先してテーブル本体置換で表示
-- 行は描画されない（壊れたフィルタで誤解しないため）
+- render 時、`filter_error` が Some なら**既存 `render_widget_error` と同じ関数**でテーブル本体を置換表示（行は描画されない）
 - ポーリングは触らない（粘着）
 
 ### サーバ側エラー（labelSelector が無効など）
 
 - 既存通り `NodeMessage::Poll(Err(e))` → action.rs の `update_widget_item_for_table` で `set_widget_error(NODE_WIDGET_ID, &e)`
-- 既存 `widget_error` 経路で表示、ポーリングが失敗し続ければ表示維持
-- 成功すれば自動的に消える（既存挙動）
+- Tab レベルの widget_error 経路で表示、ポーリングが失敗し続ければ表示維持、成功すれば自動的に消える（既存挙動）
+- このとき Table widget の render は呼ばれないので、`filter_error` が立っていても見えない（widget_error が優先）
 
-### 表示の優先順位
+### 両方立つケース
 
-`filter_error > widget_error`。ユーザーが直接アクションできる（フィルタを書き直す）方が上位。両方 Some のときは filter_error を表示。
+例: フィルタ parse エラー中にサーバ側もエラーになった → Tab レベルの widget_error が表示される。サーバ復旧したら widget_error が clear され、filter_error が見える。自然な振る舞い。
 
 ## ヘルプ
 
@@ -429,7 +478,7 @@ src/features/node/
 
 ### Node タブ実装
 - `src/features/node/filter.rs` — NodeFilterPredicate を列ベースに再定義
-- `src/features/node/filter/parser.rs` — `<col>:<val>` 構文に拡張、`TableFilterPredicate::Node(...)` を返す
+- `src/features/node/filter/parser.rs` — `<col>:<val>` 構文に拡張、`TableFilterPredicate` を返す（ベア値は NAME 列 OR、列明示は AND across columns）
 - `src/features/node/view/widgets/node.rs` — filter_form 復活、node_filter_applicator() 設定
 - `src/features/node/view/widgets/node_filter.rs` — 削除
 - `src/features/node/view/widgets/node_filter_help.rs` — 保持、起動経路は applicator の help_dialog_id 経由
@@ -440,7 +489,7 @@ src/features/node/
 
 ## テスト
 
-- `TableFilterPredicate::matches`: Substring / Node の各ケースを単体テスト
+- `TableFilterPredicate::matches`: 列内 OR・列間 AND・exclude (any-match-excludes) の各組み合わせを単体テスト
 - `substring_applicator`: parser → Predicate のラウンドトリップ、空入力で Empty
 - `node_filter_applicator` parser: `<col>:<val>` / `!<col>:<val>` / `label:` の各パターン、エラー、列名大小区別なし
 - Table widget の filter_state ベース行絞り込み（既存の Pod 行テストが等価結果になるか）
@@ -464,8 +513,10 @@ src/features/node/
 
 ## 主要な設計判断の記録
 
-- **既存タブも parser ベースに統一する**: Table widget 内部に `if let Some(predicate)` と `if let Some(filtered_word)` の 2 系統を残すと負債になるので、一気に統一する。既存タブは SubstringFilterApplicator（live + 単一列 substring）で挙動を完全に保つ。
+- **既存タブも parser ベースに統一する**: Table widget 内部に `if let Some(predicate)` と `if let Some(filtered_word)` の 2 系統を残すと負債になるので、一気に統一する。既存タブは SubstringFilterApplicator（live + 単一列 substring、OR 維持）で挙動を完全に保つ。
 - **適用タイミングは applicator ごとに宣言**: Live と EnterToConfirm を実装に依存させず、parser とセットで applicator が自分の適切な戦略を持つ。
-- **エラーは 2 種別を別フィールドで管理**: ライフサイクルが違う（API は自動 clear、parse は粘着）ので、widget_error と filter_error を別に持つ。render で優先順位だけ決める。
+- **意味論は「列内 OR、列間 AND、exclude は any-match excludes」**: SQL / kubectl labelSelector / spreadsheet など主要な「列ベースフィルタ」慣習と一致。既存 Pod の `/foo bar` (OR) も同じ枠組みに自然に収まる（NAME 単一列の OR 形）。単一列 AND が必要なレアケースは regex lookahead `NAME:(?=.*foo)(?=.*bar)` で対応。
+- **エラーは管理階層が違う**: `widget_error` は Tab レベル（既存・既存タブの API エラー UI を変えない）、`filter_error` は Table widget レベル（新規・粘着）。優先順位は技術的に `widget_error > filter_error`（widget_error 表示時は Table.render が呼ばれない）。UX 的にも妥当: API 失敗は最優先メッセージ、parse エラーは API 復旧次第顔を出す。
+- **TableFilterPredicate は単一 struct**: 新意味論では Substring と Node が同じ「列内 OR、列間 AND」で表現できるため、enum 分岐は不要。将来別種マッチが必要になった時点で enum 化すれば良い（YAGNI）。
 - **API 形は applicator 構造体で束ねる**: builder のメソッドを増やすより、parser/strategy/help/on_apply を 1 ショットの applicator として渡す方が、タブ側コードがシンプルで設定漏れも起きない。
-- **dyn は既存パターン (`define_callback!` = `Rc<dyn Fn>`) を踏襲**: コールバック層では既に dyn を多用しているので一貫性。ホットパス（matches）だけは enum で static dispatch。
+- **dyn は既存パターン (`define_callback!` = `Rc<dyn Fn>`) を踏襲**: コールバック層では既に dyn を多用しているので一貫性。ホットパス（matches）は単一 struct のメソッドなので static dispatch。

--- a/docs/superpowers/specs/2026-05-27-table-filter-redesign.md
+++ b/docs/superpowers/specs/2026-05-27-table-filter-redesign.md
@@ -1,0 +1,471 @@
+# Table 高度フィルタ機構 設計
+
+- 関連 Issue: [#920 feat: add Node tab for viewing node information](https://github.com/sarub0b0/kubetui/issues/920)（Node タブ Plan 5 の差し戻しを含む）
+- ステータス: ドラフト
+- 作成日: 2026-05-27
+
+## 概要
+
+`Table` ウィジェットに**プラガブルなフィルタ機構**を導入する。共通フレームワークの上で、既存タブ（Pod / Config / Network / Event / API / Yaml / Context / Namespace）は今と同じ「単一列への部分一致 live フィルタ」を実現し、Node タブは列ベースの高度な構文（`<col>:<val>` / `!<col>:<val>` / `label:<sel>`）をプラグインとして実現する。Plan 5 のダイアログ方式は破棄し、Table 既存の `filter_form` を全タブで再活用する。
+
+## 背景
+
+Plan 5 で「Node タブ用のフィルタ」として独立ダイアログ + 独立メッセージを実装したが、3 つの問題が明らかになった:
+
+1. **ダイアログが大きすぎる**: 1 行入力に対してダイアログサイズが過剰、kubetui の小ペイン設計と合わない。
+2. **エラーがポーリングで消える**: フィルタ parse エラーを `set_widget_error(NODE_WIDGET_ID, ...)` で表示していたが、次ポーリングが `clear_widget_error` を呼ぶため消失。
+3. **既存フィルタとの一貫性欠如**: 既存タブの `/` 部分一致フィルタと Node の `/` ダイアログが**別の UX**になっている。将来「任意列でフィルタしたい」要求が他タブにも出たとき、機構が 2 系統あることで設計が混乱する。
+
+## ゴール / 非ゴール
+
+### ゴール
+
+- Table ウィジェットの `filter_form` UI を全タブで活用（Node 用に独立ダイアログを作らない）
+- 既存タブの UX を保ったまま、内部実装を統一パスへ移行
+- Node タブで以下の構文をサポート:
+  - `<value>` → NAME 列に regex マッチ
+  - `<column>:<value>` → 任意列に regex マッチ
+  - `!<column>:<value>` → 任意列で除外
+  - `label:<selector>` → k8s labelSelector（サーバ側絞り込み）
+  - スペース区切り AND、複数項目可
+- フィルタ parse エラーは**ポーリングで消えない**粘着状態として管理
+- API は kubetui 既存パターン（`define_callback!` / enum dispatch）と整合
+
+### 非ゴール
+
+- 既存タブの構文を Node 同等の高度フィルタに自動拡張する（YAGNI、別タブで要求が出てから）
+- ライブ filter と Enter filter を混在させる UI（タブごとに 1 つ選ぶ）
+- フィルタ条件の永続化（in-memory のみ）
+
+## UI / レイアウト
+
+Table ウィジェットの既存 `filter_form`（1 行）を全タブで使う。
+
+```
++-- Node [3/8]  filter: STATUS:Ready ----------+
+| STATUS:Ready                                 |  <- filter_form (FilterConfirm モードで常駐)
++----------------------------------------------+
+| NAME              STATUS  ROLES  AGE  VER    |
+| gke-prod-001      Ready   worker 10d v1.30   |
+| gke-prod-002      Ready   worker 10d v1.30   |
+| ...                                          |
++----------------------------------------------+
+```
+
+`/` で入力モードへ、Enter で確定。確定後は filter_form が 1 行常駐し、現在の条件が見える。
+
+## アーキテクチャ
+
+### コア型
+
+```rust
+// src/ui/widget/table/filter_applicator.rs (新規)
+
+/// パーサ・戦略・副作用・ヘルプ ID を 1 つに束ねたファクトリ。
+/// Table::builder().filter_applicator(...) で渡す。
+pub struct TableFilterApplicator {
+    pub(crate) parser: TableFilterParser,            // define_callback!
+    pub(crate) strategy: ApplyStrategy,              // Live | EnterToConfirm
+    pub(crate) help_dialog_id: Option<&'static str>, // Some なら入力中 `?` で開く
+    pub(crate) on_apply: Option<OnFilterApply>,      // define_callback!, 副作用フック
+}
+
+pub enum ApplyStrategy {
+    /// 毎キーで parser を呼ぶ。空入力は「フィルタなし」相当。Substring 系で使う。
+    Live,
+    /// Enter のみで parser を呼ぶ。Node 系の高度構文で使う。
+    EnterToConfirm,
+}
+
+define_callback!(
+    pub TableFilterParser,
+    Fn(&str) -> Result<TableFilterPredicate, String>
+);
+
+define_callback!(
+    pub OnFilterApply,
+    Fn(&TableFilterPredicate, &mut Window)
+);
+
+/// 全タブで共通のフィルタ判定 enum（static dispatch）。
+pub enum TableFilterPredicate {
+    /// 既存タブ用: 単一列に部分一致
+    Substring {
+        column: String,    // 正準形は小文字
+        pattern: String,
+    },
+    /// Node タブ用: 列ベース regex + ラベルセレクタ
+    Node(NodeFilterPredicate),
+    /// 「フィルタなし」相当（live モードで入力が空のとき）
+    Empty,
+}
+
+impl TableFilterPredicate {
+    pub fn matches(&self, item: &TableItem, header: &[String]) -> bool {
+        match self {
+            Self::Empty => true,
+            Self::Substring { column, pattern } => { /* find column in header, substring match */ }
+            Self::Node(p) => p.matches(item, header),
+        }
+    }
+}
+```
+
+### Table widget の拡張
+
+Task 0 #980 で `filter_form: Option<FilterForm>` 化済み。さらに以下を追加:
+
+```rust
+pub struct Table<'a> {
+    // 既存:
+    filter_form: Option<FilterForm>,
+    filtered_key: String,  // 旧パスでのみ使う、新パスでは無視
+
+    // 新規:
+    filter_applicator: Option<TableFilterApplicator>,
+    filter_state: Option<TableFilterPredicate>,   // 最後に成功した parse 結果
+    filter_error: Option<String>,                 // 粘着エラー
+    ...
+}
+```
+
+`filtered_key` は移行期間中残すが、すべてのタブが SubstringFilterApplicator に乗り換え完了したら削除（不要になる）。
+
+### Table widget 内部のフロー
+
+#### キー入力時
+
+```rust
+// Mode::FilterInput で何かキー入力 → filter_form.on_key_event 後:
+match applicator.strategy {
+    ApplyStrategy::Live => {
+        // 毎キーで parse → state 更新
+        let input = filter_form.content();
+        match (applicator.parser)(&input) {
+            Ok(p) => { filter_state = Some(p); filter_error = None; }
+            Err(e) => { filter_error = Some(e); }
+        }
+        // Live は副作用なし（on_apply は呼ばない）
+    }
+    ApplyStrategy::EnterToConfirm => {
+        // タイプ中は何もしない。入力バッファに溜まるだけ。
+    }
+}
+```
+
+#### Enter 押下時
+
+```rust
+let input = filter_form.content();
+let parsed = (applicator.parser)(&input);
+
+match parsed {
+    Ok(p) => {
+        filter_state = Some(p);
+        filter_error = None;
+        // 副作用フック（例: NodeFilter なら label_selector を SharedNodeFilter へ書き込み）
+        if let Some(cb) = &applicator.on_apply {
+            // schedule cb(&p, &mut window) via Window callback queue
+        }
+        mode = FilterConfirm;
+    }
+    Err(e) => {
+        filter_error = Some(e);
+        // filter_state は変更しない（旧成功状態が残ったまま、ただし render はエラー優先で行を見せない）
+        mode = FilterInput;  // 入力モード継続
+    }
+}
+```
+
+#### 入力中の `?` または `help`
+
+```rust
+if input == "?" || input == "help" {
+    if let Some(id) = applicator.help_dialog_id {
+        filter_form.clear();
+        window.open_dialog(id);
+    }
+    // help_dialog_id が None なら通常の文字入力扱い
+}
+```
+
+#### 行フィルタリング
+
+```rust
+fn item_passes_filter(&self, item: &TableItem) -> bool {
+    if let Some(p) = &self.filter_state {
+        p.matches(item, &self.header.original)
+    } else {
+        true
+    }
+}
+```
+
+`filtered_key` / `filtered_word` ベースの旧分岐は削除。すべての行絞り込みは `filter_state` を経由する。
+
+#### Render
+
+```rust
+// 既存:
+if let Some(e) = &self.filter_error.as_ref().or(self.widget_error.as_ref()) {
+    // テーブル本体置換でエラー表示（filter_error を widget_error より優先）
+} else {
+    // 通常 render
+}
+```
+
+`filter_error` と `widget_error` は別フィールド・別ライフサイクル。`filter_error` は parse 失敗で立ち、parse 成功 / フィルタクリアで降りる。`widget_error` は既存通り API 失敗で立ち、API 成功で降りる。
+
+## 既存タブの移行
+
+各タブの Table 生成箇所で:
+
+```rust
+// Before:
+Table::builder()
+    .filter_form(filter_form)
+    .filtered_key("NAME")
+    .build()
+
+// After:
+Table::builder()
+    .filter_form(filter_form)
+    .filter_applicator(substring_applicator("NAME"))
+    .build()
+```
+
+`substring_applicator` ファクトリ:
+
+```rust
+pub fn substring_applicator(column: &str) -> TableFilterApplicator {
+    let col = column.to_string();
+    TableFilterApplicator {
+        parser: (move |input: &str| {
+            if input.is_empty() {
+                Ok(TableFilterPredicate::Empty)
+            } else {
+                Ok(TableFilterPredicate::Substring {
+                    column: col.clone(),
+                    pattern: input.to_string(),
+                })
+            }
+        }).into(),
+        strategy: ApplyStrategy::Live,
+        help_dialog_id: None,
+        on_apply: None,
+    }
+}
+```
+
+挙動は完全に等価:
+- live で毎キー絞り込み
+- 単一列（NAME）に部分一致
+- 空入力で「フィルタなし」
+
+対象タブ: Pod / Config / Network / Event / API / Yaml / Context / Namespace の各 Table 生成箇所。
+
+## Node タブのフィルタ実装
+
+### 構文
+
+```
+nginx                            → NAME に nginx を含む（regex）
+NAME:gke.*worker                → NAME に regex
+STATUS:Ready                    → STATUS が Ready (regex)
+STATUS:^Ready$                  → STATUS が完全に Ready
+!NS:kube-system                 → NAME に kube-system を含まない
+label:role=worker               → k8s labelSelector (server-side)
+label:role=worker,zone=us-west  → カンマ AND の k8s labelSelector
+NAME:gke STATUS:Ready label:role=worker
+                                → 上記すべての AND
+```
+
+- 列名は大小区別しない、正準形は小文字（CLI / Pod log query と同型）
+- 同一列の include 複数 → AND（両方マッチ）
+- 同一列内の OR は regex の `|` で
+- `label:` は最後勝ち（k8s API は labelSelector 1 つ）
+
+### NodeFilterPredicate
+
+```rust
+pub struct NodeFilterPredicate {
+    column_includes: HashMap<String, Vec<Regex>>,
+    column_excludes: HashMap<String, Vec<Regex>>,
+    label_selector: Option<String>,
+    raw: String,
+}
+
+impl NodeFilterPredicate {
+    pub fn matches(&self, item: &TableItem, header: &[String]) -> bool {
+        // 各列について: include は全マッチ、exclude は1つもマッチしない
+        // label_selector はサーバ側で適用済みなので matches では無視
+    }
+}
+```
+
+### NodeFilterApplicator
+
+```rust
+pub fn node_filter_applicator(
+    label_registry: Vec<NodeLabelColumn>,
+    tx: Sender<Message>,
+) -> TableFilterApplicator {
+    TableFilterApplicator {
+        parser: build_node_filter_parser(label_registry),
+        strategy: ApplyStrategy::EnterToConfirm,
+        help_dialog_id: Some(NODE_FILTER_HELP_DIALOG_ID),
+        on_apply: Some(build_on_apply(tx)),
+    }
+}
+
+fn build_on_apply(tx: Sender<Message>) -> OnFilterApply {
+    (move |predicate: &TableFilterPredicate, _w: &mut Window| {
+        if let TableFilterPredicate::Node(node_pred) = predicate {
+            // labelSelector を SharedNodeFilter 経由で poller に
+            tx.send(NodeFilterMessage::Apply(Some(node_pred.clone())).into())
+                .expect("Failed to send NodeFilterMessage::Apply");
+        }
+    }).into()
+}
+```
+
+### サーバ側フィルタリング
+
+`NodeFilterMessage::Apply(Option<NodeFilterPredicate>)` を controller が受けて `SharedNodeFilter` に書き込む。`NodePoller` が次ポーリングで `predicate.label_selector` を URL `?labelSelector=...` に反映してリクエスト。
+
+クライアント側 regex は Table widget の `filter_state.matches()` 経由で全行に適用される。
+
+## エラーハンドリング
+
+### parse エラー（クライアント側）
+
+- `filter_form` の Enter（または live モードの毎キー）で `parser(input)` が `Err(msg)` を返す
+- Table の `filter_error = Some(msg)` をセット
+- render 時、`filter_error` を `widget_error` より優先してテーブル本体置換で表示
+- 行は描画されない（壊れたフィルタで誤解しないため）
+- ポーリングは触らない（粘着）
+
+### サーバ側エラー（labelSelector が無効など）
+
+- 既存通り `NodeMessage::Poll(Err(e))` → action.rs の `update_widget_item_for_table` で `set_widget_error(NODE_WIDGET_ID, &e)`
+- 既存 `widget_error` 経路で表示、ポーリングが失敗し続ければ表示維持
+- 成功すれば自動的に消える（既存挙動）
+
+### 表示の優先順位
+
+`filter_error > widget_error`。ユーザーが直接アクションできる（フィルタを書き直す）方が上位。両方 Some のときは filter_error を表示。
+
+## ヘルプ
+
+`Applicator::help_dialog_id` が Some のとき、入力中に `?` または `help` を打つと filter_form をクリアして該当ダイアログを開く。Pod log query の慣習を踏襲。
+
+Substring applicator は `help_dialog_id = None`（既存タブはヘルプなし、現状維持）。
+Node applicator は `help_dialog_id = Some(NODE_FILTER_HELP_DIALOG_ID)`。
+
+## データフロー
+
+```
+[ユーザー入力 `/`]
+        ↓
+[filter_form 入力モード]
+        ↓
+タイプ:
+  - Live applicator → 毎キーで parser → state 更新（成功時）or error（失敗時）
+  - EnterToConfirm applicator → 何もしない
+        ↓
+[Enter]
+        ↓
+parser(input)
+  ├── Ok(predicate) ──→ Table.filter_state = Some(predicate)
+  │                     Table.filter_error = None
+  │                     on_apply(&predicate, &mut Window)
+  │                       └─ Node の場合: NodeFilterMessage::Apply で SharedNodeFilter 更新
+  │                          → 次ポーリングで URL に labelSelector 反映
+  │                     mode = FilterConfirm
+  │                     render: filter_state で行をフィルタして表示
+  │
+  └── Err(msg) ─────────→ Table.filter_error = Some(msg)
+                           mode = FilterInput 継続
+                           render: テーブル本体置換でエラー表示（行は描画されない）
+```
+
+## モジュール構成
+
+```
+src/ui/widget/table/
+├── filter.rs                  # FilterForm (既存)
+├── filter_applicator.rs       # 新規: TableFilterApplicator, ApplyStrategy, TableFilterPredicate
+└── item.rs                    # 既存
+
+src/features/node/
+├── filter.rs                  # 既存（Plan 5）: NodeFilterPredicate を再定義（列ベースに拡張）
+├── filter/parser.rs           # 既存（Plan 5）: nom パーサ、構文を拡張
+└── view/widgets/
+    ├── node.rs                # 修正: filter_form 復活、node_filter_applicator を設定
+    ├── node_filter.rs         # 削除: ダイアログとしての node_filter_widget
+    ├── node_filter_help.rs    # 保持: ヘルプダイアログ
+    └── ...
+```
+
+## 既存ファイルの編集点
+
+### Table widget 拡張（新規共有ウィジェット改修）
+- `src/ui/widget/table.rs` — TableBuilder に `filter_applicator` フィールド + setter、Table struct に 3 フィールド追加（applicator, filter_state, filter_error）。on_key_event の Enter / 通常キーで applicator を呼ぶ。render で filter_error 優先。
+- `src/ui/widget/table/filter_applicator.rs` — 新規。型定義一式。
+- `src/ui/widget/table/item.rs` — item_passes_filter を新パスに切り替え（filter_state 経由）。filtered_key / filtered_word の参照を削除。
+- `src/ui/widget.rs` — `pub use table::filter_applicator::...` re-export
+
+### 既存タブ移行（SubstringFilterApplicator へ）
+- `src/features/pod/view/widgets/pod.rs`
+- `src/features/config/view/widgets/config.rs`
+- `src/features/network/view/widgets/network.rs`
+- `src/features/event/view/widgets/event.rs`（あれば）
+- `src/features/api_resources/view/dialog.rs`
+- `src/features/yaml/view/dialogs/{name,kind}.rs`
+- `src/features/context/view/dialog.rs`
+- `src/features/namespace/view/{single,multiple}_namespaces_dialog.rs`
+
+各箇所で `.filtered_key("NAME")` を `.filter_applicator(substring_applicator("NAME"))` に置換。
+
+### Node タブ実装
+- `src/features/node/filter.rs` — NodeFilterPredicate を列ベースに再定義
+- `src/features/node/filter/parser.rs` — `<col>:<val>` 構文に拡張、`TableFilterPredicate::Node(...)` を返す
+- `src/features/node/view/widgets/node.rs` — filter_form 復活、node_filter_applicator() 設定
+- `src/features/node/view/widgets/node_filter.rs` — 削除
+- `src/features/node/view/widgets/node_filter_help.rs` — 保持、起動経路は applicator の help_dialog_id 経由
+- `src/features/component_id.rs` — `NODE_FILTER_WIDGET_ID` 削除（ダイアログとしてのウィジェットがなくなる）
+
+### 既存タブの構造的変更（filter_state ベースへの完全移行）
+移行が完了したら、Table widget から `filtered_key` / `filtered_word` 関連コードを削除。`InnerItem::update_filter` も削除し、絞り込みは外部から `filter_state` 経由で行うようにする。
+
+## テスト
+
+- `TableFilterPredicate::matches`: Substring / Node の各ケースを単体テスト
+- `substring_applicator`: parser → Predicate のラウンドトリップ、空入力で Empty
+- `node_filter_applicator` parser: `<col>:<val>` / `!<col>:<val>` / `label:` の各パターン、エラー、列名大小区別なし
+- Table widget の filter_state ベース行絞り込み（既存の Pod 行テストが等価結果になるか）
+- filter_error がポーリング更新で消えないことの単体テスト
+- 既存タブの substring filter ライブ挙動の単体テスト（substring_applicator 経由で）
+
+## 段階的実装計画（plan で詳細化）
+
+実装規模が大きいので 2 つの PR に分割:
+
+### PR A: Table widget の filter_applicator 化＋全既存タブの SubstringFilterApplicator 移行
+- 共有ウィジェット改修（`fmt` ベース起点）
+- 既存タブの UX を保ったまま内部実装を統一
+- マージされると、既存タブの filtered_key 構成は API 上消える
+
+### PR B: Node タブの NodeFilterApplicator 実装（Plan 5 ブランチを再構築）
+- PR A の上にスタック
+- Plan 5 既存実装の流用パーツ（NodeFilterPredicate, parser, SharedNodeFilter, controller の Apply ハンドラ, poller の URL labelSelector）はそのまま
+- 独立ダイアログ `node_filter_widget` は削除
+- node.rs で `filter_applicator(node_filter_applicator(...))` を設定
+
+## 主要な設計判断の記録
+
+- **既存タブも parser ベースに統一する**: Table widget 内部に `if let Some(predicate)` と `if let Some(filtered_word)` の 2 系統を残すと負債になるので、一気に統一する。既存タブは SubstringFilterApplicator（live + 単一列 substring）で挙動を完全に保つ。
+- **適用タイミングは applicator ごとに宣言**: Live と EnterToConfirm を実装に依存させず、parser とセットで applicator が自分の適切な戦略を持つ。
+- **エラーは 2 種別を別フィールドで管理**: ライフサイクルが違う（API は自動 clear、parse は粘着）ので、widget_error と filter_error を別に持つ。render で優先順位だけ決める。
+- **API 形は applicator 構造体で束ねる**: builder のメソッドを増やすより、parser/strategy/help/on_apply を 1 ショットの applicator として渡す方が、タブ側コードがシンプルで設定漏れも起きない。
+- **dyn は既存パターン (`define_callback!` = `Rc<dyn Fn>`) を踏襲**: コールバック層では既に dyn を多用しているので一貫性。ホットパス（matches）だけは enum で static dispatch。

--- a/src/features/config/view/widgets/config.rs
+++ b/src/features/config/view/widgets/config.rs
@@ -19,6 +19,7 @@ use crate::{
             WidgetBase,
             WidgetTheme,
             WidgetTrait as _,
+            substring_applicator,
         },
         Window,
         WindowAction,
@@ -44,7 +45,7 @@ pub fn config_widget(tx: &Sender<Message>, theme: WidgetThemeConfig) -> Widget<'
         .widget_base(widget_base)
         .filter_form(filter_form)
         .theme(table_theme)
-        .filtered_key("NAME")
+        .filter_applicator(substring_applicator("NAME"))
         .block_injection(block_injection())
         .on_select(on_select(tx))
         .build()

--- a/src/features/config/view/widgets/config.rs
+++ b/src/features/config/view/widgets/config.rs
@@ -10,6 +10,7 @@ use crate::{
     ui::{
         event::EventResult,
         widget::{
+            substring_applicator,
             FilterForm,
             FilterFormTheme,
             Table,
@@ -19,7 +20,6 @@ use crate::{
             WidgetBase,
             WidgetTheme,
             WidgetTrait as _,
-            substring_applicator,
         },
         Window,
         WindowAction,

--- a/src/features/network/view/widgets/network.rs
+++ b/src/features/network/view/widgets/network.rs
@@ -18,6 +18,7 @@ use crate::{
     ui::{
         event::EventResult,
         widget::{
+            substring_applicator,
             FilterForm,
             FilterFormTheme,
             Table,
@@ -27,7 +28,6 @@ use crate::{
             WidgetBase,
             WidgetTheme,
             WidgetTrait as _,
-            substring_applicator,
         },
         Window,
         WindowAction,

--- a/src/features/network/view/widgets/network.rs
+++ b/src/features/network/view/widgets/network.rs
@@ -27,6 +27,7 @@ use crate::{
             WidgetBase,
             WidgetTheme,
             WidgetTrait as _,
+            substring_applicator,
         },
         Window,
         WindowAction,
@@ -52,7 +53,7 @@ pub fn network_widget(tx: &Sender<Message>, theme: WidgetThemeConfig) -> Widget<
         .widget_base(widget_base)
         .filter_form(filter_form)
         .theme(table_theme)
-        .filtered_key("NAME")
+        .filter_applicator(substring_applicator("NAME"))
         .block_injection(block_injection())
         .on_select(on_select(tx))
         .build()

--- a/src/features/pod/view/widgets/pod.rs
+++ b/src/features/pod/view/widgets/pod.rs
@@ -19,6 +19,7 @@ use crate::{
     ui::{
         event::EventResult,
         widget::{
+            substring_applicator,
             FilterForm,
             FilterFormTheme,
             Item,
@@ -29,7 +30,6 @@ use crate::{
             WidgetBase,
             WidgetTheme,
             WidgetTrait as _,
-            substring_applicator,
         },
         Window,
         WindowAction,

--- a/src/features/pod/view/widgets/pod.rs
+++ b/src/features/pod/view/widgets/pod.rs
@@ -29,6 +29,7 @@ use crate::{
             WidgetBase,
             WidgetTheme,
             WidgetTrait as _,
+            substring_applicator,
         },
         Window,
         WindowAction,
@@ -55,7 +56,7 @@ pub fn pod_widget(tx: &Sender<Message>, theme: WidgetThemeConfig) -> Widget<'sta
         .widget_base(widget_base)
         .filter_form(filter_form)
         .theme(table_theme)
-        .filtered_key("NAME")
+        .filter_applicator(substring_applicator("NAME"))
         .action('t', open_pod_columns_dialog())
         .block_injection(block_injection())
         .on_select(on_select(tx))

--- a/src/ui/widget/table.rs
+++ b/src/ui/widget/table.rs
@@ -301,21 +301,15 @@ impl Table<'_> {
             .max_width(self.max_width())
             .build();
 
-        let word = self.filter_word();
-        self.items.update_filter(word);
+        let header = self.items.header().original().to_vec();
+        let state = self.filter_state.clone();
+        self.items.apply_filter(|item| {
+            state.as_ref().map(|p| p.matches(item, &header)).unwrap_or(true)
+        });
 
         self.adjust_selected(old_len, self.items.len());
 
         self.update_row_bounds();
-    }
-
-    /// Current filter input string, or empty when this table has no built-in
-    /// filter.
-    fn filter_word(&self) -> String {
-        self.filter_form
-            .as_ref()
-            .map(|f| f.content())
-            .unwrap_or_default()
     }
 
     fn update_row_bounds(&mut self) {
@@ -388,12 +382,14 @@ impl Table<'_> {
 
     fn filter_items(&mut self) {
         let old_len = self.items.len();
+        let header = self.items.header().original().to_vec();
+        let state = self.filter_state.clone();
 
-        let word = self.filter_word();
-        self.items.update_filter(word);
+        self.items.apply_filter(|item| {
+            state.as_ref().map(|p| p.matches(item, &header)).unwrap_or(true)
+        });
 
         self.adjust_selected(old_len, self.items.len());
-
         self.update_row_bounds();
     }
 

--- a/src/ui/widget/table.rs
+++ b/src/ui/widget/table.rs
@@ -654,6 +654,19 @@ impl WidgetTrait for Table<'_> {
                     }
 
                     _ => {
+                        // `?` または `help` 入力でヘルプダイアログを開く（applicator が
+                        // help_dialog_id を持つ場合のみ）。Pod log query の慣習に合わせる。
+                        if let Some(help_id) = self.would_be_help_command(ev) {
+                            if let Some(filter_form) = self.filter_form.as_mut() {
+                                filter_form.clear();
+                            }
+                            self.mode.normal();
+                            return EventResult::Callback(Callback::from(move |w: &mut Window| {
+                                w.open_dialog(help_id.clone());
+                                EventResult::Nop
+                            }));
+                        }
+
                         let result = if let Some(filter_form) = self.filter_form.as_mut() {
                             filter_form.on_key_event(ev)
                         } else {
@@ -740,6 +753,28 @@ impl Table<'_> {
         self.state
             .selected()
             .and_then(|index| self.items().get(index).map(|item| Rc::new(item.clone())))
+    }
+
+    /// 現在の入力 + 押下キーがヘルプトリガーになるかを判定。
+    /// applicator が help_dialog_id を持ち、確定後の文字列が "?" または
+    /// "help" と完全一致する場合に Some(help_id) を返す。
+    fn would_be_help_command(&self, ev: KeyEvent) -> Option<String> {
+        let help_id = self.filter_applicator.as_ref()?.help_dialog_id.clone()?;
+        let current = self
+            .filter_form
+            .as_ref()
+            .map(|f| f.content())
+            .unwrap_or_default();
+        let typed = match key_event_to_code(ev) {
+            KeyCode::Char(c) => c,
+            _ => return None,
+        };
+        let pending = format!("{}{}", current, typed);
+        if pending == "?" || pending == "help" {
+            Some(help_id)
+        } else {
+            None
+        }
     }
 
     fn match_action(&self, ev: UserEvent) -> Option<&Callback> {
@@ -1362,6 +1397,61 @@ mod tests {
 
                 assert_eq!((table.state.selected(), table.state.offset()), (None, 0));
             }
+        }
+    }
+
+    mod help_dispatch {
+        use super::*;
+
+        fn dummy_applicator_with_help() -> TableFilterApplicator {
+            let parser: TableFilterParser =
+                (|_input: &str| Ok(TableFilterPredicate::default())).into();
+            TableFilterApplicator::new(parser, ApplyStrategy::EnterToConfirm)
+                .with_help_dialog("test-help-dialog")
+        }
+
+        #[test]
+        fn typing_question_mark_returns_help_callback() {
+            let mut table = Table::builder()
+                .filter_form(FilterForm::builder().build())
+                .filter_applicator(dummy_applicator_with_help())
+                .build();
+            // FilterInput モードへ
+            let _ = table.on_key_event(KeyEvent::from(KeyCode::Char('/')));
+            // `?` を打つ
+            let result = table.on_key_event(KeyEvent::from(KeyCode::Char('?')));
+
+            assert!(matches!(result, EventResult::Callback(_)));
+        }
+
+        #[test]
+        fn typing_normal_char_does_not_open_help() {
+            let mut table = Table::builder()
+                .filter_form(FilterForm::builder().build())
+                .filter_applicator(dummy_applicator_with_help())
+                .build();
+            let _ = table.on_key_event(KeyEvent::from(KeyCode::Char('/')));
+            let result = table.on_key_event(KeyEvent::from(KeyCode::Char('n')));
+
+            // n を打っても help_callback は返さない
+            assert!(!matches!(result, EventResult::Callback(_)));
+        }
+
+        #[test]
+        fn help_does_not_open_without_help_dialog_id() {
+            // help_dialog_id を持たない applicator
+            let parser: TableFilterParser =
+                (|_input: &str| Ok(TableFilterPredicate::default())).into();
+            let applicator = TableFilterApplicator::new(parser, ApplyStrategy::Live);
+
+            let mut table = Table::builder()
+                .filter_form(FilterForm::builder().build())
+                .filter_applicator(applicator)
+                .build();
+            let _ = table.on_key_event(KeyEvent::from(KeyCode::Char('/')));
+            let result = table.on_key_event(KeyEvent::from(KeyCode::Char('?')));
+
+            assert!(!matches!(result, EventResult::Callback(_)));
         }
     }
 }

--- a/src/ui/widget/table.rs
+++ b/src/ui/widget/table.rs
@@ -43,6 +43,13 @@ use super::{
 };
 
 pub use filter::{FilterForm, FilterFormTheme};
+pub use filter_applicator::{
+    ApplyStrategy,
+    OnFilterApply,
+    TableFilterApplicator,
+    TableFilterParser,
+    TableFilterPredicate,
+};
 
 use item::InnerItem;
 
@@ -79,6 +86,7 @@ pub struct TableBuilder {
     id: String,
     widget_base: WidgetBase,
     filter_form: Option<FilterForm>,
+    filter_applicator: Option<TableFilterApplicator>,
     theme: TableTheme,
     header: Vec<String>,
     items: Vec<TableItem>,
@@ -107,6 +115,13 @@ impl TableBuilder {
     /// to user-defined actions registered via `.action('/', ...)`.
     pub fn filter_form(mut self, filter_form: FilterForm) -> Self {
         self.filter_form = Some(filter_form);
+        self
+    }
+
+    /// Enable rich filter parsing with the given applicator. Replaces the
+    /// default substring-only filter behavior with parser-driven filtering.
+    pub fn filter_applicator(mut self, applicator: TableFilterApplicator) -> Self {
+        self.filter_applicator = Some(applicator);
         self
     }
 
@@ -178,6 +193,9 @@ impl TableBuilder {
             highlight_injection: self.highlight_injection,
             filtered_key: self.filtered_key.clone(),
             filter_form: self.filter_form,
+            filter_applicator: self.filter_applicator,
+            filter_state: None,
+            filter_error: None,
             ..Default::default()
         };
 
@@ -241,6 +259,9 @@ pub struct Table<'a> {
     chunk: Rect,
     row_bounds: Vec<(usize, usize)>,
     filter_form: Option<FilterForm>,
+    filter_applicator: Option<TableFilterApplicator>,
+    filter_state: Option<TableFilterPredicate>,
+    filter_error: Option<String>,
     filtered_key: String,
     mode: Mode,
     on_select: Option<OnSelectCallback>,

--- a/src/ui/widget/table.rs
+++ b/src/ui/widget/table.rs
@@ -813,6 +813,29 @@ impl RenderTrait for Table<'_> {
 
         let chunk = self.chunk();
 
+        if let Some(err) = self.filter_error.clone() {
+            let lines = vec![err];
+            let error_theme = crate::ui::widget::error::ErrorTheme::default();
+            crate::ui::widget::error::render_widget_error(
+                f,
+                chunk,
+                block.clone(),
+                &lines,
+                &error_theme,
+            );
+
+            // filter_form は引き続き描画（ユーザーが入力を直せるよう）
+            match self.mode {
+                Mode::Normal => {}
+                Mode::FilterInput | Mode::FilterConfirm => {
+                    if let Some(filter_form) = self.filter_form.as_mut() {
+                        filter_form.render(f, self.mode.is_filter_input() && is_active, false);
+                    }
+                }
+            }
+            return;
+        }
+
         if self.items.is_empty() {
             let paragraph = Paragraph::new(" No data".dark_gray()).block(block);
             f.render_widget(paragraph, chunk);
@@ -944,6 +967,50 @@ mod tests {
             let _ = table.on_key_event(slash_event());
 
             assert!(matches!(table.mode, Mode::FilterInput));
+        }
+    }
+
+    mod filter_error_render {
+        use super::*;
+        use ratatui::{backend::TestBackend, Terminal};
+
+        #[test]
+        fn filter_error_replaces_table_body() {
+            let backend = TestBackend::new(40, 6);
+            let mut terminal = Terminal::new(backend).unwrap();
+
+            let mut table = Table::builder()
+                .header(["NAME".to_string(), "STATUS".to_string()])
+                .items([TableItem::new(
+                    vec!["node-a".to_string(), "Ready".to_string()],
+                    None,
+                )])
+                .build();
+            table.filter_error = Some("invalid regex 'foo['".to_string());
+            table.update_chunk(Rect::new(0, 0, 40, 6));
+
+            terminal
+                .draw(|f| table.render(f, true, false))
+                .unwrap();
+
+            let buffer = terminal.backend().buffer().clone();
+            let mut dump = String::new();
+            for y in 0..buffer.area.height {
+                for x in 0..buffer.area.width {
+                    dump.push_str(buffer[(x, y)].symbol());
+                }
+            }
+
+            assert!(
+                dump.contains("invalid regex"),
+                "error text should be rendered: {}",
+                dump
+            );
+            assert!(
+                !dump.contains("node-a"),
+                "rows should NOT be rendered when filter_error is set: {}",
+                dump
+            );
         }
     }
 

--- a/src/ui/widget/table.rs
+++ b/src/ui/widget/table.rs
@@ -43,13 +43,17 @@ use super::{
 };
 
 pub use filter::{FilterForm, FilterFormTheme};
+// `OnFilterApply` and `TableFilterParser` are part of the public filter API
+// surface; their first internal consumer (Node tab) lands in PR B. The
+// `unused_imports` warning is therefore expected and silenced here.
+#[allow(unused_imports)]
 pub use filter_applicator::{
+    substring_applicator,
     ApplyStrategy,
     OnFilterApply,
     TableFilterApplicator,
     TableFilterParser,
     TableFilterPredicate,
-    substring_applicator,
 };
 
 use item::InnerItem;
@@ -295,7 +299,10 @@ impl Table<'_> {
         let header = self.items.header().original().to_vec();
         let state = self.filter_state.clone();
         self.items.apply_filter(|item| {
-            state.as_ref().map(|p| p.matches(item, &header)).unwrap_or(true)
+            state
+                .as_ref()
+                .map(|p| p.matches(item, &header))
+                .unwrap_or(true)
         });
 
         self.adjust_selected(old_len, self.items.len());
@@ -377,7 +384,10 @@ impl Table<'_> {
         let state = self.filter_state.clone();
 
         self.items.apply_filter(|item| {
-            state.as_ref().map(|p| p.matches(item, &header)).unwrap_or(true)
+            state
+                .as_ref()
+                .map(|p| p.matches(item, &header))
+                .unwrap_or(true)
         });
 
         self.adjust_selected(old_len, self.items.len());
@@ -701,9 +711,7 @@ impl WidgetTrait for Table<'_> {
     fn clear(&mut self) {
         self.state = TableState::default();
 
-        self.items = InnerItem::builder()
-            .max_width(self.max_width())
-            .build();
+        self.items = InnerItem::builder().max_width(self.max_width()).build();
 
         self.row_bounds = Vec::default();
 
@@ -729,10 +737,7 @@ impl Table<'_> {
 
     /// 直近 parse 成功した predicate と applicator の on_apply を捕捉して、
     /// Window 渡しの Callback に詰めて返す。
-    fn on_filter_apply_callback(
-        &self,
-        predicate: TableFilterPredicate,
-    ) -> Option<Callback> {
+    fn on_filter_apply_callback(&self, predicate: TableFilterPredicate) -> Option<Callback> {
         let on_apply = self.filter_applicator.as_ref()?.on_apply.clone()?;
         Some(Callback::from(move |w: &mut Window| {
             (on_apply.closure)(&predicate, w);
@@ -1015,9 +1020,7 @@ mod tests {
             table.filter_error = Some("invalid regex 'foo['".to_string());
             table.update_chunk(Rect::new(0, 0, 40, 6));
 
-            terminal
-                .draw(|f| table.render(f, true, false))
-                .unwrap();
+            terminal.draw(|f| table.render(f, true, false)).unwrap();
 
             let buffer = terminal.backend().buffer().clone();
             let mut dump = String::new();

--- a/src/ui/widget/table.rs
+++ b/src/ui/widget/table.rs
@@ -1,5 +1,6 @@
 // mod filter_form;
 mod filter;
+mod filter_applicator;
 mod item;
 
 use std::rc::Rc;

--- a/src/ui/widget/table.rs
+++ b/src/ui/widget/table.rs
@@ -92,7 +92,6 @@ pub struct TableBuilder {
     header: Vec<String>,
     items: Vec<TableItem>,
     state: TableState,
-    filtered_key: String,
     on_select: Option<OnSelectCallback>,
     actions: Vec<(UserEvent, Callback)>,
     block_injection: Option<RenderBlockInjection>,
@@ -144,11 +143,6 @@ impl TableBuilder {
         self
     }
 
-    pub fn filtered_key(mut self, key: impl Into<String>) -> Self {
-        self.filtered_key = key.into();
-        self
-    }
-
     pub fn on_select<F>(mut self, cb: F) -> Self
     where
         F: Into<OnSelectCallback>,
@@ -192,7 +186,6 @@ impl TableBuilder {
             state: self.state,
             block_injection: self.block_injection,
             highlight_injection: self.highlight_injection,
-            filtered_key: self.filtered_key.clone(),
             filter_form: self.filter_form,
             filter_applicator: self.filter_applicator,
             filter_state: None,
@@ -203,7 +196,6 @@ impl TableBuilder {
         table.items = InnerItem::builder()
             .header(self.header)
             .items(self.items)
-            .filtered_key(self.filtered_key)
             .build();
 
         table.update_row_bounds();
@@ -263,7 +255,6 @@ pub struct Table<'a> {
     filter_applicator: Option<TableFilterApplicator>,
     filter_state: Option<TableFilterPredicate>,
     filter_error: Option<String>,
-    filtered_key: String,
     mode: Mode,
     on_select: Option<OnSelectCallback>,
     actions: Vec<(UserEvent, Callback)>,
@@ -298,7 +289,6 @@ impl Table<'_> {
         self.items = InnerItem::builder()
             .header(header)
             .items(rows)
-            .filtered_key(self.filtered_key.clone())
             .max_width(self.max_width())
             .build();
 
@@ -510,6 +500,7 @@ impl WidgetTrait for Table<'_> {
         let old_len = self.items.len();
 
         self.items.update_items(items.table());
+        self.filter_items();
 
         self.adjust_selected(old_len, self.items.len());
 
@@ -712,7 +703,6 @@ impl WidgetTrait for Table<'_> {
 
         self.items = InnerItem::builder()
             .max_width(self.max_width())
-            .filtered_key(self.filtered_key.clone())
             .build();
 
         self.row_bounds = Vec::default();

--- a/src/ui/widget/table.rs
+++ b/src/ui/widget/table.rs
@@ -633,7 +633,24 @@ impl WidgetTrait for Table<'_> {
             Mode::FilterInput => {
                 match key_event_to_code(ev) {
                     KeyCode::Enter => {
+                        // EnterToConfirm 戦略では Enter で初めて parser を呼ぶ。
+                        // Live 戦略では既にタイプ中に state が更新されているが、parse を
+                        // 再走させてエラー状態を最終確定する。
+                        let parsed = self.run_parser_and_update_state();
+
+                        // パース失敗時は FilterInput モード継続（filter_error が立っている）
+                        if self.filter_error.is_some() {
+                            return EventResult::Nop;
+                        }
+
                         self.mode.filter_confirm();
+
+                        // 成功時は applicator の on_apply 副作用を Window 経由で呼ぶ。
+                        if let Some(predicate) = parsed {
+                            if let Some(cb) = self.on_filter_apply_callback(predicate) {
+                                return EventResult::Callback(cb);
+                            }
+                        }
                     }
 
                     KeyCode::Esc => {
@@ -708,6 +725,19 @@ impl Table<'_> {
             self.selected_item()
                 .map(|v| Callback::new(move |w| cb(w, &v)))
         })
+    }
+
+    /// 直近 parse 成功した predicate と applicator の on_apply を捕捉して、
+    /// Window 渡しの Callback に詰めて返す。
+    fn on_filter_apply_callback(
+        &self,
+        predicate: TableFilterPredicate,
+    ) -> Option<Callback> {
+        let on_apply = self.filter_applicator.as_ref()?.on_apply.clone()?;
+        Some(Callback::from(move |w: &mut Window| {
+            (on_apply.closure)(&predicate, w);
+            EventResult::Nop
+        }))
     }
 
     fn selected_item(&self) -> Option<Rc<TableItem>> {

--- a/src/ui/widget/table.rs
+++ b/src/ui/widget/table.rs
@@ -49,6 +49,7 @@ pub use filter_applicator::{
     TableFilterApplicator,
     TableFilterParser,
     TableFilterPredicate,
+    substring_applicator,
 };
 
 use item::InnerItem;

--- a/src/ui/widget/table.rs
+++ b/src/ui/widget/table.rs
@@ -641,17 +641,22 @@ impl WidgetTrait for Table<'_> {
                     }
 
                     _ => {
-                        // Only reachable when filter_form is Some (FilterInput
-                        // is only entered via the gated `/` branch above).
-                        let ev = if let Some(filter_form) = self.filter_form.as_mut() {
+                        let result = if let Some(filter_form) = self.filter_form.as_mut() {
                             filter_form.on_key_event(ev)
                         } else {
                             EventResult::Ignore
                         };
 
+                        // Live strategy: 毎キーで parse → state/error を更新
+                        if let Some(applicator) = self.filter_applicator.as_ref() {
+                            if applicator.strategy == ApplyStrategy::Live {
+                                self.run_parser_and_update_state();
+                            }
+                        }
+
                         self.filter_items();
 
-                        return ev;
+                        return result;
                     }
                 }
             }
@@ -715,6 +720,32 @@ impl Table<'_> {
         self.actions
             .iter()
             .find_map(|(cb_ev, cb)| if *cb_ev == ev { Some(cb) } else { None })
+    }
+
+    /// 現在の filter_form 入力を parser に渡し、結果で filter_state / filter_error を
+    /// 更新する。
+    ///
+    /// 成功時は Some(predicate)、失敗時は None。
+    /// Live モードでは毎キー、EnterToConfirm モードでは Enter 時に呼ぶ。
+    fn run_parser_and_update_state(&mut self) -> Option<TableFilterPredicate> {
+        let applicator = self.filter_applicator.as_ref()?;
+        let input = self
+            .filter_form
+            .as_ref()
+            .map(|f| f.content())
+            .unwrap_or_default();
+
+        match (applicator.parser.closure)(&input) {
+            Ok(predicate) => {
+                self.filter_error = None;
+                self.filter_state = Some(predicate.clone());
+                Some(predicate)
+            }
+            Err(msg) => {
+                self.filter_error = Some(msg);
+                None
+            }
+        }
     }
 }
 

--- a/src/ui/widget/table.rs
+++ b/src/ui/widget/table.rs
@@ -428,6 +428,9 @@ impl Table<'_> {
             filter_form.clear();
         }
 
+        self.filter_state = None;
+        self.filter_error = None;
+
         self.filter_items();
     }
 }
@@ -1039,6 +1042,32 @@ mod tests {
                 !dump.contains("node-a"),
                 "rows should NOT be rendered when filter_error is set: {}",
                 dump
+            );
+        }
+
+        #[test]
+        fn filter_cancel_clears_filter_error_and_state() {
+            let mut table = Table::builder()
+                .header(["NAME".to_string(), "STATUS".to_string()])
+                .items([TableItem::new(
+                    vec!["node-a".to_string(), "Ready".to_string()],
+                    None,
+                )])
+                .filter_form(FilterForm::default())
+                .build();
+
+            table.filter_error = Some("invalid regex 'foo['".to_string());
+            table.filter_state = Some(TableFilterPredicate::default());
+
+            table.filter_cancel();
+
+            assert!(
+                table.filter_error.is_none(),
+                "filter_error must be cleared on cancel (so the error overlay does not linger after Esc)"
+            );
+            assert!(
+                table.filter_state.is_none(),
+                "filter_state must be cleared on cancel (so Esc fully discards any applied filter)"
             );
         }
     }

--- a/src/ui/widget/table/filter_applicator.rs
+++ b/src/ui/widget/table/filter_applicator.rs
@@ -1,0 +1,270 @@
+use std::collections::HashMap;
+
+use regex::Regex;
+
+use crate::ui::widget::{styled_graphemes::StyledGraphemes, TableItem};
+
+/// A set of filter predicates that determine whether a [`TableItem`] should be
+/// shown in the table.
+///
+/// All non-empty fields are AND-combined; within `column_includes` and
+/// `column_excludes` the per-column patterns are AND-combined too, but the
+/// patterns within a single column list are OR-combined.
+///
+/// ```text
+/// result = (col_A matches include_A?) AND (col_B matches include_B?) AND …
+///        AND NOT (col_A matches exclude_A?) AND NOT (col_B matches exclude_B?) AND …
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct TableFilterPredicate {
+    /// Column-name → list of regexes, any one of which must match that column
+    /// (OR within a column, AND across columns).
+    pub column_includes: HashMap<String, Vec<Regex>>,
+
+    /// Column-name → list of regexes; if any pattern matches the column,
+    /// the row is excluded.
+    pub column_excludes: HashMap<String, Vec<Regex>>,
+
+    /// Opaque label selector string (e.g. `"app=foo,env=prod"`).
+    /// Stored for display / forwarding; NOT evaluated inside `matches()`.
+    pub label_selector: Option<String>,
+
+    /// Raw filter string stored for display / forwarding.
+    /// NOT evaluated inside `matches()`.
+    pub raw: String,
+}
+
+impl TableFilterPredicate {
+    /// Returns `true` when this predicate is entirely empty (no filtering).
+    pub fn is_empty(&self) -> bool {
+        self.column_includes.is_empty()
+            && self.column_excludes.is_empty()
+            && self.label_selector.is_none()
+            && self.raw.is_empty()
+    }
+
+    /// Returns `true` when `item` passes all active filters.
+    pub fn matches(&self, item: &TableItem, header: &[String]) -> bool {
+        // --- column_includes (AND across columns, OR within) ---
+        for (col, patterns) in &self.column_includes {
+            let cell = cell_of(item, header, col).unwrap_or_default();
+            if !patterns.iter().any(|r| r.is_match(&cell)) {
+                return false;
+            }
+        }
+
+        // --- column_excludes (AND across columns, OR within → exclude) ---
+        for (col, patterns) in &self.column_excludes {
+            let cell = cell_of(item, header, col).unwrap_or_default();
+            if patterns.iter().any(|r| r.is_match(&cell)) {
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
+/// Returns the ANSI-stripped text of the column named `col_name` in `item`,
+/// or `None` if the column name is not found in `header`.
+// TODO(perf): cell_of() is called per column × per row × per render. Each
+// invocation re-lowercases the entire header. If profiling shows this in the
+// hot path once Table widget wiring lands (Tasks 5/7), pre-compute a
+// column-name → index map at filter_state set time.
+fn cell_of(item: &TableItem, header: &[String], col_name: &str) -> Option<String> {
+    let col_name_lower = col_name.to_lowercase();
+    let idx = header
+        .iter()
+        .position(|h| h.to_lowercase() == col_name_lower)?;
+
+    item.item
+        .get(idx)
+        .map(|c| c.styled_graphemes_symbols().concat())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_item(cells: &[&str]) -> TableItem {
+        TableItem::new(cells.iter().map(|s| s.to_string()).collect::<Vec<_>>(), None)
+    }
+
+    fn header(cols: &[&str]) -> Vec<String> {
+        cols.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn empty_predicate_matches_anything() {
+        let pred = TableFilterPredicate::default();
+        let item = make_item(&["foo", "bar"]);
+        let hdr = header(&["NAME", "STATUS"]);
+        assert!(pred.matches(&item, &hdr));
+    }
+
+    #[test]
+    fn includes_within_column_use_or() {
+        let mut pred = TableFilterPredicate::default();
+        pred.column_includes.insert(
+            "STATUS".to_string(),
+            vec![
+                Regex::new("Running").unwrap(),
+                Regex::new("Pending").unwrap(),
+            ],
+        );
+        let hdr = header(&["NAME", "STATUS"]);
+
+        // matches "Running"
+        assert!(pred.matches(&make_item(&["pod-a", "Running"]), &hdr));
+        // matches "Pending"
+        assert!(pred.matches(&make_item(&["pod-b", "Pending"]), &hdr));
+        // neither → rejected
+        assert!(!pred.matches(&make_item(&["pod-c", "Failed"]), &hdr));
+    }
+
+    #[test]
+    fn includes_across_columns_use_and() {
+        let mut pred = TableFilterPredicate::default();
+        pred.column_includes
+            .insert("NAME".to_string(), vec![Regex::new("web").unwrap()]);
+        pred.column_includes
+            .insert("STATUS".to_string(), vec![Regex::new("Running").unwrap()]);
+        let hdr = header(&["NAME", "STATUS"]);
+
+        // both match
+        assert!(pred.matches(&make_item(&["web-server", "Running"]), &hdr));
+        // name matches but status doesn't
+        assert!(!pred.matches(&make_item(&["web-server", "Pending"]), &hdr));
+        // status matches but name doesn't
+        assert!(!pred.matches(&make_item(&["api-server", "Running"]), &hdr));
+    }
+
+    #[test]
+    fn excludes_any_match_excludes() {
+        let mut pred = TableFilterPredicate::default();
+        pred.column_excludes.insert(
+            "STATUS".to_string(),
+            vec![
+                Regex::new("Failed").unwrap(),
+                Regex::new("Error").unwrap(),
+            ],
+        );
+        let hdr = header(&["NAME", "STATUS"]);
+
+        assert!(pred.matches(&make_item(&["pod-a", "Running"]), &hdr));
+        assert!(!pred.matches(&make_item(&["pod-b", "Failed"]), &hdr));
+        assert!(!pred.matches(&make_item(&["pod-c", "Error"]), &hdr));
+    }
+
+    #[test]
+    fn excludes_across_columns_block_on_any_match() {
+        let mut pred = TableFilterPredicate::default();
+        pred.column_excludes
+            .insert("NAME".to_string(), vec![Regex::new("bad").unwrap()]);
+        pred.column_excludes
+            .insert("STATUS".to_string(), vec![Regex::new("Failed").unwrap()]);
+        let hdr = header(&["NAME", "STATUS"]);
+
+        // neither column excluded → passes
+        assert!(pred.matches(&make_item(&["good-pod", "Running"]), &hdr));
+        // NAME matches exclusion → rejected
+        assert!(!pred.matches(&make_item(&["bad-pod", "Running"]), &hdr));
+        // STATUS matches exclusion → rejected
+        assert!(!pred.matches(&make_item(&["good-pod", "Failed"]), &hdr));
+    }
+
+    #[test]
+    fn includes_and_excludes_combine() {
+        let mut pred = TableFilterPredicate::default();
+        pred.column_includes
+            .insert("NAME".to_string(), vec![Regex::new("web").unwrap()]);
+        pred.column_excludes
+            .insert("STATUS".to_string(), vec![Regex::new("Failed").unwrap()]);
+        let hdr = header(&["NAME", "STATUS"]);
+
+        // include satisfied, exclude not triggered
+        assert!(pred.matches(&make_item(&["web-server", "Running"]), &hdr));
+        // include satisfied, but exclude triggered
+        assert!(!pred.matches(&make_item(&["web-server", "Failed"]), &hdr));
+        // include NOT satisfied
+        assert!(!pred.matches(&make_item(&["api-server", "Running"]), &hdr));
+    }
+
+    #[test]
+    fn column_name_matching_is_case_insensitive() {
+        let mut pred = TableFilterPredicate::default();
+        pred.column_includes
+            .insert("status".to_string(), vec![Regex::new("Running").unwrap()]);
+        // header uses uppercase "STATUS"
+        let hdr = header(&["NAME", "STATUS"]);
+
+        assert!(pred.matches(&make_item(&["pod-a", "Running"]), &hdr));
+        assert!(!pred.matches(&make_item(&["pod-a", "Pending"]), &hdr));
+    }
+
+    #[test]
+    fn unknown_column_yields_empty_cell_so_fails_match() {
+        let mut pred = TableFilterPredicate::default();
+        pred.column_includes
+            .insert("NONEXISTENT".to_string(), vec![Regex::new("anything").unwrap()]);
+        let hdr = header(&["NAME", "STATUS"]);
+        // The cell for an unknown column is "", which can never match "anything"
+        assert!(!pred.matches(&make_item(&["pod-a", "Running"]), &hdr));
+    }
+
+    #[test]
+    fn ansi_escape_in_cell_is_stripped_before_match() {
+        let mut pred = TableFilterPredicate::default();
+        pred.column_includes
+            .insert("STATUS".to_string(), vec![Regex::new("Running").unwrap()]);
+        let hdr = header(&["NAME", "STATUS"]);
+
+        // Cell contains ANSI green color around "Running"
+        let item = make_item(&["pod-a", "\x1b[32mRunning\x1b[0m"]);
+        assert!(pred.matches(&item, &hdr));
+    }
+
+    #[test]
+    fn ansi_escape_does_not_pollute_anchor_match() {
+        let mut pred = TableFilterPredicate::default();
+        // Anchored regex: would fail if ANSI bytes were left in the string
+        pred.column_includes
+            .insert("STATUS".to_string(), vec![Regex::new("^Ready$").unwrap()]);
+        let hdr = header(&["NAME", "STATUS"]);
+
+        // After stripping ANSI, the cell is "Ready" — anchored regex must match
+        let item = make_item(&["pod-a", "\x1b[31mReady\x1b[0m"]);
+        assert!(pred.matches(&item, &hdr));
+    }
+
+    #[test]
+    fn ansi_escape_in_cell_not_matched_as_part_of_value() {
+        let mut pred = TableFilterPredicate::default();
+        // This regex matches the literal ANSI escape sequence fragment
+        pred.column_includes
+            .insert("STATUS".to_string(), vec![Regex::new(r"\[31m").unwrap()]);
+        let hdr = header(&["NAME", "STATUS"]);
+
+        // After ANSI stripping, "[31m" is gone — regex must NOT match
+        let item = make_item(&["pod-a", "\x1b[31mReady\x1b[0m"]);
+        assert!(!pred.matches(&item, &hdr));
+    }
+
+    #[test]
+    fn is_empty_is_false_when_only_label_selector_is_set() {
+        let pred = TableFilterPredicate {
+            label_selector: Some("app=foo".to_string()),
+            ..TableFilterPredicate::default()
+        };
+        assert!(!pred.is_empty());
+    }
+
+    #[test]
+    fn is_empty_is_false_when_only_raw_is_set() {
+        let pred = TableFilterPredicate {
+            raw: "STATUS:Running".to_string(),
+            ..TableFilterPredicate::default()
+        };
+        assert!(!pred.is_empty());
+    }
+}

--- a/src/ui/widget/table/filter_applicator.rs
+++ b/src/ui/widget/table/filter_applicator.rs
@@ -166,6 +166,42 @@ impl TableFilterApplicator {
 #[allow(unused_imports)]
 use EventResult as _;
 
+/// 既存タブが使う「単一列の部分一致」フィルタを構成する。
+/// `column` は対象列名（大小区別なし、内部で小文字化）。
+///
+/// 挙動は既存の `filtered_key + split(' ').any(contains)` と等価:
+/// - 空入力 → フィルタなし（全行 pass）
+/// - スペース区切りの複数 pattern → OR
+/// - 各 pattern は `regex::escape` でリテラル化（ユーザーは regex を
+///   意識しなくていい、`.` `*` 等が混入しても安全）
+pub fn substring_applicator(column: &str) -> TableFilterApplicator {
+    let col = column.to_string().to_lowercase();
+    let parser: TableFilterParser = (move |input: &str| {
+        let raw = input.to_string();
+        let patterns: Result<Vec<Regex>, _> = input
+            .split_whitespace()
+            .map(regex::escape)
+            .map(|p| Regex::new(&p))
+            .collect();
+        let patterns = patterns.map_err(|e| e.to_string())?;
+
+        let mut column_includes = HashMap::new();
+        if !patterns.is_empty() {
+            column_includes.insert(col.clone(), patterns);
+        }
+
+        Ok(TableFilterPredicate {
+            column_includes,
+            column_excludes: HashMap::new(),
+            label_selector: None,
+            raw,
+        })
+    })
+    .into();
+
+    TableFilterApplicator::new(parser, ApplyStrategy::Live)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -350,5 +386,67 @@ mod tests {
             ..TableFilterPredicate::default()
         };
         assert!(!pred.is_empty());
+    }
+
+    fn invoke_parser(a: &TableFilterApplicator, input: &str) -> TableFilterPredicate {
+        (a.parser.closure)(input).expect("test input must parse")
+    }
+
+    #[test]
+    fn substring_applicator_empty_input_matches_everything() {
+        let a = substring_applicator("NAME");
+        let p = invoke_parser(&a, "");
+        let h = header(&["NAME"]);
+        assert!(p.matches(&make_item(&["nginx"]), &h));
+        assert!(p.matches(&make_item(&[""]), &h));
+        assert!(p.is_empty());
+    }
+
+    #[test]
+    fn substring_applicator_single_pattern_substring_match() {
+        let a = substring_applicator("NAME");
+        let p = invoke_parser(&a, "nginx");
+        let h = header(&["NAME"]);
+        assert!(p.matches(&make_item(&["abc-nginx-prod"]), &h));
+        assert!(!p.matches(&make_item(&["web-server"]), &h));
+    }
+
+    #[test]
+    fn substring_applicator_space_separated_is_or() {
+        // 既存挙動と等価: "nginx web" は NAME に nginx OR web
+        let a = substring_applicator("NAME");
+        let p = invoke_parser(&a, "nginx web");
+        let h = header(&["NAME"]);
+        assert!(p.matches(&make_item(&["nginx-x"]), &h));
+        assert!(p.matches(&make_item(&["web-y"]), &h));
+        assert!(!p.matches(&make_item(&["api-z"]), &h));
+    }
+
+    #[test]
+    fn substring_applicator_special_chars_are_escaped() {
+        // "a.b" がリテラルとして扱われる（regex の `.` ではない）
+        let a = substring_applicator("NAME");
+        let p = invoke_parser(&a, "a.b");
+        let h = header(&["NAME"]);
+        assert!(p.matches(&make_item(&["x-a.b-y"]), &h));
+        assert!(!p.matches(&make_item(&["x-a_b-y"]), &h)); // regex の . なら通るがリテラルなので落ちる
+    }
+
+    #[test]
+    fn substring_applicator_strategy_is_live() {
+        let a = substring_applicator("NAME");
+        assert_eq!(a.strategy, ApplyStrategy::Live);
+    }
+
+    #[test]
+    fn substring_applicator_help_dialog_id_is_none() {
+        let a = substring_applicator("NAME");
+        assert_eq!(a.help_dialog_id, None);
+    }
+
+    #[test]
+    fn substring_applicator_on_apply_is_none() {
+        let a = substring_applicator("NAME");
+        assert!(a.on_apply.is_none());
     }
 }

--- a/src/ui/widget/table/filter_applicator.rs
+++ b/src/ui/widget/table/filter_applicator.rs
@@ -27,15 +27,21 @@ pub struct TableFilterPredicate {
 
     /// Opaque label selector string (e.g. `"app=foo,env=prod"`).
     /// Stored for display / forwarding; NOT evaluated inside `matches()`.
+    /// Consumed by external callers (e.g. PR B Node tab on_apply hook).
+    #[allow(dead_code)]
     pub label_selector: Option<String>,
 
     /// Raw filter string stored for display / forwarding.
     /// NOT evaluated inside `matches()`.
+    /// Consumed by external callers (e.g. title display in PR B).
+    #[allow(dead_code)]
     pub raw: String,
 }
 
 impl TableFilterPredicate {
     /// Returns `true` when this predicate is entirely empty (no filtering).
+    /// Consumed by external callers (e.g. PR B Node tab title display).
+    #[allow(dead_code)]
     pub fn is_empty(&self) -> bool {
         self.column_includes.is_empty()
             && self.column_excludes.is_empty()
@@ -106,6 +112,8 @@ pub enum ApplyStrategy {
     /// Filter is applied on every keystroke (incremental / live search).
     Live,
     /// Filter is applied only when the user presses Enter.
+    /// Used by Node tab (PR B); no internal consumer in PR A.
+    #[allow(dead_code)]
     EnterToConfirm,
 }
 
@@ -131,7 +139,10 @@ impl std::fmt::Debug for TableFilterApplicator {
             .field("strategy", &self.strategy)
             .field("help_dialog_id", &self.help_dialog_id)
             .field("parser", &"<TableFilterParser>")
-            .field("on_apply", &self.on_apply.as_ref().map(|_| "<OnFilterApply>"))
+            .field(
+                "on_apply",
+                &self.on_apply.as_ref().map(|_| "<OnFilterApply>"),
+            )
             .finish()
     }
 }
@@ -149,12 +160,16 @@ impl TableFilterApplicator {
 
     /// Attach a help-dialog id. When the filter input is focused and the user
     /// presses `?`, the dialog with this id will be opened.
+    /// Consumed by external callers (PR B Node tab).
+    #[allow(dead_code)]
     pub fn with_help_dialog(mut self, id: impl Into<String>) -> Self {
         self.help_dialog_id = Some(id.into());
         self
     }
 
     /// Attach a callback that is invoked after every filter change.
+    /// Consumed by external callers (PR B Node tab on_apply for labelSelector).
+    #[allow(dead_code)]
     pub fn with_on_apply(mut self, cb: OnFilterApply) -> Self {
         self.on_apply = Some(cb);
         self
@@ -207,7 +222,10 @@ mod tests {
     use super::*;
 
     fn make_item(cells: &[&str]) -> TableItem {
-        TableItem::new(cells.iter().map(|s| s.to_string()).collect::<Vec<_>>(), None)
+        TableItem::new(
+            cells.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+            None,
+        )
     }
 
     fn header(cols: &[&str]) -> Vec<String> {
@@ -264,10 +282,7 @@ mod tests {
         let mut pred = TableFilterPredicate::default();
         pred.column_excludes.insert(
             "STATUS".to_string(),
-            vec![
-                Regex::new("Failed").unwrap(),
-                Regex::new("Error").unwrap(),
-            ],
+            vec![Regex::new("Failed").unwrap(), Regex::new("Error").unwrap()],
         );
         let hdr = header(&["NAME", "STATUS"]);
 
@@ -325,8 +340,10 @@ mod tests {
     #[test]
     fn unknown_column_yields_empty_cell_so_fails_match() {
         let mut pred = TableFilterPredicate::default();
-        pred.column_includes
-            .insert("NONEXISTENT".to_string(), vec![Regex::new("anything").unwrap()]);
+        pred.column_includes.insert(
+            "NONEXISTENT".to_string(),
+            vec![Regex::new("anything").unwrap()],
+        );
         let hdr = header(&["NAME", "STATUS"]);
         // The cell for an unknown column is "", which can never match "anything"
         assert!(!pred.matches(&make_item(&["pod-a", "Running"]), &hdr));

--- a/src/ui/widget/table/filter_applicator.rs
+++ b/src/ui/widget/table/filter_applicator.rs
@@ -82,6 +82,90 @@ fn cell_of(item: &TableItem, header: &[String], col_name: &str) -> Option<String
         .map(|c| c.styled_graphemes_symbols().concat())
 }
 
+// ---------------------------------------------------------------------------
+// Callback types and factory struct
+// ---------------------------------------------------------------------------
+
+use crate::{
+    define_callback,
+    ui::{event::EventResult, Window},
+};
+
+// TableFilterParser: parses a raw filter string into a TableFilterPredicate.
+// Returns Ok(predicate) on success, or Err(message) for display to the user.
+define_callback!(pub TableFilterParser, Fn(&str) -> Result<TableFilterPredicate, String>);
+
+// OnFilterApply: called after a filter has been applied (or cleared). Receives
+// the new predicate and a mutable Window reference for side effects (e.g.,
+// forwarding labelSelector to a poller via shared state).
+define_callback!(pub OnFilterApply, Fn(&TableFilterPredicate, &mut Window));
+
+/// Controls *when* the filter is actually applied to the table rows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApplyStrategy {
+    /// Filter is applied on every keystroke (incremental / live search).
+    Live,
+    /// Filter is applied only when the user presses Enter.
+    EnterToConfirm,
+}
+
+/// Bundles everything a [`Table`] widget needs to support column filtering.
+///
+/// Construct via [`TableFilterApplicator::new`] and use the builder methods to
+/// attach optional components before passing to `Table::builder().filter_applicator()`.
+pub struct TableFilterApplicator {
+    /// Converts a raw filter string into a [`TableFilterPredicate`].
+    pub(crate) parser: TableFilterParser,
+    /// Controls when the predicate is applied to the visible rows.
+    pub(crate) strategy: ApplyStrategy,
+    /// Optional dialog-id of the help overlay (opened when user presses `?`
+    /// while the filter input is focused).
+    pub(crate) help_dialog_id: Option<String>,
+    /// Optional callback invoked after the filter changes.
+    pub(crate) on_apply: Option<OnFilterApply>,
+}
+
+impl std::fmt::Debug for TableFilterApplicator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TableFilterApplicator")
+            .field("strategy", &self.strategy)
+            .field("help_dialog_id", &self.help_dialog_id)
+            .field("parser", &"<TableFilterParser>")
+            .field("on_apply", &self.on_apply.as_ref().map(|_| "<OnFilterApply>"))
+            .finish()
+    }
+}
+
+impl TableFilterApplicator {
+    /// Create a new applicator with the given parser and apply strategy.
+    pub fn new(parser: TableFilterParser, strategy: ApplyStrategy) -> Self {
+        Self {
+            parser,
+            strategy,
+            help_dialog_id: None,
+            on_apply: None,
+        }
+    }
+
+    /// Attach a help-dialog id. When the filter input is focused and the user
+    /// presses `?`, the dialog with this id will be opened.
+    pub fn with_help_dialog(mut self, id: impl Into<String>) -> Self {
+        self.help_dialog_id = Some(id.into());
+        self
+    }
+
+    /// Attach a callback that is invoked after every filter change.
+    pub fn with_on_apply(mut self, cb: OnFilterApply) -> Self {
+        self.on_apply = Some(cb);
+        self
+    }
+}
+
+// Suppress unused-import warning: EventResult is referenced by the
+// define_callback! expansion indirectly; keep the use above for correctness.
+#[allow(unused_imports)]
+use EventResult as _;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/ui/widget/table/item.rs
+++ b/src/ui/widget/table/item.rs
@@ -132,6 +132,21 @@ impl InnerItem<'_> {
         self.inner_filter_items();
         self.inner_update_rendered_items();
     }
+
+    /// 外部から渡された predicate で original_items を filtered_items に
+    /// 絞り込む。filter_state ベースの新パスで使う。
+    pub fn apply_filter<F>(&mut self, mut predicate: F)
+    where
+        F: FnMut(&TableItem) -> bool,
+    {
+        self.filtered_items = self
+            .original_items
+            .iter()
+            .filter(|i| predicate(i))
+            .cloned()
+            .collect();
+        self.inner_update_rendered_items();
+    }
 }
 
 impl InnerItem<'_> {

--- a/src/ui/widget/table/item.rs
+++ b/src/ui/widget/table/item.rs
@@ -191,7 +191,6 @@ impl InnerItem<'_> {
             self.item_margin = 0;
         }
     }
-
 }
 
 #[derive(Debug, Default)]

--- a/src/ui/widget/table/item.rs
+++ b/src/ui/widget/table/item.rs
@@ -1,14 +1,11 @@
 use ratatui::widgets::{Cell, Row};
 use std::ops::Deref;
 
-use crate::{
-    logger,
-    ui::widget::{
-        line::convert_lines_to_styled_lines,
-        styled_graphemes::StyledGraphemes,
-        wrap::wrap_line,
-        TableItem,
-    },
+use crate::ui::widget::{
+    line::convert_lines_to_styled_lines,
+    styled_graphemes::StyledGraphemes,
+    wrap::wrap_line,
+    TableItem,
 };
 
 use super::COLUMN_SPACING;
@@ -21,7 +18,6 @@ pub struct InnerItemBuilder {
     header: Vec<String>,
     items: Vec<TableItem>,
     max_width: usize,
-    filtered_key: String,
 }
 
 impl InnerItemBuilder {
@@ -40,17 +36,11 @@ impl InnerItemBuilder {
         self
     }
 
-    pub fn filtered_key(mut self, key: impl Into<String>) -> Self {
-        self.filtered_key = key.into();
-        self
-    }
-
     pub fn build(self) -> InnerItem<'static> {
         let mut inner_item = InnerItem {
             header: Header::new(self.header),
             original_items: self.items.clone(),
             filtered_items: self.items,
-            filtered_key: self.filtered_key,
             ..Default::default()
         };
 
@@ -75,8 +65,6 @@ pub struct InnerItem<'a> {
     item_margin: u16,
     digits: Digits,
     max_width: usize,
-    filtered_key: String,
-    filtered_word: String,
 }
 
 impl InnerItem<'_> {
@@ -118,18 +106,12 @@ impl InnerItem<'_> {
 
     pub fn update_items(&mut self, item: Vec<TableItem>) {
         self.original_items = item;
-        self.inner_filter_items();
+        self.filtered_items = self.original_items.clone();
         self.inner_update_rendered_items();
     }
 
     pub fn update_max_width(&mut self, max_width: usize) {
         self.max_width = max_width;
-        self.inner_update_rendered_items();
-    }
-
-    pub fn update_filter(&mut self, word: impl Into<String>) {
-        self.filtered_word = word.into();
-        self.inner_filter_items();
         self.inner_update_rendered_items();
     }
 
@@ -150,31 +132,6 @@ impl InnerItem<'_> {
 }
 
 impl InnerItem<'_> {
-    fn inner_filter_items(&mut self) {
-        self.filtered_items = if self.filtered_word.is_empty() {
-            self.original_items.clone()
-        } else {
-            self.original_items
-                .iter()
-                .filter_map(|item| {
-                    let choice = item.item[self.filtered_index()]
-                        .styled_graphemes_symbols()
-                        .concat();
-
-                    if self
-                        .filtered_word
-                        .split(' ')
-                        .any(|pattern| choice.contains(pattern))
-                    {
-                        Some(item.clone())
-                    } else {
-                        None
-                    }
-                })
-                .collect()
-        }
-    }
-
     fn inner_update_rendered_items(&mut self) {
         self.digits = Digits::new(&self.filtered_items, &self.header.original, self.max_width);
 
@@ -235,23 +192,6 @@ impl InnerItem<'_> {
         }
     }
 
-    fn filtered_index(&self) -> usize {
-        let index = self
-            .header
-            .original
-            .iter()
-            .position(|header| header == &self.filtered_key)
-            .unwrap_or(0);
-
-        logger!(
-            debug,
-            "[table] header={:?} filtered_key={}",
-            self.header.original,
-            index
-        );
-
-        index
-    }
 }
 
 #[derive(Debug, Default)]
@@ -368,45 +308,6 @@ impl Deref for Digits {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    mod filtered_index {
-        use super::*;
-        use pretty_assertions::assert_eq;
-
-        #[test]
-        fn headerにfiltered_keyに一致する要素があるとき要素のインデックスを返す() {
-            let item = InnerItem::builder()
-                .header(
-                    ["FOO", "BAR", "BAZ"]
-                        .iter()
-                        .map(ToString::to_string)
-                        .collect::<Vec<_>>(),
-                )
-                .filtered_key("BAR")
-                .build();
-
-            let actual = item.filtered_index();
-
-            assert_eq!(actual, 1);
-        }
-
-        #[test]
-        fn headerにfiltered_keyに一致する要素がないとき0を返す() {
-            let item = InnerItem::builder()
-                .header(
-                    ["FOO", "BAR", "BAZ"]
-                        .iter()
-                        .map(ToString::to_string)
-                        .collect::<Vec<_>>(),
-                )
-                .filtered_key("HOGE")
-                .build();
-
-            let actual = item.filtered_index();
-
-            assert_eq!(actual, 0);
-        }
-    }
 
     mod digits {
         use super::*;


### PR DESCRIPTION
Stacked on #980.

## Summary

- Make the shared Table widget's filter mechanism pluggable via `TableFilterApplicator`, and migrate the three existing tabs (Pod / Config / Network) to it through `substring_applicator` while preserving their current OR-substring semantics.
- Add a richer column-aware filter framework (OR within a column, AND across columns, any-match excludes; `label_selector` carried at the type level), the two `ApplyStrategy` modes (`Live` / `EnterToConfirm`), and a sticky filter-error rendering path. These pieces are the foundation for the Node tab in the follow-up PR.
- Strip ANSI escapes from cell values via `styled_graphemes_symbols().concat()` before matching, so colorized cells (e.g. a Pod row colorized by a status-based highlight rule) still match against their visible text.

## Scope

This PR ships only the framework. Public surface added for the next PR — `TableFilterPredicate::{label_selector, raw, is_empty}`, `ApplyStrategy::EnterToConfirm`, and `TableFilterApplicator::{with_help_dialog, with_on_apply}` — has no internal consumer here and is annotated with `#[allow(dead_code)]` plus a note pointing at PR B (Node tab).

## Design docs

- Spec: `docs/superpowers/specs/2026-05-27-table-filter-redesign.md`
- Plan: `docs/superpowers/plans/2026-05-27-table-filter-applicator.md`

## Automated checks

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --all-targets` — no new warnings from this PR (3 pre-existing `too_many_arguments` warnings are untouched)
- [x] `cargo test --all` — 557 passed / 0 failed
- [x] New unit tests cover:
  - `TableFilterPredicate` column / label / raw / empty-state predicates (13 cases)
  - `substring_applicator` for empty input, single token, OR with multiple tokens, and regex-special escaping (6 cases)
  - ANSI-stripping in `cell_of` (3 cases)
  - `filter_error` body-replacement rendering
  - `?` key dispatches the applicator's help dialog
  - `filter_cancel` clears both `filter_error` and `filter_state`

## Manual verification

Run `cargo run` against any cluster with at least a few pods/configmaps/services. Repeat each step on **Pod**, **Config**, and **Network** tabs unless noted.

### Existing tabs: no regression

- [x] `/` opens the filter input form; cursor enters it.
- [x] Typing a single token (e.g. `kube`) live-filters rows by substring as you type. Backspace progressively unfilters.
- [x] Multiple space-separated tokens act as **OR** (e.g. `kube system` keeps rows matching either token in the `NAME` column).
- [x] Matching is **case-sensitive** — same as the legacy behavior. `KUBE` and `kube` are treated as different patterns. (Making this case-insensitive is intentionally out of scope; it would be a separate behavior change.)
- [x] **Pod tab specifically — ANSI-colorized NAME still matches by visible text.** When a row's `STATUS` matches a highlight rule in `pod_highlight_rules` (defaults: `Completed|Evicted` → dark gray, `BackOff|Err|Unknown` → red), the kube worker wraps *every cell of that row*, including `NAME`, in ANSI escape codes (`\x1b[…m…\x1b[0m`). The filter must still find such rows by their visible name text. To exercise this, ensure a pod in `Completed`/`Error`/`CrashLoopBackOff`/etc. exists (e.g. `kubectl run badpod --image=does-not-exist`), then `/` and filter by a substring of that pod's name. The row should still match.
- [x] Regex special characters in the input are treated as literal substrings — typing `.` or `[` does not produce a regex error or unexpected matches.
- [x] Press `Enter` while filtering: the form stays visible, rows stay filtered, focus moves to the table (FilterConfirm mode). Arrow keys navigate filtered rows.
- [x] Press `/` again from FilterConfirm: returns to FilterInput, existing text is editable.
- [x] Press `Esc` from FilterInput or FilterConfirm: form hides, **all rows reappear**, and no stale error overlay is shown (regression test added for this).
- [x] Background polling updates (wait ~1s for the tick): filtered rows stay filtered; newly arriving rows that match the filter appear, non-matching ones do not.
- [x] Tab navigation (e.g. switch from Pod to Config and back): existing behavior is unchanged. Filter state is preserved when returning to a previously filtered tab.

### What is NOT manually verifiable in this PR

End-to-end exercise of the items below requires a tab that uses an applicator richer than `substring_applicator`. The only such tab (Node) ships in the follow-up PR. They are covered by unit tests here, but reviewers cannot drive them from the TUI on this PR alone.

- **Column-aware filtering** (`column:value`, multiple columns combined with AND, multiple values on the same column combined with OR, `!column:value` for excludes). The framework — `TableFilterPredicate.column_includes` / `column_excludes` and `TableFilterPredicate::matches` against the visible (ANSI-stripped) cell text — is fully implemented and unit-tested, but `substring_applicator` does not expose a parser that produces these predicates: any input is treated as plain substring tokens against the single column the tab was configured with.
- **`filter_error` body replacement.** `substring_applicator` wraps every token with `regex::escape`, so parsing never fails. The sticky-error rendering path therefore has no user-visible trigger here.
- **`?` opens applicator-defined help dialog.** `substring_applicator` does not register a help dialog; the dispatch path only fires when `TableFilterApplicator::with_help_dialog` is called.
- **`ApplyStrategy::EnterToConfirm`.** All three migrated tabs use `Live`; the deferred-apply path is exercised only in PR B.