### PR TITLE
feat(node): show [selected/total] indicator in Node title

### DIFF
--- a/src/features/node/view/widgets/node.rs
+++ b/src/features/node/view/widgets/node.rs
@@ -51,9 +51,30 @@ pub fn node_widget(
         .filter_applicator(node_filter_applicator(label_registry, tx.clone()))
         .theme(table_theme)
         .action('t', open_node_columns_dialog())
+        .block_injection(block_injection())
         .on_select(on_select(tx))
         .build()
         .into()
+}
+
+/// Append a `[selected/visible]` indicator to the Node title, matching the
+/// Pod / Config / Network tabs. When a filter is active the visible count
+/// (denominator) shrinks, which is the same implicit filter feedback the
+/// other tabs provide.
+fn block_injection() -> impl Fn(&Table) -> WidgetBase {
+    |table: &Table| {
+        let index = if let Some(index) = table.state().selected() {
+            index + 1
+        } else {
+            0
+        };
+
+        let mut base = table.widget_base().clone();
+
+        *base.append_title_mut() = Some(format!(" [{}/{}]", index, table.items().len()).into());
+
+        base
+    }
 }
 
 fn open_node_columns_dialog() -> impl Fn(&mut Window) -> EventResult {


### PR DESCRIPTION
Part of #920. Follow-up from #983 (Node filter).

## Summary

The Node tab was the only Table-based tab **without** the `[selected/total]` title indicator that Pod / Config / Network all show. Add the same `block_injection` so every list tab is consistent.

```
Node [3/12]      cursor at row 3 of 12 visible rows
Node [1/3]       after a filter narrows the list to 3 rows
```

## Design note (why not `[matched/total]`)

An earlier revision of this PR showed `[matched/total]` (filtered count over original total), but that diverged from the established convention: Pod / Config / Network all use `[cursor/visible]` and convey filtering implicitly via the shrinking denominator. Two tabs showing the same `[x/y]` brackets with different meanings is confusing, so this PR adopts the **identical** convention instead. No new `Table` accessors are needed — it reuses `state().selected()` and `items().len()` exactly like the sibling tabs.

## Changes

- Add `block_injection` to `node_widget` appending ` [selected/visible]` to the title (verbatim copy of the Pod/Config/Network pattern).

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --bin kubetui --all-targets` — no new warnings
- [x] `cargo test --all` — 624 passed / 0 failed
- [ ] Manual: Node tab shows `Node [n/total]`; moving the cursor updates the numerator; applying a filter shrinks the denominator; clearing restores it — matching Pod/Config/Network behavior.