### PR TITLE
fix(pod): apply theme to log query help dialog

### DIFF
--- a/src/features/pod/view/tab.rs
+++ b/src/features/pod/view/tab.rs
@@ -49,8 +49,8 @@ impl PodTab {
         let pod_widget = pod_widget(tx, theme.clone());
         let log_query_widget = log_query_widget(tx, namespaces, theme.clone());
         let pod_columns_dialog = pod_columns_dialog(tx, default_columns, theme.clone());
-        let log_widget = log_widget(tx, clipboard, theme, log_max_lines);
-        let log_query_help_widget = log_query_help_widget();
+        let log_widget = log_widget(tx, clipboard, theme.clone(), log_max_lines);
+        let log_query_help_widget = log_query_help_widget(theme);
 
         let layout = TabLayout::new(layout, split_direction);
 

--- a/src/features/pod/view/widgets/log_query_help.rs
+++ b/src/features/pod/view/widgets/log_query_help.rs
@@ -2,19 +2,33 @@ use indoc::indoc;
 use ratatui::crossterm::event::KeyCode;
 
 use crate::{
+    config::theme::WidgetThemeConfig,
     features::component_id::POD_LOG_QUERY_HELP_DIALOG_ID,
     message::UserEvent,
     ui::{
         event::EventResult,
-        widget::{Text, Widget, WidgetBase},
+        widget::{SearchForm, SearchFormTheme, Text, TextTheme, Widget, WidgetBase, WidgetTheme},
         Window,
     },
 };
 
-pub fn log_query_help_widget() -> Widget<'static> {
+pub fn log_query_help_widget(theme: WidgetThemeConfig) -> Widget<'static> {
+    let widget_theme = WidgetTheme::from(theme.clone());
+    let text_theme = TextTheme::from(theme.clone());
+    let search_theme = SearchFormTheme::from(theme);
+
+    let widget_base = WidgetBase::builder()
+        .title("Log Query Help")
+        .theme(widget_theme)
+        .build();
+
+    let search_form = SearchForm::builder().theme(search_theme).build();
+
     Text::builder()
         .id(POD_LOG_QUERY_HELP_DIALOG_ID)
-        .widget_base(WidgetBase::builder().title("Log Query Help").build())
+        .widget_base(widget_base)
+        .search_form(search_form)
+        .theme(text_theme)
         .items(content())
         .action(UserEvent::from(KeyCode::Enter), close_dialog())
         .build()


### PR DESCRIPTION
## Summary

`log_query_help_widget` (the `?`/`help` dialog in the Pod log query input) built its `WidgetBase`, `Text`, and `SearchForm` without a theme, so the dialog rendered with default styling instead of the configured component theme. This is inconsistent with `pod_columns_dialog` and the general `HelpDialog`, which both apply `WidgetTheme` / `TextTheme` / `SearchFormTheme`.

Discovered while building the Node tab filter help dialog (#983), which had the same omission — this PR fixes the pre-existing Pod side.

## Changes

- `log_query_help_widget` now takes `theme: WidgetThemeConfig` and applies:
  - `WidgetTheme::from(theme)` on the `WidgetBase`
  - `TextTheme::from(theme)` on the `Text` widget
  - `SearchFormTheme::from(theme)` on a themed `SearchForm`
  - (mirrors `HelpDialog::new`)
- `PodTab::new` threads its existing `theme` into the call.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --bin kubetui --all-targets` — no new warnings
- [x] `cargo test --all` — 589 passed / 0 failed
- [ ] Manual: open the Pod tab, focus the log query input, type `?` (or `help`) → the **Log Query Help** dialog frame, body text, and search bar all follow the configured theme.