### PR TITLE
feat(node): column-aware filter via TableFilterApplicator (Plan 5 of #920)

### DIFF
--- a/src/features/component_id.rs
+++ b/src/features/component_id.rs
@@ -35,6 +35,7 @@ component_id!(
     // dialogs
     pod_columns_dialog,
     node_columns_dialog,
+    node_filter_help_dialog,
     pod_log_query_help_dialog,
     context_dialog,
     single_namespace_dialog,

--- a/src/features/node.rs
+++ b/src/features/node.rs
@@ -1,3 +1,4 @@
+pub mod filter;
 pub mod kube;
 pub mod message;
 mod node_columns;

--- a/src/features/node/filter.rs
+++ b/src/features/node/filter.rs
@@ -8,4 +8,6 @@
 
 mod parser;
 
+// Consumed by the node_filter_applicator factory in Task 6 (this PR).
+#[allow(unused_imports)]
 pub use parser::parse_node_filter;

--- a/src/features/node/filter.rs
+++ b/src/features/node/filter.rs
@@ -18,7 +18,13 @@ use crate::{
     },
     message::Message,
     ui::{
-        widget::{ApplyStrategy, OnFilterApply, TableFilterApplicator, TableFilterParser},
+        widget::{
+            ApplyStrategy,
+            OnFilterApply,
+            OnFilterCancel,
+            TableFilterApplicator,
+            TableFilterParser,
+        },
         Window,
     },
 };
@@ -41,16 +47,28 @@ pub fn node_filter_applicator(
     let parser: TableFilterParser =
         (move |input: &str| parse_node_filter(input, &label_registry)).into();
 
+    let tx_apply = tx.clone();
+    let tx_cancel = tx;
+
     let on_apply: OnFilterApply = (move |predicate: &crate::ui::widget::TableFilterPredicate,
                                          _window: &mut Window| {
-        tx.send(NodeMessage::Filter(predicate.label_selector.clone()).into())
+        tx_apply
+            .send(NodeMessage::Filter(predicate.label_selector.clone()).into())
             .expect("Failed to send NodeMessage::Filter");
+    })
+    .into();
+
+    let on_cancel: OnFilterCancel = (move |_window: &mut Window| {
+        tx_cancel
+            .send(NodeMessage::Filter(None).into())
+            .expect("Failed to send NodeMessage::Filter(None) on cancel");
     })
     .into();
 
     TableFilterApplicator::new(parser, ApplyStrategy::EnterToConfirm)
         .with_help_dialog(NODE_FILTER_HELP_DIALOG_ID)
         .with_on_apply(on_apply)
+        .with_on_cancel(on_cancel)
 }
 
 #[cfg(test)]

--- a/src/features/node/filter.rs
+++ b/src/features/node/filter.rs
@@ -1,0 +1,11 @@
+//! Node tab filter: parser + `TableFilterApplicator` factory.
+//!
+//! The parser produces a `TableFilterPredicate` directly (no Node-specific
+//! predicate type). The factory wires the parser into the Table widget's
+//! filter framework with `ApplyStrategy::EnterToConfirm`, a help-dialog
+//! dispatch, and an `on_apply` callback that forwards the parsed
+//! `labelSelector` to the Node poller via `NodeFilterMessage::Apply`.
+
+mod parser;
+
+pub use parser::parse_node_filter;

--- a/src/features/node/filter.rs
+++ b/src/features/node/filter.rs
@@ -4,15 +4,18 @@
 //! predicate type). The factory wires the parser into the Table widget's
 //! filter framework with `ApplyStrategy::EnterToConfirm`. Server-side
 //! `labelSelector` forwarding is handled via the `on_apply` callback that
-//! sends `NodeMessage::Filter` to the poller. The help-dialog dispatch is
-//! wired in a later task (T10).
+//! sends `NodeMessage::Filter` to the poller. Typing `?` or `help` in the
+//! filter input opens the `NODE_FILTER_HELP_DIALOG_ID` dialog.
 
 mod parser;
 
 use crossbeam::channel::Sender;
 
 use crate::{
-    features::node::{message::NodeMessage, node_columns::NodeLabelColumn},
+    features::{
+        component_id::NODE_FILTER_HELP_DIALOG_ID,
+        node::{message::NodeMessage, node_columns::NodeLabelColumn},
+    },
     message::Message,
     ui::{
         widget::{ApplyStrategy, OnFilterApply, TableFilterApplicator, TableFilterParser},
@@ -45,7 +48,9 @@ pub fn node_filter_applicator(
     })
     .into();
 
-    TableFilterApplicator::new(parser, ApplyStrategy::EnterToConfirm).with_on_apply(on_apply)
+    TableFilterApplicator::new(parser, ApplyStrategy::EnterToConfirm)
+        .with_help_dialog(NODE_FILTER_HELP_DIALOG_ID)
+        .with_on_apply(on_apply)
 }
 
 #[cfg(test)]

--- a/src/features/node/filter.rs
+++ b/src/features/node/filter.rs
@@ -3,32 +3,49 @@
 //! The parser produces a `TableFilterPredicate` directly (no Node-specific
 //! predicate type). The factory wires the parser into the Table widget's
 //! filter framework with `ApplyStrategy::EnterToConfirm`. Server-side
-//! `labelSelector` forwarding and the help-dialog dispatch are wired in
-//! later tasks (T7 for the message, T10 for the help dialog).
+//! `labelSelector` forwarding is handled via the `on_apply` callback that
+//! sends `NodeMessage::Filter` to the poller. The help-dialog dispatch is
+//! wired in a later task (T10).
 
 mod parser;
 
+use crossbeam::channel::Sender;
+
 use crate::{
-    features::node::node_columns::NodeLabelColumn,
-    ui::widget::{ApplyStrategy, TableFilterApplicator, TableFilterParser},
+    features::node::{message::NodeMessage, node_columns::NodeLabelColumn},
+    message::Message,
+    ui::{
+        widget::{ApplyStrategy, OnFilterApply, TableFilterApplicator, TableFilterParser},
+        Window,
+    },
 };
 
-// Consumed by the node_filter_applicator factory in this file.
-#[allow(unused_imports)]
 pub use parser::parse_node_filter;
 
 /// Build the Node tab's filter applicator.
 ///
 /// `label_registry` is captured by value and used by the parser for
-/// column-name validation. The applicator uses `EnterToConfirm` strategy
-/// so that the parser only runs on Enter (avoids spamming the kube API
-/// mid-typing once server-side labelSelector forwarding lands in Task 7).
-#[allow(dead_code)]
-pub fn node_filter_applicator(label_registry: Vec<NodeLabelColumn>) -> TableFilterApplicator {
+/// column-name validation. `tx` is captured by the `on_apply` callback to
+/// forward the parsed `label_selector` to the Node poller via
+/// `NodeMessage::Filter`.
+///
+/// The applicator uses `EnterToConfirm` strategy so that the parser only
+/// runs on Enter (avoids spamming the kube API mid-typing).
+pub fn node_filter_applicator(
+    label_registry: Vec<NodeLabelColumn>,
+    tx: Sender<Message>,
+) -> TableFilterApplicator {
     let parser: TableFilterParser =
         (move |input: &str| parse_node_filter(input, &label_registry)).into();
 
-    TableFilterApplicator::new(parser, ApplyStrategy::EnterToConfirm)
+    let on_apply: OnFilterApply = (move |predicate: &crate::ui::widget::TableFilterPredicate,
+                                         _window: &mut Window| {
+        tx.send(NodeMessage::Filter(predicate.label_selector.clone()).into())
+            .expect("Failed to send NodeMessage::Filter");
+    })
+    .into();
+
+    TableFilterApplicator::new(parser, ApplyStrategy::EnterToConfirm).with_on_apply(on_apply)
 }
 
 #[cfg(test)]
@@ -37,9 +54,7 @@ mod tests {
 
     #[test]
     fn applicator_constructs_without_panic() {
-        // 単に factory が構築できることを exercise する。
-        // 後続 task の widget 切替まで applicator は consume されないので、
-        // ここで型エラーやクロージャ捕捉エラーを早期検出する。
-        let _ = node_filter_applicator(Vec::new());
+        let (tx, _rx) = crossbeam::channel::bounded(1);
+        let _ = node_filter_applicator(Vec::new(), tx);
     }
 }

--- a/src/features/node/filter.rs
+++ b/src/features/node/filter.rs
@@ -2,12 +2,44 @@
 //!
 //! The parser produces a `TableFilterPredicate` directly (no Node-specific
 //! predicate type). The factory wires the parser into the Table widget's
-//! filter framework with `ApplyStrategy::EnterToConfirm`, a help-dialog
-//! dispatch, and an `on_apply` callback that forwards the parsed
-//! `labelSelector` to the Node poller via `NodeFilterMessage::Apply`.
+//! filter framework with `ApplyStrategy::EnterToConfirm`. Server-side
+//! `labelSelector` forwarding and the help-dialog dispatch are wired in
+//! later tasks (T7 for the message, T10 for the help dialog).
 
 mod parser;
 
-// Consumed by the node_filter_applicator factory in Task 6 (this PR).
+use crate::{
+    features::node::node_columns::NodeLabelColumn,
+    ui::widget::{ApplyStrategy, TableFilterApplicator, TableFilterParser},
+};
+
+// Consumed by the node_filter_applicator factory in this file.
 #[allow(unused_imports)]
 pub use parser::parse_node_filter;
+
+/// Build the Node tab's filter applicator.
+///
+/// `label_registry` is captured by value and used by the parser for
+/// column-name validation. The applicator uses `EnterToConfirm` strategy
+/// so that the parser only runs on Enter (avoids spamming the kube API
+/// mid-typing once server-side labelSelector forwarding lands in Task 7).
+#[allow(dead_code)]
+pub fn node_filter_applicator(label_registry: Vec<NodeLabelColumn>) -> TableFilterApplicator {
+    let parser: TableFilterParser =
+        (move |input: &str| parse_node_filter(input, &label_registry)).into();
+
+    TableFilterApplicator::new(parser, ApplyStrategy::EnterToConfirm)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn applicator_constructs_without_panic() {
+        // 単に factory が構築できることを exercise する。
+        // 後続 task の widget 切替まで applicator は consume されないので、
+        // ここで型エラーやクロージャ捕捉エラーを早期検出する。
+        let _ = node_filter_applicator(Vec::new());
+    }
+}

--- a/src/features/node/filter/parser.rs
+++ b/src/features/node/filter/parser.rs
@@ -9,6 +9,8 @@ use crate::{features::node::node_columns::NodeLabelColumn, ui::widget::TableFilt
 /// `label_registry` supplies the set of valid label-column headers (in
 /// addition to the builtin Node column headers). Unknown column names
 /// produce a parse error.
+// Consumed by the node_filter_applicator factory in Task 6 (this PR).
+#[allow(dead_code)]
 pub fn parse_node_filter(
     input: &str,
     label_registry: &[NodeLabelColumn],
@@ -18,8 +20,7 @@ pub fn parse_node_filter(
 
     let mut column_includes: HashMap<String, Vec<Regex>> = HashMap::new();
     if !trimmed.is_empty() {
-        let regexes: Result<Vec<Regex>, _> =
-            trimmed.split_whitespace().map(Regex::new).collect();
+        let regexes: Result<Vec<Regex>, _> = trimmed.split_whitespace().map(Regex::new).collect();
         let regexes = regexes.map_err(|e| format!("invalid regex: {}", e))?;
         column_includes.insert("name".to_string(), regexes);
     }

--- a/src/features/node/filter/parser.rs
+++ b/src/features/node/filter/parser.rs
@@ -5,7 +5,7 @@ use std::{
 
 use nom::{
     branch::alt,
-    bytes::complete::is_not,
+    bytes::complete::{is_not, tag},
     character::complete::{anychar, char, multispace0, multispace1},
     combinator::{map, value, verify},
     error::{ContextError, ParseError},
@@ -152,7 +152,7 @@ fn parse_token<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
     s: &'a str,
 ) -> IResult<&'a str, Term, E> {
     // 1. label: (must be tried before the generic include path)
-    let label_result = preceded(nom::bytes::complete::tag("label:"), value_string::<E>).parse(s);
+    let label_result = preceded(tag("label:"), value_string::<E>).parse(s);
     if let Ok((rem, sel)) = label_result {
         return Ok((rem, Term::Label(sel)));
     }

--- a/src/features/node/filter/parser.rs
+++ b/src/features/node/filter/parser.rs
@@ -11,9 +11,23 @@ enum Term {
     Bare(String),
     /// `<col>:<value>` include.
     Include { column: String, value: String },
+    /// `!<col>:<value>` exclude.
+    Exclude { column: String, value: String },
 }
 
 fn parse_term(token: &str) -> Term {
+    if let Some(stripped) = token.strip_prefix('!') {
+        if let Some((col, val)) = stripped.split_once(':') {
+            if !col.is_empty() && !val.is_empty() {
+                return Term::Exclude {
+                    column: col.to_lowercase(),
+                    value: val.to_string(),
+                };
+            }
+        }
+        // Fall through: `!worker` without colon is a bare value.
+    }
+
     if let Some((col, val)) = token.split_once(':') {
         // Empty column or empty value is treated as Bare so the user sees
         // a regex error later (or no-op). Stricter validation happens in
@@ -43,6 +57,7 @@ pub fn parse_node_filter(
 
     let trimmed = input.trim();
     let mut column_includes: HashMap<String, Vec<Regex>> = HashMap::new();
+    let mut column_excludes: HashMap<String, Vec<Regex>> = HashMap::new();
 
     for token in trimmed.split_whitespace() {
         match parse_term(token) {
@@ -58,12 +73,17 @@ pub fn parse_node_filter(
                     Regex::new(&value).map_err(|e| format!("invalid regex '{}': {}", value, e))?;
                 column_includes.entry(column).or_default().push(rx);
             }
+            Term::Exclude { column, value } => {
+                let rx =
+                    Regex::new(&value).map_err(|e| format!("invalid regex '{}': {}", value, e))?;
+                column_excludes.entry(column).or_default().push(rx);
+            }
         }
     }
 
     Ok(TableFilterPredicate {
         column_includes,
-        column_excludes: HashMap::new(),
+        column_excludes,
         label_selector: None,
         raw: trimmed.to_string(),
     })
@@ -152,5 +172,32 @@ mod tests {
         assert_eq!(p.column_includes.len(), 2);
         assert_eq!(p.column_includes.get("name").unwrap().len(), 1);
         assert_eq!(p.column_includes.get("status").unwrap().len(), 1);
+    }
+
+    #[test]
+    fn excludes_prefixed_with_bang_populate_column_excludes() {
+        let p = parse_node_filter("!ns:kube-system", &no_label_cols()).unwrap();
+        assert!(p.column_includes.is_empty());
+        let patterns = p.column_excludes.get("ns").expect("ns column");
+        assert_eq!(patterns.len(), 1);
+        assert!(patterns[0].is_match("kube-system"));
+    }
+
+    #[test]
+    fn includes_and_excludes_coexist() {
+        let p = parse_node_filter("status:Ready !ns:kube-system", &no_label_cols()).unwrap();
+        assert_eq!(p.column_includes.len(), 1);
+        assert_eq!(p.column_excludes.len(), 1);
+    }
+
+    #[test]
+    fn bang_without_colon_is_treated_as_bare_value() {
+        // `!worker` は `!name:worker` の省略形ではない。bang は明示的な column と組でのみ意味を持つ。
+        let p = parse_node_filter("!worker", &no_label_cols()).unwrap();
+        // 文字列 `!worker` がそのまま NAME 列の regex になる。regex crate は `!worker` をリテラル `!worker` のマッチとして受け入れる。
+        let patterns = p.column_includes.get("name").expect("name column");
+        assert_eq!(patterns.len(), 1);
+        assert!(patterns[0].is_match("!worker"));
+        assert!(p.column_excludes.is_empty());
     }
 }

--- a/src/features/node/filter/parser.rs
+++ b/src/features/node/filter/parser.rs
@@ -13,9 +13,18 @@ enum Term {
     Include { column: String, value: String },
     /// `!<col>:<value>` exclude.
     Exclude { column: String, value: String },
+    /// `label:<selector>` → passed verbatim to the k8s API as labelSelector.
+    Label(String),
 }
 
 fn parse_term(token: &str) -> Term {
+    // `label:` is checked first so it is never mistaken for a generic column include.
+    if let Some(sel) = token.strip_prefix("label:") {
+        if !sel.is_empty() {
+            return Term::Label(sel.to_string());
+        }
+    }
+
     if let Some(stripped) = token.strip_prefix('!') {
         if let Some((col, val)) = stripped.split_once(':') {
             if !col.is_empty() && !val.is_empty() {
@@ -58,6 +67,7 @@ pub fn parse_node_filter(
     let trimmed = input.trim();
     let mut column_includes: HashMap<String, Vec<Regex>> = HashMap::new();
     let mut column_excludes: HashMap<String, Vec<Regex>> = HashMap::new();
+    let mut label_selector: Option<String> = None;
 
     for token in trimmed.split_whitespace() {
         match parse_term(token) {
@@ -78,13 +88,17 @@ pub fn parse_node_filter(
                     Regex::new(&value).map_err(|e| format!("invalid regex '{}': {}", value, e))?;
                 column_excludes.entry(column).or_default().push(rx);
             }
+            Term::Label(sel) => {
+                // Last label: term wins (k8s API accepts only one labelSelector value).
+                label_selector = Some(sel);
+            }
         }
     }
 
     Ok(TableFilterPredicate {
         column_includes,
         column_excludes,
-        label_selector: None,
+        label_selector,
         raw: trimmed.to_string(),
     })
 }
@@ -199,5 +213,42 @@ mod tests {
         assert_eq!(patterns.len(), 1);
         assert!(patterns[0].is_match("!worker"));
         assert!(p.column_excludes.is_empty());
+    }
+
+    #[test]
+    fn label_selector_is_captured_verbatim() {
+        let p = parse_node_filter("label:role=worker", &no_label_cols()).unwrap();
+        assert_eq!(p.label_selector.as_deref(), Some("role=worker"));
+        assert!(p.column_includes.is_empty());
+        assert!(p.column_excludes.is_empty());
+    }
+
+    #[test]
+    fn label_selector_supports_kubectl_comma_and() {
+        let p = parse_node_filter("label:role=worker,zone=us-west", &no_label_cols()).unwrap();
+        assert_eq!(
+            p.label_selector.as_deref(),
+            Some("role=worker,zone=us-west")
+        );
+    }
+
+    #[test]
+    fn multiple_label_terms_keep_the_last() {
+        // The k8s API accepts only one labelSelector value; spec requires
+        // last-wins to match the Pod log query convention.
+        let p = parse_node_filter("label:a=1 label:b=2", &no_label_cols()).unwrap();
+        assert_eq!(p.label_selector.as_deref(), Some("b=2"));
+    }
+
+    #[test]
+    fn label_and_column_terms_coexist() {
+        let p = parse_node_filter(
+            "status:Ready label:role=worker !ns:kube-system",
+            &no_label_cols(),
+        )
+        .unwrap();
+        assert_eq!(p.column_includes.len(), 1);
+        assert_eq!(p.column_excludes.len(), 1);
+        assert_eq!(p.label_selector.as_deref(), Some("role=worker"));
     }
 }

--- a/src/features/node/filter/parser.rs
+++ b/src/features/node/filter/parser.rs
@@ -1,8 +1,12 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use regex::Regex;
+use strum::IntoEnumIterator;
 
-use crate::{features::node::node_columns::NodeLabelColumn, ui::widget::TableFilterPredicate};
+use crate::{
+    features::node::node_columns::{NodeColumn, NodeLabelColumn},
+    ui::widget::TableFilterPredicate,
+};
 
 /// One parsed term from the input.
 #[derive(Debug)]
@@ -51,6 +55,19 @@ fn parse_term(token: &str) -> Term {
     Term::Bare(token.to_string())
 }
 
+/// Build the set of valid column names from the builtin `NodeColumn` variants
+/// plus any headers registered in `label_registry`. All names are lowercased
+/// so matching is case-insensitive.
+fn valid_columns(label_registry: &[NodeLabelColumn]) -> HashSet<String> {
+    let mut set: HashSet<String> = NodeColumn::iter()
+        .map(|c| c.display().to_lowercase())
+        .collect();
+    for lc in label_registry {
+        set.insert(lc.header.to_lowercase());
+    }
+    set
+}
+
 /// Parse a Node-filter input string into a `TableFilterPredicate`.
 ///
 /// `label_registry` supplies the set of valid label-column headers (in
@@ -62,7 +79,7 @@ pub fn parse_node_filter(
     input: &str,
     label_registry: &[NodeLabelColumn],
 ) -> Result<TableFilterPredicate, String> {
-    let _ = label_registry; // consumed in Task 5
+    let valid = valid_columns(label_registry);
 
     let trimmed = input.trim();
     let mut column_includes: HashMap<String, Vec<Regex>> = HashMap::new();
@@ -79,11 +96,17 @@ pub fn parse_node_filter(
                     .push(rx);
             }
             Term::Include { column, value } => {
+                if !valid.contains(&column) {
+                    return Err(format!("unknown column '{}'", column));
+                }
                 let rx =
                     Regex::new(&value).map_err(|e| format!("invalid regex '{}': {}", value, e))?;
                 column_includes.entry(column).or_default().push(rx);
             }
             Term::Exclude { column, value } => {
+                if !valid.contains(&column) {
+                    return Err(format!("unknown column '{}'", column));
+                }
                 let rx =
                     Regex::new(&value).map_err(|e| format!("invalid regex '{}': {}", value, e))?;
                 column_excludes.entry(column).or_default().push(rx);
@@ -190,16 +213,16 @@ mod tests {
 
     #[test]
     fn excludes_prefixed_with_bang_populate_column_excludes() {
-        let p = parse_node_filter("!ns:kube-system", &no_label_cols()).unwrap();
+        let p = parse_node_filter("!name:kube-system", &no_label_cols()).unwrap();
         assert!(p.column_includes.is_empty());
-        let patterns = p.column_excludes.get("ns").expect("ns column");
+        let patterns = p.column_excludes.get("name").expect("name column");
         assert_eq!(patterns.len(), 1);
         assert!(patterns[0].is_match("kube-system"));
     }
 
     #[test]
     fn includes_and_excludes_coexist() {
-        let p = parse_node_filter("status:Ready !ns:kube-system", &no_label_cols()).unwrap();
+        let p = parse_node_filter("status:Ready !name:kube-system", &no_label_cols()).unwrap();
         assert_eq!(p.column_includes.len(), 1);
         assert_eq!(p.column_excludes.len(), 1);
     }
@@ -243,12 +266,60 @@ mod tests {
     #[test]
     fn label_and_column_terms_coexist() {
         let p = parse_node_filter(
-            "status:Ready label:role=worker !ns:kube-system",
+            "status:Ready label:role=worker !name:kube-system",
             &no_label_cols(),
         )
         .unwrap();
         assert_eq!(p.column_includes.len(), 1);
         assert_eq!(p.column_excludes.len(), 1);
         assert_eq!(p.label_selector.as_deref(), Some("role=worker"));
+    }
+
+    fn registry_with(name: &str, header: &str) -> Vec<NodeLabelColumn> {
+        vec![NodeLabelColumn {
+            name: name.to_string(),
+            key: "irrelevant.example.com/key".to_string(),
+            header: header.to_string(),
+        }]
+    }
+
+    #[test]
+    fn unknown_column_produces_parse_error() {
+        let err = parse_node_filter("statusu:Ready", &no_label_cols()).unwrap_err();
+        assert!(
+            err.contains("unknown column") && err.contains("statusu"),
+            "error should mention the bad column: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn unknown_column_in_exclude_also_errors() {
+        let err = parse_node_filter("!agee:1h", &no_label_cols()).unwrap_err();
+        assert!(
+            err.contains("unknown column") && err.contains("agee"),
+            "error should mention the bad column: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn builtin_columns_are_accepted() {
+        // `name` and `status` are builtin headers — must not error.
+        assert!(parse_node_filter("name:n status:s", &no_label_cols()).is_ok());
+    }
+
+    #[test]
+    fn registered_label_column_header_is_accepted() {
+        let regs = registry_with("zone", "ZONE");
+        let p = parse_node_filter("zone:us-west", &regs).unwrap();
+        assert!(p.column_includes.contains_key("zone"));
+    }
+
+    #[test]
+    fn label_keyword_is_not_treated_as_a_column_lookup() {
+        // 'label:role=worker' must NOT trigger unknown-column validation
+        // (it's the special-cased k8s labelSelector path).
+        assert!(parse_node_filter("label:role=worker", &no_label_cols()).is_ok());
     }
 }

--- a/src/features/node/filter/parser.rs
+++ b/src/features/node/filter/parser.rs
@@ -1,5 +1,19 @@
-use std::collections::{HashMap, HashSet};
+use std::{
+    borrow::Cow,
+    collections::{HashMap, HashSet},
+};
 
+use nom::{
+    branch::alt,
+    bytes::complete::is_not,
+    character::complete::{anychar, char, multispace0, multispace1},
+    combinator::{map, value, verify},
+    error::{ContextError, ParseError},
+    multi::{fold_many0, separated_list0},
+    sequence::{delimited, preceded},
+    IResult,
+    Parser,
+};
 use regex::Regex;
 use strum::IntoEnumIterator;
 
@@ -7,6 +21,110 @@ use crate::{
     features::node::node_columns::{NodeColumn, NodeLabelColumn},
     ui::widget::TableFilterPredicate,
 };
+
+// ---------------------------------------------------------------------------
+// Quoting helpers (copied from pod/kube/filter/parser.rs to avoid cross-feature dep)
+// ---------------------------------------------------------------------------
+
+/// Parse a quoted string (`"..."` or `'...'`), handling escape sequences.
+///
+/// Escape rules inside quotes:
+///   `\"` → `"`   `\'` → `'`   `\\` → `\`   `\<other>` → `\<other>` (verbatim)
+fn quoted<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+    s: &'a str,
+) -> IResult<&'a str, Cow<'a, str>, E> {
+    #[inline]
+    fn multispace<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+    ) -> impl Parser<&'a str, Output = Cow<'a, str>, Error = E> {
+        map(multispace1, Cow::Borrowed)
+    }
+
+    #[inline]
+    fn escaped_char<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+    ) -> impl Parser<&'a str, Output = Cow<'a, str>, Error = E> {
+        preceded(
+            char('\\'),
+            alt((
+                value(Cow::Borrowed("\""), char('"')),
+                value(Cow::Borrowed("'"), char('\'')),
+                value(Cow::Borrowed("\\"), char('\\')),
+                map(anychar, |c| Cow::Owned(format!(r"\{}", c))),
+            )),
+        )
+    }
+
+    #[inline]
+    fn not_quote_slash<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+        quote_slash: &'a str,
+    ) -> impl Parser<&'a str, Output = Cow<'a, str>, Error = E> {
+        map(
+            verify(is_not(quote_slash), |s: &str| !s.is_empty()),
+            Cow::Borrowed,
+        )
+    }
+
+    #[inline]
+    fn fold<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+        parser: impl Parser<&'a str, Output = Cow<'a, str>, Error = E>,
+    ) -> impl Parser<&'a str, Output = String, Error = E> {
+        fold_many0(parser, String::default, |mut s, parsed| {
+            s.push_str(&parsed);
+            s
+        })
+    }
+
+    let double_quoted = delimited(
+        char('"'),
+        fold(alt((
+            escaped_char(),
+            not_quote_slash(r#""\"#),
+            multispace(),
+        ))),
+        char('"'),
+    );
+
+    let single_quoted = delimited(
+        char('\''),
+        fold(alt((
+            escaped_char(),
+            not_quote_slash(r#"\'"#),
+            multispace(),
+        ))),
+        char('\''),
+    );
+
+    let (remaining, value) = alt((double_quoted, single_quoted)).parse(s)?;
+
+    Ok((remaining, Cow::Owned(value)))
+}
+
+/// Parse an unquoted value: any non-whitespace characters that do not start
+/// with a quote character. Mirrors `non_space` in the pod filter parser.
+fn unquoted<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+    s: &'a str,
+) -> IResult<&'a str, Cow<'a, str>, E> {
+    let (remaining, value) =
+        verify(is_not(" \t\r\n"), |s: &str| !s.starts_with(['"', '\''])).parse(s)?;
+    Ok((remaining, Cow::Borrowed(value)))
+}
+
+/// Parse a value that may be quoted or unquoted.
+fn value_string<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+    s: &'a str,
+) -> IResult<&'a str, String, E> {
+    map(alt((quoted, unquoted)), |c| c.into_owned()).parse(s)
+}
+
+/// Parse a column name token: non-empty, stops at whitespace, `:`, `!`, or quote chars.
+fn column_name<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+    s: &'a str,
+) -> IResult<&'a str, &'a str, E> {
+    verify(is_not(" \t\r\n:!\"'"), |s: &str| !s.is_empty()).parse(s)
+}
+
+// ---------------------------------------------------------------------------
+// Term types and token parser
+// ---------------------------------------------------------------------------
 
 /// One parsed term from the input.
 #[derive(Debug)]
@@ -21,39 +139,77 @@ enum Term {
     Label(String),
 }
 
-fn parse_term(token: &str) -> Term {
-    // `label:` is checked first so it is never mistaken for a generic column include.
-    if let Some(sel) = token.strip_prefix("label:") {
-        if !sel.is_empty() {
-            return Term::Label(sel.to_string());
-        }
+/// Parse one whitespace-delimited token into a `Term`.
+///
+/// Priority order:
+///   1. `label:<value>` → Label (special-cased before generic Include)
+///   2. `!<col>:<value>` → Exclude
+///   3. `<col>:<value>` → Include
+///   4. `<value>` → Bare
+///
+/// For (3)/(4) the value may be quoted (`"..."` / `'...'`) or unquoted.
+fn parse_token<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+    s: &'a str,
+) -> IResult<&'a str, Term, E> {
+    // 1. label: (must be tried before the generic include path)
+    let label_result = preceded(nom::bytes::complete::tag("label:"), value_string::<E>).parse(s);
+    if let Ok((rem, sel)) = label_result {
+        return Ok((rem, Term::Label(sel)));
     }
 
-    if let Some(stripped) = token.strip_prefix('!') {
-        if let Some((col, val)) = stripped.split_once(':') {
-            if !col.is_empty() && !val.is_empty() {
-                return Term::Exclude {
+    // 2. !col:value  (exclude)
+    let exclude_result = preceded(char::<&'a str, E>('!'), |s: &'a str| {
+        // We need col:value after the `!`
+        let (s2, col) = column_name::<E>(s)?;
+        let (s3, _) = char::<&'a str, E>(':').parse(s2)?;
+        let (s4, val) = value_string::<E>(s3)?;
+        Ok((s4, (col.to_lowercase(), val)))
+    })
+    .parse(s);
+    if let Ok((rem, (col, val))) = exclude_result {
+        return Ok((
+            rem,
+            Term::Exclude {
+                column: col,
+                value: val,
+            },
+        ));
+    }
+
+    // 3. col:value  (include) — but only if input is NOT starting with a quote
+    //    (otherwise `"bare quoted"` would fail column_name and fall to Bare correctly)
+    if !s.starts_with(['"', '\'']) {
+        // Try to parse col:value.  If we successfully match `col:` followed by a
+        // quote character, we MUST parse it as a quoted value — do not fall through
+        // to Bare, which would silently read the whole token as unquoted.
+        let col_colon_result = (|s: &'a str| -> IResult<&'a str, (&'a str, &'a str), E> {
+            let (s2, col) = column_name::<E>(s)?;
+            let (s3, _) = char::<&'a str, E>(':').parse(s2)?;
+            Ok((s3, (s, col)))
+        })(s);
+
+        if let Ok((after_colon, (_orig, col))) = col_colon_result {
+            // We have `col:` consumed.  Now parse the value — this will fail hard
+            // if the value is an unclosed quote (nom Err::Error propagated).
+            let (rem, val) = value_string::<E>(after_colon)?;
+            return Ok((
+                rem,
+                Term::Include {
                     column: col.to_lowercase(),
-                    value: val.to_string(),
-                };
-            }
+                    value: val,
+                },
+            ));
         }
-        // Fall through: `!worker` without colon is a bare value.
     }
 
-    if let Some((col, val)) = token.split_once(':') {
-        // Empty column or empty value is treated as Bare so the user sees
-        // a regex error later (or no-op). Stricter validation happens in
-        // Task 5 (column-name validation).
-        if !col.is_empty() && !val.is_empty() {
-            return Term::Include {
-                column: col.to_lowercase(),
-                value: val.to_string(),
-            };
-        }
-    }
-    Term::Bare(token.to_string())
+    // 4. Bare value (quoted or unquoted)
+    let (rem, val) = value_string::<E>(s)?;
+    Ok((rem, Term::Bare(val)))
 }
+
+// ---------------------------------------------------------------------------
+// Column validation helpers
+// ---------------------------------------------------------------------------
 
 /// Build the set of valid column names from the builtin `NodeColumn` variants
 /// plus any headers registered in `label_registry`. All names are lowercased
@@ -68,11 +224,19 @@ fn valid_columns(label_registry: &[NodeLabelColumn]) -> HashSet<String> {
     set
 }
 
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
 /// Parse a Node-filter input string into a `TableFilterPredicate`.
 ///
 /// `label_registry` supplies the set of valid label-column headers (in
 /// addition to the builtin Node column headers). Unknown column names
 /// produce a parse error.
+///
+/// Values may be quoted (`"..."` / `'...'`) to include whitespace, with the
+/// same escape rules as the Pod log query parser:
+///   `\"` → `"`   `\'` → `'`   `\\` → `\`   `\<other>` → `\<other>`
 // Consumed by the node_filter_applicator factory in Task 6 (this PR).
 #[allow(dead_code)]
 pub fn parse_node_filter(
@@ -86,8 +250,32 @@ pub fn parse_node_filter(
     let mut column_excludes: HashMap<String, Vec<Regex>> = HashMap::new();
     let mut label_selector: Option<String> = None;
 
-    for token in trimmed.split_whitespace() {
-        match parse_term(token) {
+    if trimmed.is_empty() {
+        return Ok(TableFilterPredicate {
+            column_includes,
+            column_excludes,
+            label_selector,
+            raw: trimmed.to_string(),
+        });
+    }
+
+    // Parse the whole trimmed input as whitespace-separated tokens.
+    type E<'a> = nom::error::Error<&'a str>;
+    let parse_result = delimited(
+        multispace0,
+        separated_list0(multispace1, parse_token::<E>),
+        multispace0,
+    )
+    .parse(trimmed);
+
+    let (remaining, terms) = parse_result.map_err(|e| format!("parse error: {}", e))?;
+
+    if !remaining.is_empty() {
+        return Err(format!("unexpected input near: {:?}", remaining));
+    }
+
+    for term in terms {
+        match term {
             Term::Bare(v) => {
                 let rx = Regex::new(&v).map_err(|e| format!("invalid regex '{}': {}", v, e))?;
                 column_includes
@@ -321,5 +509,62 @@ mod tests {
         // 'label:role=worker' must NOT trigger unknown-column validation
         // (it's the special-cased k8s labelSelector path).
         assert!(parse_node_filter("label:role=worker", &no_label_cols()).is_ok());
+    }
+
+    // -----------------------------------------------------------------------
+    // New quoting / escape tests (Task 12)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn double_quoted_value_with_spaces_is_kept_intact() {
+        let p = parse_node_filter(r#"os-image:"Ubuntu 22.04.3 LTS""#, &no_label_cols()).unwrap();
+        let patterns = p.column_includes.get("os-image").expect("os-image col");
+        assert_eq!(patterns.len(), 1);
+        assert!(patterns[0].is_match("Ubuntu 22.04.3 LTS"));
+    }
+
+    #[test]
+    fn single_quoted_value_with_spaces_is_kept_intact() {
+        let p = parse_node_filter(r#"os-image:'Ubuntu 22.04 LTS'"#, &no_label_cols()).unwrap();
+        let patterns = p.column_includes.get("os-image").unwrap();
+        assert!(patterns[0].is_match("Ubuntu 22.04 LTS"));
+    }
+
+    #[test]
+    fn quoted_value_with_escaped_quote() {
+        let p = parse_node_filter(r#"name:"foo\"bar""#, &no_label_cols()).unwrap();
+        let patterns = p.column_includes.get("name").unwrap();
+        // 値は `foo"bar` という regex
+        assert!(patterns[0].is_match(r#"foo"bar"#));
+    }
+
+    #[test]
+    fn quoted_value_preserves_regex_backslash_classes() {
+        // `\s` をリテラルに残して regex `\s`（空白）になる
+        let p = parse_node_filter(r#"name:"foo\sbar""#, &no_label_cols()).unwrap();
+        let patterns = p.column_includes.get("name").unwrap();
+        assert!(patterns[0].is_match("foo bar")); // regex \s が空白マッチ
+        assert!(!patterns[0].is_match("foobar"));
+    }
+
+    #[test]
+    fn bare_value_with_quoted_spaces() {
+        // bare の場合も quoted value をサポート: "node a" → NAME に regex "node a"
+        let p = parse_node_filter(r#""node a""#, &no_label_cols()).unwrap();
+        let patterns = p.column_includes.get("name").unwrap();
+        assert!(patterns[0].is_match("node a"));
+    }
+
+    #[test]
+    fn mixed_quoted_and_unquoted_tokens() {
+        let p =
+            parse_node_filter(r#"status:Ready os-image:"Ubuntu 22.04""#, &no_label_cols()).unwrap();
+        assert_eq!(p.column_includes.len(), 2);
+        assert!(p.column_includes.get("os-image").unwrap()[0].is_match("Ubuntu 22.04"));
+    }
+
+    #[test]
+    fn unclosed_quote_is_a_parse_error() {
+        assert!(parse_node_filter(r#"name:"unterminated"#, &no_label_cols()).is_err());
     }
 }

--- a/src/features/node/filter/parser.rs
+++ b/src/features/node/filter/parser.rs
@@ -4,6 +4,30 @@ use regex::Regex;
 
 use crate::{features::node::node_columns::NodeLabelColumn, ui::widget::TableFilterPredicate};
 
+/// One parsed term from the input.
+#[derive(Debug)]
+enum Term {
+    /// Bare value (no prefix) → defaults to NAME include.
+    Bare(String),
+    /// `<col>:<value>` include.
+    Include { column: String, value: String },
+}
+
+fn parse_term(token: &str) -> Term {
+    if let Some((col, val)) = token.split_once(':') {
+        // Empty column or empty value is treated as Bare so the user sees
+        // a regex error later (or no-op). Stricter validation happens in
+        // Task 5 (column-name validation).
+        if !col.is_empty() && !val.is_empty() {
+            return Term::Include {
+                column: col.to_lowercase(),
+                value: val.to_string(),
+            };
+        }
+    }
+    Term::Bare(token.to_string())
+}
+
 /// Parse a Node-filter input string into a `TableFilterPredicate`.
 ///
 /// `label_registry` supplies the set of valid label-column headers (in
@@ -15,14 +39,26 @@ pub fn parse_node_filter(
     input: &str,
     label_registry: &[NodeLabelColumn],
 ) -> Result<TableFilterPredicate, String> {
-    let _ = label_registry; // used by later tasks
-    let trimmed = input.trim();
+    let _ = label_registry; // consumed in Task 5
 
+    let trimmed = input.trim();
     let mut column_includes: HashMap<String, Vec<Regex>> = HashMap::new();
-    if !trimmed.is_empty() {
-        let regexes: Result<Vec<Regex>, _> = trimmed.split_whitespace().map(Regex::new).collect();
-        let regexes = regexes.map_err(|e| format!("invalid regex: {}", e))?;
-        column_includes.insert("name".to_string(), regexes);
+
+    for token in trimmed.split_whitespace() {
+        match parse_term(token) {
+            Term::Bare(v) => {
+                let rx = Regex::new(&v).map_err(|e| format!("invalid regex '{}': {}", v, e))?;
+                column_includes
+                    .entry("name".to_string())
+                    .or_default()
+                    .push(rx);
+            }
+            Term::Include { column, value } => {
+                let rx =
+                    Regex::new(&value).map_err(|e| format!("invalid regex '{}': {}", value, e))?;
+                column_includes.entry(column).or_default().push(rx);
+            }
+        }
     }
 
     Ok(TableFilterPredicate {
@@ -75,5 +111,46 @@ mod tests {
         let patterns = p.column_includes.get("name").expect("name column");
         assert_eq!(patterns.len(), 2);
         assert_eq!(p.raw, "foo bar");
+    }
+
+    #[test]
+    fn explicit_column_include_creates_column_entry() {
+        let p = parse_node_filter("status:Ready", &no_label_cols()).unwrap();
+        assert_eq!(p.column_includes.len(), 1);
+        let patterns = p.column_includes.get("status").expect("status column");
+        assert_eq!(patterns.len(), 1);
+        assert!(patterns[0].is_match("Ready"));
+        assert_eq!(p.raw, "status:Ready");
+    }
+
+    #[test]
+    fn column_names_are_case_insensitive_canonicalized_lowercase() {
+        let p = parse_node_filter("STATUS:Ready Name:worker", &no_label_cols()).unwrap();
+        assert!(p.column_includes.contains_key("status"));
+        assert!(p.column_includes.contains_key("name"));
+    }
+
+    #[test]
+    fn same_column_includes_accumulate_in_order() {
+        let p = parse_node_filter("status:Ready status:Pending", &no_label_cols()).unwrap();
+        let patterns = p.column_includes.get("status").expect("status column");
+        assert_eq!(patterns.len(), 2);
+        assert!(patterns[0].is_match("Ready"));
+        assert!(patterns[1].is_match("Pending"));
+    }
+
+    #[test]
+    fn different_columns_coexist_in_predicate() {
+        let p = parse_node_filter("status:Ready name:worker", &no_label_cols()).unwrap();
+        assert_eq!(p.column_includes.len(), 2);
+    }
+
+    #[test]
+    fn bare_and_column_includes_mix() {
+        // `foo status:Ready` → NAME has `foo`, STATUS has `Ready`
+        let p = parse_node_filter("foo status:Ready", &no_label_cols()).unwrap();
+        assert_eq!(p.column_includes.len(), 2);
+        assert_eq!(p.column_includes.get("name").unwrap().len(), 1);
+        assert_eq!(p.column_includes.get("status").unwrap().len(), 1);
     }
 }

--- a/src/features/node/filter/parser.rs
+++ b/src/features/node/filter/parser.rs
@@ -1,0 +1,78 @@
+use std::collections::HashMap;
+
+use regex::Regex;
+
+use crate::{features::node::node_columns::NodeLabelColumn, ui::widget::TableFilterPredicate};
+
+/// Parse a Node-filter input string into a `TableFilterPredicate`.
+///
+/// `label_registry` supplies the set of valid label-column headers (in
+/// addition to the builtin Node column headers). Unknown column names
+/// produce a parse error.
+pub fn parse_node_filter(
+    input: &str,
+    label_registry: &[NodeLabelColumn],
+) -> Result<TableFilterPredicate, String> {
+    let _ = label_registry; // used by later tasks
+    let trimmed = input.trim();
+
+    let mut column_includes: HashMap<String, Vec<Regex>> = HashMap::new();
+    if !trimmed.is_empty() {
+        let regexes: Result<Vec<Regex>, _> =
+            trimmed.split_whitespace().map(Regex::new).collect();
+        let regexes = regexes.map_err(|e| format!("invalid regex: {}", e))?;
+        column_includes.insert("name".to_string(), regexes);
+    }
+
+    Ok(TableFilterPredicate {
+        column_includes,
+        column_excludes: HashMap::new(),
+        label_selector: None,
+        raw: trimmed.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    fn no_label_cols() -> Vec<NodeLabelColumn> {
+        Vec::new()
+    }
+
+    #[test]
+    fn empty_input_yields_empty_predicate() {
+        let p = parse_node_filter("", &no_label_cols()).unwrap();
+        assert!(p.column_includes.is_empty());
+        assert!(p.column_excludes.is_empty());
+        assert_eq!(p.label_selector, None);
+        assert_eq!(p.raw, "");
+    }
+
+    #[test]
+    fn whitespace_only_input_yields_empty_predicate() {
+        let p = parse_node_filter("   \t  ", &no_label_cols()).unwrap();
+        assert!(p.column_includes.is_empty());
+        assert_eq!(p.raw, "");
+    }
+
+    #[test]
+    fn single_bare_value_becomes_name_include() {
+        let p = parse_node_filter("worker", &no_label_cols()).unwrap();
+        assert_eq!(p.column_includes.len(), 1);
+        let patterns = p.column_includes.get("name").expect("name column");
+        assert_eq!(patterns.len(), 1);
+        assert!(patterns[0].is_match("gke-worker-1"));
+        assert!(!patterns[0].is_match("gke-control-1"));
+        assert_eq!(p.raw, "worker");
+    }
+
+    #[test]
+    fn multiple_bare_values_become_name_or() {
+        let p = parse_node_filter("foo bar", &no_label_cols()).unwrap();
+        let patterns = p.column_includes.get("name").expect("name column");
+        assert_eq!(patterns.len(), 2);
+        assert_eq!(p.raw, "foo bar");
+    }
+}

--- a/src/features/node/kube/node.rs
+++ b/src/features/node/kube/node.rs
@@ -21,6 +21,7 @@ use crate::{
 };
 
 pub type SharedNodeColumns = Arc<RwLock<NodeColumns>>;
+pub type SharedNodeFilter = Arc<RwLock<Option<String>>>;
 
 #[derive(Debug, Clone, Default)]
 pub struct NodeConfig {
@@ -31,6 +32,7 @@ pub struct NodeConfig {
 pub struct NodePoller {
     tx: Sender<Message>,
     shared_node_columns: SharedNodeColumns,
+    shared_node_filter: SharedNodeFilter,
     kube_client: KubeClient,
 }
 
@@ -38,11 +40,13 @@ impl NodePoller {
     pub fn new(
         tx: Sender<Message>,
         shared_node_columns: SharedNodeColumns,
+        shared_node_filter: SharedNodeFilter,
         kube_client: KubeClient,
     ) -> Self {
         Self {
             tx,
             shared_node_columns,
+            shared_node_filter,
             kube_client,
         }
     }
@@ -55,7 +59,12 @@ impl InfiniteWorker for NodePoller {
         let Self { tx, .. } = self;
         loop {
             interval.tick().await;
-            let node_info = get_node_table(&self.kube_client, &self.shared_node_columns).await;
+            let node_info = get_node_table(
+                &self.kube_client,
+                &self.shared_node_columns,
+                &self.shared_node_filter,
+            )
+            .await;
             if let Err(e) = tx.send(NodeMessage::Poll(node_info).into()) {
                 logger!(error, "Failed to send NodeMessage::Poll: {}", e);
                 return;
@@ -67,6 +76,7 @@ impl InfiniteWorker for NodePoller {
 async fn get_node_table<C: KubeClientRequest>(
     client: &C,
     shared_node_columns: &SharedNodeColumns,
+    shared_node_filter: &SharedNodeFilter,
 ) -> Result<KubeTable> {
     let node_columns = shared_node_columns.read().await;
 
@@ -82,7 +92,14 @@ async fn get_node_table<C: KubeClientRequest>(
         })
         .collect();
 
-    let path = Node::url_path(&(), None);
+    let base_path = Node::url_path(&(), None);
+    let path = {
+        let filter = shared_node_filter.read().await;
+        match filter.as_deref().filter(|s| !s.is_empty()) {
+            Some(sel) => format!("{}?labelSelector={}", base_path, sel),
+            None => base_path,
+        }
+    };
     let table: Table = client.request_table(&path).await?;
 
     let builtin_indexes = table.find_indexes(&builtin_targets)?;
@@ -200,7 +217,10 @@ mod tests {
         );
 
         let shared = Arc::new(RwLock::new(NodeColumns::default()));
-        let table = get_node_table(&client, &shared).await.unwrap();
+        let shared_filter = Arc::new(RwLock::new(None));
+        let table = get_node_table(&client, &shared, &shared_filter)
+            .await
+            .unwrap();
 
         assert_eq!(
             table.header,
@@ -256,10 +276,51 @@ mod tests {
             },
         ]);
         let shared = Arc::new(RwLock::new(specs));
-        let table = get_node_table(&client, &shared).await.unwrap();
+        let shared_filter = Arc::new(RwLock::new(None));
+        let table = get_node_table(&client, &shared, &shared_filter)
+            .await
+            .unwrap();
 
         assert_eq!(table.header, vec!["NAME", "MIG"]);
         assert_eq!(table.rows[0].name, "node-a");
         assert_eq!(table.rows[0].row, vec!["node-a", "success"]);
+    }
+
+    #[tokio::test]
+    async fn url_includes_label_selector_when_set() {
+        let mut client = crate::kube::mock::MockTestKubeClient::new();
+        mock_expect!(
+            client,
+            request_table,
+            Table,
+            eq("/api/v1/nodes?labelSelector=env%3Dprod"),
+            Ok(node_table_fixture())
+        );
+
+        let shared = Arc::new(RwLock::new(NodeColumns::default()));
+        let shared_filter = Arc::new(RwLock::new(Some("env%3Dprod".to_string())));
+        let table = get_node_table(&client, &shared, &shared_filter)
+            .await
+            .unwrap();
+        assert_eq!(table.rows.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn url_omits_label_selector_when_empty() {
+        let mut client = crate::kube::mock::MockTestKubeClient::new();
+        mock_expect!(
+            client,
+            request_table,
+            Table,
+            eq("/api/v1/nodes"),
+            Ok(node_table_fixture())
+        );
+
+        let shared = Arc::new(RwLock::new(NodeColumns::default()));
+        let shared_filter = Arc::new(RwLock::new(Some(String::new())));
+        let table = get_node_table(&client, &shared, &shared_filter)
+            .await
+            .unwrap();
+        assert_eq!(table.rows.len(), 2);
     }
 }

--- a/src/features/node/message.rs
+++ b/src/features/node/message.rs
@@ -10,6 +10,9 @@ pub enum NodeMessage {
     Poll(Result<KubeTable>),
     /// Replace the active labelSelector value. `None` clears it (the
     /// poller stops sending ?labelSelector= in its request URL).
+    /// Constructed by the filter applicator's on_apply callback wired in
+    /// Task 8 (node.rs widget switchover); no internal sender in T7 yet.
+    #[allow(dead_code)]
     Filter(Option<String>),
 }
 

--- a/src/features/node/message.rs
+++ b/src/features/node/message.rs
@@ -8,6 +8,9 @@ use super::NodeColumns;
 pub enum NodeMessage {
     Request(NodeColumns),
     Poll(Result<KubeTable>),
+    /// Replace the active labelSelector value. `None` clears it (the
+    /// poller stops sending ?labelSelector= in its request URL).
+    Filter(Option<String>),
 }
 
 impl From<NodeMessage> for Message {

--- a/src/features/node/message.rs
+++ b/src/features/node/message.rs
@@ -10,9 +10,6 @@ pub enum NodeMessage {
     Poll(Result<KubeTable>),
     /// Replace the active labelSelector value. `None` clears it (the
     /// poller stops sending ?labelSelector= in its request URL).
-    /// Constructed by the filter applicator's on_apply callback wired in
-    /// Task 8 (node.rs widget switchover); no internal sender in T7 yet.
-    #[allow(dead_code)]
     Filter(Option<String>),
 }
 

--- a/src/features/node/view/tab.rs
+++ b/src/features/node/view/tab.rs
@@ -35,7 +35,7 @@ impl NodeTab {
         label_registry: Vec<NodeLabelColumn>,
         theme: WidgetThemeConfig,
     ) -> Self {
-        let node_widget = node_widget(tx.clone(), theme.clone());
+        let node_widget = node_widget(tx.clone(), label_registry.clone(), theme.clone());
         let detail_widget = node_detail_widget(clipboard, theme.clone());
         let node_columns_dialog = node_columns_dialog(tx, default_columns, label_registry, theme);
 

--- a/src/features/node/view/tab.rs
+++ b/src/features/node/view/tab.rs
@@ -43,8 +43,9 @@ impl NodeTab {
     ) -> Self {
         let node_widget = node_widget(tx.clone(), label_registry.clone(), theme.clone());
         let detail_widget = node_detail_widget(clipboard, theme.clone());
-        let node_columns_dialog = node_columns_dialog(tx, default_columns, label_registry, theme);
-        let node_filter_help_dialog = node_filter_help_widget();
+        let node_columns_dialog =
+            node_columns_dialog(tx, default_columns, label_registry, theme.clone());
+        let node_filter_help_dialog = node_filter_help_widget(theme);
 
         let tab = Tab::new(
             NODE_TAB_ID,

--- a/src/features/node/view/tab.rs
+++ b/src/features/node/view/tab.rs
@@ -18,11 +18,17 @@ use crate::{
     },
 };
 
-use super::widgets::{node_columns_dialog, node_detail_widget, node_widget};
+use super::widgets::{
+    node_columns_dialog,
+    node_detail_widget,
+    node_filter_help_widget,
+    node_widget,
+};
 
 pub struct NodeTab {
     pub tab: Tab<'static>,
     pub node_columns_dialog: Widget<'static>,
+    pub node_filter_help_dialog: Widget<'static>,
 }
 
 impl NodeTab {
@@ -38,6 +44,7 @@ impl NodeTab {
         let node_widget = node_widget(tx.clone(), label_registry.clone(), theme.clone());
         let detail_widget = node_detail_widget(clipboard, theme.clone());
         let node_columns_dialog = node_columns_dialog(tx, default_columns, label_registry, theme);
+        let node_filter_help_dialog = node_filter_help_widget();
 
         let tab = Tab::new(
             NODE_TAB_ID,
@@ -49,6 +56,7 @@ impl NodeTab {
         Self {
             tab,
             node_columns_dialog,
+            node_filter_help_dialog,
         }
     }
 }

--- a/src/features/node/view/widgets.rs
+++ b/src/features/node/view/widgets.rs
@@ -1,7 +1,9 @@
 mod detail;
 mod node;
 mod node_columns_dialog;
+mod node_filter_help;
 
 pub use detail::*;
 pub use node::*;
 pub use node_columns_dialog::*;
+pub use node_filter_help::*;

--- a/src/features/node/view/widgets/node.rs
+++ b/src/features/node/view/widgets/node.rs
@@ -4,13 +4,16 @@ use crate::{
     config::theme::WidgetThemeConfig,
     features::{
         component_id::{NODE_COLUMNS_DIALOG_ID, NODE_DETAIL_WIDGET_ID, NODE_WIDGET_ID},
-        node::message::NodeDetailMessage,
+        node::{
+            filter::node_filter_applicator,
+            message::NodeDetailMessage,
+            node_columns::NodeLabelColumn,
+        },
     },
     message::Message,
     ui::{
         event::EventResult,
         widget::{
-            substring_applicator,
             FilterForm,
             FilterFormTheme,
             Table,
@@ -25,7 +28,11 @@ use crate::{
     },
 };
 
-pub fn node_widget(tx: Sender<Message>, theme: WidgetThemeConfig) -> Widget<'static> {
+pub fn node_widget(
+    tx: Sender<Message>,
+    label_registry: Vec<NodeLabelColumn>,
+    theme: WidgetThemeConfig,
+) -> Widget<'static> {
     let widget_theme = WidgetTheme::from(theme.clone());
     let table_theme = TableTheme::from(theme.clone());
 
@@ -41,7 +48,7 @@ pub fn node_widget(tx: Sender<Message>, theme: WidgetThemeConfig) -> Widget<'sta
         .id(NODE_WIDGET_ID)
         .widget_base(widget_base)
         .filter_form(filter_form)
-        .filter_applicator(substring_applicator("NAME"))
+        .filter_applicator(node_filter_applicator(label_registry, tx.clone()))
         .theme(table_theme)
         .action('t', open_node_columns_dialog())
         .on_select(on_select(tx))

--- a/src/features/node/view/widgets/node_filter_help.rs
+++ b/src/features/node/view/widgets/node_filter_help.rs
@@ -2,19 +2,29 @@ use indoc::indoc;
 use ratatui::crossterm::event::KeyCode;
 
 use crate::{
+    config::theme::WidgetThemeConfig,
     features::component_id::NODE_FILTER_HELP_DIALOG_ID,
     message::UserEvent,
     ui::{
         event::EventResult,
-        widget::{Text, Widget, WidgetBase},
+        widget::{Text, TextTheme, Widget, WidgetBase, WidgetTheme},
         Window,
     },
 };
 
-pub fn node_filter_help_widget() -> Widget<'static> {
+pub fn node_filter_help_widget(theme: WidgetThemeConfig) -> Widget<'static> {
+    let widget_theme = WidgetTheme::from(theme.clone());
+    let text_theme = TextTheme::from(theme);
+
+    let widget_base = WidgetBase::builder()
+        .title("Node Filter Help")
+        .theme(widget_theme)
+        .build();
+
     Text::builder()
         .id(NODE_FILTER_HELP_DIALOG_ID)
-        .widget_base(WidgetBase::builder().title("Node Filter Help").build())
+        .widget_base(widget_base)
+        .theme(text_theme)
         .items(content())
         .action(UserEvent::from(KeyCode::Enter), close_dialog())
         .build()

--- a/src/features/node/view/widgets/node_filter_help.rs
+++ b/src/features/node/view/widgets/node_filter_help.rs
@@ -7,23 +7,27 @@ use crate::{
     message::UserEvent,
     ui::{
         event::EventResult,
-        widget::{Text, TextTheme, Widget, WidgetBase, WidgetTheme},
+        widget::{SearchForm, SearchFormTheme, Text, TextTheme, Widget, WidgetBase, WidgetTheme},
         Window,
     },
 };
 
 pub fn node_filter_help_widget(theme: WidgetThemeConfig) -> Widget<'static> {
     let widget_theme = WidgetTheme::from(theme.clone());
-    let text_theme = TextTheme::from(theme);
+    let text_theme = TextTheme::from(theme.clone());
+    let search_theme = SearchFormTheme::from(theme);
 
     let widget_base = WidgetBase::builder()
         .title("Node Filter Help")
         .theme(widget_theme)
         .build();
 
+    let search_form = SearchForm::builder().theme(search_theme).build();
+
     Text::builder()
         .id(NODE_FILTER_HELP_DIALOG_ID)
         .widget_base(widget_base)
+        .search_form(search_form)
         .theme(text_theme)
         .items(content())
         .action(UserEvent::from(KeyCode::Enter), close_dialog())

--- a/src/features/node/view/widgets/node_filter_help.rs
+++ b/src/features/node/view/widgets/node_filter_help.rs
@@ -35,6 +35,12 @@ fn content() -> Vec<String> {
                               server-side (e.g. role=worker,zone=us-west).
                               Last 'label:' wins if repeated.
 
+        Quoting (values with spaces):
+           "value with spaces"           Double-quoted value
+           'value with spaces'           Single-quoted value
+           \" \' \\                      Literal " ' \ inside quotes
+           \<other>                      Backslash preserved (regex \s etc.)
+
         Combining:
            Same column, multiple includes  ->  OR (in-list)
            Different columns, includes     ->  AND across columns
@@ -46,6 +52,8 @@ fn content() -> Vec<String> {
            NAME:gke STATUS:Ready           NAME~gke AND STATUS~Ready
            STATUS:Ready STATUS:Pending     STATUS in (Ready, Pending)
            !NAME:control label:zone=us     Server-side label filter + name exclude
+           OS-IMAGE:"Ubuntu 22.04 LTS"     Quoted value with whitespace
+           NAME:"foo bar"                  Quote bare value too
 
         Column names are case-insensitive. Unknown columns produce a
         parse error. Press Enter to apply, Esc to cancel. Type ? or

--- a/src/features/node/view/widgets/node_filter_help.rs
+++ b/src/features/node/view/widgets/node_filter_help.rs
@@ -1,0 +1,64 @@
+use indoc::indoc;
+use ratatui::crossterm::event::KeyCode;
+
+use crate::{
+    features::component_id::NODE_FILTER_HELP_DIALOG_ID,
+    message::UserEvent,
+    ui::{
+        event::EventResult,
+        widget::{Text, Widget, WidgetBase},
+        Window,
+    },
+};
+
+pub fn node_filter_help_widget() -> Widget<'static> {
+    Text::builder()
+        .id(NODE_FILTER_HELP_DIALOG_ID)
+        .widget_base(WidgetBase::builder().title("Node Filter Help").build())
+        .items(content())
+        .action(UserEvent::from(KeyCode::Enter), close_dialog())
+        .build()
+        .into()
+}
+
+fn content() -> Vec<String> {
+    indoc! {r#"
+        Usage: TERM [ TERM ]...
+
+        Terms:
+           <value>            Plain value: NAME include (regex).
+           NAME:<regex>       Include nodes where NAME matches.
+           STATUS:<regex>     Include where STATUS matches. Multiple
+                              same-column includes are OR (in-list).
+           !<COL>:<regex>     Exclude nodes whose COL matches.
+           label:<selector>   Kubernetes labelSelector, applied
+                              server-side (e.g. role=worker,zone=us-west).
+                              Last 'label:' wins if repeated.
+
+        Combining:
+           Same column, multiple includes  ->  OR (in-list)
+           Different columns, includes     ->  AND across columns
+           Any matching exclude            ->  row excluded
+           Bare values                     ->  treated as NAME includes
+
+        Examples
+           worker                          Show nodes whose NAME matches 'worker'
+           NAME:gke STATUS:Ready           NAME~gke AND STATUS~Ready
+           STATUS:Ready STATUS:Pending     STATUS in (Ready, Pending)
+           !NAME:control label:zone=us     Server-side label filter + name exclude
+
+        Column names are case-insensitive. Unknown columns produce a
+        parse error. Press Enter to apply, Esc to cancel. Type ? or
+        help in the filter input to open this help.
+    "# }
+    .lines()
+    .map(ToString::to_string)
+    .collect()
+}
+
+fn close_dialog() -> impl Fn(&mut Window) -> EventResult {
+    move |w: &mut Window| {
+        w.close_dialog();
+        EventResult::Nop
+    }
+}

--- a/src/ui/widget/table.rs
+++ b/src/ui/widget/table.rs
@@ -668,11 +668,13 @@ impl WidgetTrait for Table<'_> {
                     _ => {
                         // `?` または `help` 入力でヘルプダイアログを開く（applicator が
                         // help_dialog_id を持つ場合のみ）。Pod log query の慣習に合わせる。
+                        // 入力欄の `?`/`help` 文字列だけクリアし、FilterInput モードは
+                        // 維持する。ヘルプは構文確認のためのコンテキストヘルプなので、
+                        // 閉じた後は空の入力欄に戻って続きを書ける方がメンタルモデルに沿う。
                         if let Some(help_id) = self.would_be_help_command(ev) {
                             if let Some(filter_form) = self.filter_form.as_mut() {
                                 filter_form.clear();
                             }
-                            self.mode.normal();
                             return EventResult::Callback(Callback::from(move |w: &mut Window| {
                                 w.open_dialog(help_id.clone());
                                 EventResult::Nop
@@ -1504,6 +1506,27 @@ mod tests {
             let result = table.on_key_event(KeyEvent::from(KeyCode::Char('?')));
 
             assert!(matches!(result, EventResult::Callback(_)));
+        }
+
+        #[test]
+        fn opening_help_keeps_filter_input_mode_with_cleared_form() {
+            let mut table = Table::builder()
+                .filter_form(FilterForm::builder().build())
+                .filter_applicator(dummy_applicator_with_help())
+                .build();
+            let _ = table.on_key_event(KeyEvent::from(KeyCode::Char('/')));
+            let _ = table.on_key_event(KeyEvent::from(KeyCode::Char('?')));
+
+            // ヘルプを開いても FilterInput を維持する（閉じた後すぐ続きを書ける）。
+            assert!(
+                table.mode.is_filter_input(),
+                "filter input mode must persist after opening help"
+            );
+            // `?` 文字は入力欄から消えている。
+            assert_eq!(
+                table.filter_form.as_ref().map(|f| f.content()),
+                Some(String::new())
+            );
         }
 
         #[test]

--- a/src/ui/widget/table.rs
+++ b/src/ui/widget/table.rs
@@ -43,14 +43,15 @@ use super::{
 };
 
 pub use filter::{FilterForm, FilterFormTheme};
-// `OnFilterApply` and `TableFilterParser` are part of the public filter API
-// surface; their first internal consumer (Node tab) lands in PR B. The
-// `unused_imports` warning is therefore expected and silenced here.
+// `OnFilterApply`, `OnFilterCancel`, and `TableFilterParser` are part of the
+// public filter API surface; their first internal consumers (Node tab) land in
+// PR B. The `unused_imports` warning is therefore expected and silenced here.
 #[allow(unused_imports)]
 pub use filter_applicator::{
     substring_applicator,
     ApplyStrategy,
     OnFilterApply,
+    OnFilterCancel,
     TableFilterApplicator,
     TableFilterParser,
     TableFilterPredicate,
@@ -421,7 +422,7 @@ impl Table<'_> {
         }
     }
 
-    fn filter_cancel(&mut self) {
+    fn filter_cancel(&mut self) -> Option<Callback> {
         self.mode.normal();
 
         if let Some(filter_form) = self.filter_form.as_mut() {
@@ -432,6 +433,8 @@ impl Table<'_> {
         self.filter_error = None;
 
         self.filter_items();
+
+        self.on_filter_cancel_callback()
     }
 }
 
@@ -610,7 +613,9 @@ impl WidgetTrait for Table<'_> {
                     }
 
                     KeyCode::Char('q') | KeyCode::Esc if self.mode.is_filter_confirm() => {
-                        self.filter_cancel();
+                        if let Some(cb) = self.filter_cancel() {
+                            return EventResult::Callback(cb);
+                        }
                     }
 
                     KeyCode::Enter => {
@@ -655,7 +660,9 @@ impl WidgetTrait for Table<'_> {
                     }
 
                     KeyCode::Esc => {
-                        self.filter_cancel();
+                        if let Some(cb) = self.filter_cancel() {
+                            return EventResult::Callback(cb);
+                        }
                     }
 
                     _ => {
@@ -744,6 +751,15 @@ impl Table<'_> {
         let on_apply = self.filter_applicator.as_ref()?.on_apply.clone()?;
         Some(Callback::from(move |w: &mut Window| {
             (on_apply.closure)(&predicate, w);
+            EventResult::Nop
+        }))
+    }
+
+    /// applicator の on_cancel callback を Window 渡しの Callback に詰めて返す。
+    fn on_filter_cancel_callback(&self) -> Option<Callback> {
+        let on_cancel = self.filter_applicator.as_ref()?.on_cancel.clone()?;
+        Some(Callback::from(move |w: &mut Window| {
+            (on_cancel.closure)(w);
             EventResult::Nop
         }))
     }
@@ -1059,7 +1075,7 @@ mod tests {
             table.filter_error = Some("invalid regex 'foo['".to_string());
             table.filter_state = Some(TableFilterPredicate::default());
 
-            table.filter_cancel();
+            let _ = table.filter_cancel();
 
             assert!(
                 table.filter_error.is_none(),
@@ -1069,6 +1085,49 @@ mod tests {
                 table.filter_state.is_none(),
                 "filter_state must be cleared on cancel (so Esc fully discards any applied filter)"
             );
+        }
+
+        #[test]
+        fn filter_cancel_returns_some_callback_when_applicator_has_on_cancel() {
+            use crate::ui::widget::{ApplyStrategy, TableFilterApplicator, TableFilterParser};
+
+            let applicator = TableFilterApplicator::new(
+                TableFilterParser::from(move |_: &str| {
+                    Ok(crate::ui::widget::TableFilterPredicate::default())
+                }),
+                ApplyStrategy::Live,
+            )
+            .with_on_cancel(crate::ui::widget::OnFilterCancel::from(
+                move |_w: &mut crate::ui::Window| {},
+            ));
+
+            let mut table = Table::builder()
+                .header(["NAME".to_string()])
+                .items([TableItem::new(vec!["a".to_string()], None)])
+                .filter_form(FilterForm::default())
+                .filter_applicator(applicator)
+                .build();
+
+            let cb = table.filter_cancel();
+            assert!(
+                cb.is_some(),
+                "filter_cancel should return on_cancel callback when applicator has one"
+            );
+            // State must still be cleared even when a callback is returned.
+            assert!(table.filter_state.is_none());
+            assert!(table.filter_error.is_none());
+        }
+
+        #[test]
+        fn filter_cancel_returns_none_when_no_applicator() {
+            let mut table = Table::builder()
+                .header(["NAME".to_string()])
+                .items([TableItem::new(vec!["a".to_string()], None)])
+                .filter_form(FilterForm::default())
+                .build();
+
+            let cb = table.filter_cancel();
+            assert!(cb.is_none(), "no applicator → filter_cancel returns None");
         }
     }
 

--- a/src/ui/widget/table/filter_applicator.rs
+++ b/src/ui/widget/table/filter_applicator.rs
@@ -106,6 +106,12 @@ define_callback!(pub TableFilterParser, Fn(&str) -> Result<TableFilterPredicate,
 // forwarding labelSelector to a poller via shared state).
 define_callback!(pub OnFilterApply, Fn(&TableFilterPredicate, &mut Window));
 
+// OnFilterCancel: called when the user cancels the filter (Esc out of
+// FilterInput or FilterConfirm). Receives only &mut Window — the predicate is
+// irrelevant at cancel time. Used by applicators that maintain server-side or
+// otherwise external state which must be cleared on cancel.
+define_callback!(pub OnFilterCancel, Fn(&mut Window));
+
 /// Controls *when* the filter is actually applied to the table rows.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ApplyStrategy {
@@ -131,6 +137,8 @@ pub struct TableFilterApplicator {
     pub(crate) help_dialog_id: Option<String>,
     /// Optional callback invoked after the filter changes.
     pub(crate) on_apply: Option<OnFilterApply>,
+    /// Optional callback invoked when the user cancels the filter (Esc).
+    pub(crate) on_cancel: Option<OnFilterCancel>,
 }
 
 impl std::fmt::Debug for TableFilterApplicator {
@@ -142,6 +150,10 @@ impl std::fmt::Debug for TableFilterApplicator {
             .field(
                 "on_apply",
                 &self.on_apply.as_ref().map(|_| "<OnFilterApply>"),
+            )
+            .field(
+                "on_cancel",
+                &self.on_cancel.as_ref().map(|_| "<OnFilterCancel>"),
             )
             .finish()
     }
@@ -155,6 +167,7 @@ impl TableFilterApplicator {
             strategy,
             help_dialog_id: None,
             on_apply: None,
+            on_cancel: None,
         }
     }
 
@@ -172,6 +185,17 @@ impl TableFilterApplicator {
     #[allow(dead_code)]
     pub fn with_on_apply(mut self, cb: OnFilterApply) -> Self {
         self.on_apply = Some(cb);
+        self
+    }
+
+    /// Attach a callback invoked when the user cancels the filter (Esc out of
+    /// FilterInput or FilterConfirm). Used by applicators that have server-side
+    /// or otherwise external state which needs to be cleared on cancel. The
+    /// callback receives `&mut Window` so it can interact with other widgets or
+    /// dialogs as needed.
+    #[allow(dead_code)]
+    pub fn with_on_cancel(mut self, cb: OnFilterCancel) -> Self {
+        self.on_cancel = Some(cb);
         self
     }
 }
@@ -465,5 +489,11 @@ mod tests {
     fn substring_applicator_on_apply_is_none() {
         let a = substring_applicator("NAME");
         assert!(a.on_apply.is_none());
+    }
+
+    #[test]
+    fn substring_applicator_on_cancel_is_none() {
+        let a = substring_applicator("NAME");
+        assert!(a.on_cancel.is_none());
     }
 }

--- a/src/workers/kube/controller.rs
+++ b/src/workers/kube/controller.rs
@@ -31,7 +31,7 @@ use crate::{
             message::NetworkMessage,
         },
         node::{
-            kube::{NodeConfig, NodeDetailWorker, NodePoller, SharedNodeColumns},
+            kube::{NodeConfig, NodeDetailWorker, NodePoller, SharedNodeColumns, SharedNodeFilter},
             message::{NodeDetailMessage, NodeMessage},
         },
         pod::{
@@ -306,6 +306,7 @@ impl KubeController {
             let shared_node_columns = Arc::new(RwLock::new(
                 node_config.default_columns.clone().unwrap_or_default(),
             ));
+            let shared_node_filter: SharedNodeFilter = Arc::new(RwLock::new(None));
 
             let contexts = kubeconfig
                 .contexts
@@ -323,6 +324,7 @@ impl KubeController {
                 shared_api_resources: shared_api_resources.clone(),
                 shared_pod_columns: shared_pod_columns.clone(),
                 shared_node_columns: shared_node_columns.clone(),
+                shared_node_filter: shared_node_filter.clone(),
                 apis_config: apis_config.clone(),
                 yaml_config: yaml_config.clone(),
                 fallback_namespaces: fallback_namespaces.clone(),
@@ -339,8 +341,13 @@ impl KubeController {
             )
             .spawn();
 
-            let node_handle =
-                NodePoller::new(tx.clone(), shared_node_columns.clone(), client.clone()).spawn();
+            let node_handle = NodePoller::new(
+                tx.clone(),
+                shared_node_columns.clone(),
+                shared_node_filter.clone(),
+                client.clone(),
+            )
+            .spawn();
 
             let config_handle =
                 ConfigPoller::new(tx.clone(), shared_target_namespaces.clone(), client.clone())
@@ -431,6 +438,7 @@ struct EventControllerArgs {
     shared_api_resources: SharedApiResources,
     shared_pod_columns: SharedPodColumns,
     shared_node_columns: SharedNodeColumns,
+    shared_node_filter: SharedNodeFilter,
     apis_config: ApisConfig,
     yaml_config: YamlConfig,
     fallback_namespaces: Option<Vec<String>>,
@@ -447,6 +455,7 @@ struct EventController {
     shared_api_resources: SharedApiResources,
     shared_pod_columns: SharedPodColumns,
     shared_node_columns: SharedNodeColumns,
+    shared_node_filter: SharedNodeFilter,
     apis_config: ApisConfig,
     yaml_config: YamlConfig,
     fallback_namespaces: Option<Vec<String>>,
@@ -464,6 +473,7 @@ impl EventController {
             shared_api_resources: args.shared_api_resources,
             shared_pod_columns: args.shared_pod_columns,
             shared_node_columns: args.shared_node_columns,
+            shared_node_filter: args.shared_node_filter,
             apis_config: args.apis_config,
             yaml_config: args.yaml_config,
             fallback_namespaces: args.fallback_namespaces,
@@ -512,6 +522,7 @@ impl Worker for EventController {
             shared_api_resources,
             shared_pod_columns,
             shared_node_columns,
+            shared_node_filter,
             apis_config,
             yaml_config,
             fallback_namespaces,
@@ -607,6 +618,10 @@ impl Worker for EventController {
                             *node_columns = req;
 
                             logger!(info, "Node columns updated: {:#?}", node_columns);
+                        }
+
+                        Kube::Node(NodeMessage::Filter(sel)) => {
+                            *shared_node_filter.write().await = sel;
                         }
 
                         Kube::Log(LogMessage::Request(req)) => {

--- a/src/workers/render/window.rs
+++ b/src/workers/render/window.rs
@@ -248,6 +248,7 @@ impl WindowInit {
         let NodeTab {
             tab: node_tab,
             node_columns_dialog,
+            node_filter_help_dialog,
         } = NodeTab::new(
             "Node",
             &self.tx,
@@ -315,6 +316,7 @@ impl WindowInit {
             log_query_help_dialog,
             pod_columns_dialog,
             node_columns_dialog,
+            node_filter_help_dialog,
             yaml_dialog,
         ];
 


### PR DESCRIPTION
Part of #920. Implements Plan 5 of the Node tab (#920), built on the `TableFilterApplicator` framework merged via #982.

## Summary

- Add a column-aware filter parser for the Node tab. Bare tokens default to `NAME`; `<COL>:<val>` targets a named column; `!<COL>:<val>` excludes; `label:<selector>` is the server-side k8s `labelSelector` (last-wins). Unknown column names produce a parse error.
- Values are parsed with the **same quoting/escape rules as the Pod log query** parser: `"..."` / `'...'` wrap values containing whitespace; `\"`, `\'`, `\\` escape inside quotes; other backslash sequences (e.g. `\s`) are preserved so regex character classes survive. This lets you filter space-containing columns like `OS-IMAGE:"Ubuntu 22.04.3 LTS"`.
- Wire `node_filter_applicator(label_registry, tx)` into the Node tab via `Table::builder().filter_applicator(...)`. The applicator uses `ApplyStrategy::EnterToConfirm` so parsing only runs on Enter (avoids kube API spam mid-typing).
- Forward the parsed `label_selector` to the Node poller via `NodeMessage::Filter(Option<String>)`. The poller appends `?labelSelector=...` to `/api/v1/nodes` requests on the next tick (mirrors the existing `SharedNodeColumns` plumbing via a new `SharedNodeFilter = Arc<RwLock<Option<String>>>`).
- Add the Node filter help dialog (`?` or `help` while in filter input). Hooked via `TableFilterApplicator::with_help_dialog(NODE_FILTER_HELP_DIALOG_ID)`.

### Framework changes carried in this PR (touch `src/ui/widget/table*`)

Two issues surfaced during manual testing of the server-side filter, both rooted in the PR A framework (no prior applicator exercised them). Fixed here:

- **`on_cancel` hook** (`OnFilterCancel`, `Fn(&mut Window)`, symmetric to `OnFilterApply`). Previously `Table::filter_cancel` only reset local UI state, so an applicator with server-side state (the Node labelSelector) had no way to learn the user pressed Esc — the server filter persisted across cancels, including unrecoverable states where a bad `labelSelector` raised `widget_error`. Node now wires `on_cancel` to send `NodeMessage::Filter(None)`, clearing `SharedNodeFilter` so the next poll fetches all nodes and any prior server error clears.
- **Filter help keeps `FilterInput` mode.** Typing `?` used to reset the Table to Normal mode, so dismissing the help left the user outside the filter (had to press `/` again). The filter help is contextual ("peek at syntax, then keep typing"), so the widget now stays in `FilterInput`; only the `?`/`help` text is cleared.

This **replaces** the earlier Plan 5 design that lived on the unmerged `920-node-filter` branch (standalone dialog widget).

## Filter syntax (recap from the help dialog)

```
worker                          NAME matches 'worker' (regex, substring)
^worker$                        anchored exact match
NAME:gke STATUS:Ready           NAME~gke AND STATUS~Ready
STATUS:^Ready$ STATUS:^NotReady$  STATUS in (Ready, NotReady)
!NAME:control                   exclude NAME matching 'control'
label:role=worker               server-side k8s labelSelector
OS-IMAGE:"Ubuntu 22.04 LTS"     quoted value with whitespace
```

- Values are **regex** (substring by default; use `^...$` to anchor).
- Same column, multiple includes → OR (in-list); different columns → AND; any matching exclude removes the row.
- Column names are case-insensitive; unknown columns produce a parse error.

## Automated checks

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --bin kubetui --all-targets` — no new warnings (the pre-existing `too_many_arguments` warnings grew due to two added plumbing args; same call sites, not new)
- [x] `cargo test --all` — 624 passed / 0 failed
- [x] Unit tests: parser (28 cases incl. quoting/escape), URL builder (labelSelector appended/omitted), unknown-column errors, applicator construction, `on_cancel` callback return, help keeps FilterInput mode.

## Manual verification (done)

- [x] `/` opens the inline filter form (no separate dialog).
- [x] Bare token filters NAME by regex substring. `ApplyStrategy::EnterToConfirm`: no live filtering while typing — applies on Enter.
- [x] `STATUS:Ready` matches via regex (so also `NotReady`); `STATUS:^Ready$` anchors to exact.
- [x] `NAME:.. STATUS:..` → cross-column AND. `STATUS:^Ready$ STATUS:^NotReady$` → same-column OR.
- [x] `!NAME:control` excludes; include + exclude combine.
- [x] `label:<selector>` filters server-side (count matches `kubectl get nodes -l <selector>`); clearing restores all nodes.
- [x] **Esc clears the server-side labelSelector** (next poll drops `?labelSelector=`). Recovers from a bad-labelSelector `widget_error` state.
- [x] `OS-IMAGE:"Ubuntu 22.04"` (quoted) keeps whitespace as one regex value; unquoted splits into separate tokens (expected).
- [x] `statusu:Ready` (typo) shows a sticky `unknown column 'statusu'` overlay that survives polling ticks; Esc clears it.
- [x] `?` (or `help`) opens the Node Filter Help dialog; Enter closes it and returns to the (empty) filter input still in FilterInput mode.
- [x] Regression: `t` column dialog, Enter detail pane (YAML + related Pods), label columns, and tab switching all unaffected.

## Design docs

- Spec: `docs/superpowers/specs/2026-05-27-table-filter-redesign.md` §Node tab
- Plan: `docs/superpowers/plans/2026-05-27-node-filter-applicator.md`

## Known follow-up (out of scope)

- **Title display** (`Node [matched/total]` while a filter is active): needs a public `Table::filter_state()` accessor that PR A did not expose. Deferred to a small follow-up (add the accessor, then a one-line `block_injection` on `node.rs`).

## Stack context

Both prerequisites (#982 TableFilterApplicator, #979 Node Plans 1-4) are already on `main`; this branch starts cleanly from `main` (no stacked base).