### PR TITLE
feat(table): show pre-filter total in title when filtering

### DIFF
--- a/src/features/config/view/widgets/config.rs
+++ b/src/features/config/view/widgets/config.rs
@@ -54,15 +54,9 @@ pub fn config_widget(tx: &Sender<Message>, theme: WidgetThemeConfig) -> Widget<'
 
 fn block_injection() -> impl Fn(&Table) -> WidgetBase {
     |table: &Table| {
-        let index = if let Some(index) = table.state().selected() {
-            index + 1
-        } else {
-            0
-        };
-
         let mut base = table.widget_base().clone();
 
-        *base.append_title_mut() = Some(format!(" [{}/{}]", index, table.items().len()).into());
+        *base.append_title_mut() = Some(table.count_indicator().into());
 
         base
     }

--- a/src/features/network/view/widgets/network.rs
+++ b/src/features/network/view/widgets/network.rs
@@ -62,15 +62,9 @@ pub fn network_widget(tx: &Sender<Message>, theme: WidgetThemeConfig) -> Widget<
 
 fn block_injection() -> impl Fn(&Table) -> WidgetBase {
     |table: &Table| {
-        let index = if let Some(index) = table.state().selected() {
-            index + 1
-        } else {
-            0
-        };
-
         let mut base = table.widget_base().clone();
 
-        *base.append_title_mut() = Some(format!(" [{}/{}]", index, table.items().len()).into());
+        *base.append_title_mut() = Some(table.count_indicator().into());
 
         base
     }

--- a/src/features/node/view/widgets/node.rs
+++ b/src/features/node/view/widgets/node.rs
@@ -57,21 +57,13 @@ pub fn node_widget(
         .into()
 }
 
-/// Append a `[selected/visible]` indicator to the Node title, matching the
-/// Pod / Config / Network tabs. When a filter is active the visible count
-/// (denominator) shrinks, which is the same implicit filter feedback the
-/// other tabs provide.
+/// Append the shared `[selected/visible (total)]` count indicator to the
+/// Node title, matching the Pod / Config / Network tabs.
 fn block_injection() -> impl Fn(&Table) -> WidgetBase {
     |table: &Table| {
-        let index = if let Some(index) = table.state().selected() {
-            index + 1
-        } else {
-            0
-        };
-
         let mut base = table.widget_base().clone();
 
-        *base.append_title_mut() = Some(format!(" [{}/{}]", index, table.items().len()).into());
+        *base.append_title_mut() = Some(table.count_indicator().into());
 
         base
     }

--- a/src/features/pod/view/widgets/pod.rs
+++ b/src/features/pod/view/widgets/pod.rs
@@ -74,15 +74,9 @@ fn open_pod_columns_dialog() -> impl Fn(&mut Window) -> EventResult {
 
 fn block_injection() -> impl Fn(&Table) -> WidgetBase {
     |table: &Table| {
-        let index = if let Some(index) = table.state().selected() {
-            index + 1
-        } else {
-            0
-        };
-
         let mut base = table.widget_base().clone();
 
-        *base.append_title_mut() = Some(format!(" [{}/{}]", index, table.items().len()).into());
+        *base.append_title_mut() = Some(table.count_indicator().into());
 
         base
     }

--- a/src/ui/widget/table.rs
+++ b/src/ui/widget/table.rs
@@ -280,6 +280,22 @@ impl Table<'_> {
         &self.state
     }
 
+    /// Title suffix showing the cursor position over the visible row count,
+    /// e.g. ` [3/12]`. When a filter hides some rows the pre-filter total is
+    /// appended in parens: ` [3/12 (50)]`. Shared by every list tab's
+    /// `block_injection` so the indicator stays consistent.
+    pub fn count_indicator(&self) -> String {
+        let index = self.state.selected().map(|i| i + 1).unwrap_or(0);
+        let visible = self.items.len();
+        let total = self.items.original_len();
+
+        if visible == total {
+            format!(" [{}/{}]", index, visible)
+        } else {
+            format!(" [{}/{} ({})]", index, visible, total)
+        }
+    }
+
     pub fn equal_header(&self, header: &[String]) -> bool {
         self.items.header().original() == header
     }
@@ -1130,6 +1146,74 @@ mod tests {
 
             let cb = table.filter_cancel();
             assert!(cb.is_none(), "no applicator → filter_cancel returns None");
+        }
+    }
+
+    mod count_indicator {
+        use std::collections::HashMap;
+
+        use regex::Regex;
+
+        use super::*;
+
+        fn table_with_three() -> Table<'static> {
+            Table::builder()
+                .header(["NAME".to_string()])
+                .items([
+                    TableItem::new(vec!["aaa".to_string()], None),
+                    TableItem::new(vec!["bbb".to_string()], None),
+                    TableItem::new(vec!["aab".to_string()], None),
+                ])
+                .build()
+        }
+
+        #[test]
+        fn unfiltered_shows_selected_over_total_without_parens() {
+            let table = table_with_three();
+            // builder selects the first row when items are non-empty.
+            assert_eq!(table.count_indicator(), " [1/3]");
+        }
+
+        #[test]
+        fn no_selection_shows_zero_numerator() {
+            let mut table = table_with_three();
+            table.state = TableState::default();
+            assert_eq!(table.count_indicator(), " [0/3]");
+        }
+
+        #[test]
+        fn filtered_appends_pre_filter_total_in_parens() {
+            let mut table = table_with_three();
+
+            let mut column_includes = HashMap::new();
+            column_includes.insert("name".to_string(), vec![Regex::new("aa").unwrap()]);
+            table.filter_state = Some(TableFilterPredicate {
+                column_includes,
+                column_excludes: HashMap::new(),
+                label_selector: None,
+                raw: "aa".to_string(),
+            });
+            table.filter_items();
+
+            // aaa, aab match → 2 visible of 3 total.
+            assert_eq!(table.count_indicator(), " [1/2 (3)]");
+        }
+
+        #[test]
+        fn zero_matches_shows_zero_over_zero_with_total() {
+            let mut table = table_with_three();
+
+            let mut column_includes = HashMap::new();
+            column_includes.insert("name".to_string(), vec![Regex::new("zzz").unwrap()]);
+            table.filter_state = Some(TableFilterPredicate {
+                column_includes,
+                column_excludes: HashMap::new(),
+                label_selector: None,
+                raw: "zzz".to_string(),
+            });
+            table.filter_items();
+
+            assert_eq!(table.count_indicator(), " [0/0 (3)]");
         }
     }
 

--- a/src/ui/widget/table.rs
+++ b/src/ui/widget/table.rs
@@ -281,18 +281,25 @@ impl Table<'_> {
     }
 
     /// Title suffix showing the cursor position over the visible row count,
-    /// e.g. ` [3/12]`. When a filter hides some rows the pre-filter total is
-    /// appended in parens: ` [3/12 (50)]`. Shared by every list tab's
-    /// `block_injection` so the indicator stays consistent.
+    /// e.g. ` [3/12]`. While a filter is active the pre-filter total is
+    /// appended in parens: ` [3/12 (50)]`. The parens are driven by filter
+    /// state (not by `visible != total`), so a filter that happens to match
+    /// every row still signals that the list is filtered. Shared by every
+    /// list tab's `block_injection` so the indicator stays consistent.
     pub fn count_indicator(&self) -> String {
         let index = self.state.selected().map(|i| i + 1).unwrap_or(0);
         let visible = self.items.len();
         let total = self.items.original_len();
 
-        if visible == total {
-            format!(" [{}/{}]", index, visible)
-        } else {
+        let filter_active = self
+            .filter_state
+            .as_ref()
+            .is_some_and(|predicate| !predicate.raw.is_empty());
+
+        if filter_active {
             format!(" [{}/{} ({})]", index, visible, total)
+        } else {
+            format!(" [{}/{}]", index, visible)
         }
     }
 
@@ -1197,6 +1204,26 @@ mod tests {
 
             // aaa, aab match → 2 visible of 3 total.
             assert_eq!(table.count_indicator(), " [1/2 (3)]");
+        }
+
+        #[test]
+        fn active_filter_matching_every_row_still_shows_total() {
+            let mut table = table_with_three();
+
+            // A predicate whose regex matches all three names. The filter is
+            // active (non-empty raw), so the total must still be shown even
+            // though visible == total.
+            let mut column_includes = HashMap::new();
+            column_includes.insert("name".to_string(), vec![Regex::new("a|b").unwrap()]);
+            table.filter_state = Some(TableFilterPredicate {
+                column_includes,
+                column_excludes: HashMap::new(),
+                label_selector: None,
+                raw: "a|b".to_string(),
+            });
+            table.filter_items();
+
+            assert_eq!(table.count_indicator(), " [1/3 (3)]");
         }
 
         #[test]

--- a/src/ui/widget/table/item.rs
+++ b/src/ui/widget/table/item.rs
@@ -76,6 +76,12 @@ impl InnerItem<'_> {
         self.filtered_items.len()
     }
 
+    /// Number of items before any filter is applied. `len()` returns the
+    /// post-filter (visible) count; this returns the pre-filter total.
+    pub fn original_len(&self) -> usize {
+        self.original_items.len()
+    }
+
     pub fn is_empty(&self) -> bool {
         self.filtered_items.is_empty()
     }


### PR DESCRIPTION
## Summary

Every list tab's title shows a `[selected/visible]` indicator. When a filter is active, there was no cue how many rows existed *before* filtering. This appends the pre-filter total in parens **whenever a filter is active**:

```
Unfiltered:            Pod [3/50]
Filtered (narrowed):   Pod [3/12 (50)]     ← 12 of 50 shown
Filtered (all match):  Pod [1/3 (3)]       ← still flagged as filtered
Filtered (no match):   Pod [0/0 (50)]
```

The parens are driven by **filter state**, not by `visible != total`. A filter that happens to match every row (or a server-side `label:` filter where the fetched set already equals the visible set) still shows the total, so "filtered, all match" is visually distinct from "not filtered". Unfiltered lists are unchanged.

## Changes

- `Table::count_indicator()` — builds the title suffix (` [sel/visible]`, or ` [sel/visible (total)]` while filtering). Centralizes logic that was duplicated inline in four `block_injection` functions.
- `InnerItem::original_len()` — the pre-filter row count.
- Pod / Config / Network / Node `block_injection` now call `count_indicator()`, so the indicator is identical across all list tabs.

## Scope / consistency

Applies uniformly to all four Table-based list tabs (Pod, Config, Network, Node). The bracket meaning is unchanged everywhere: `selected / visible`, with `(total)` added only while a filter is active.

Note: for a server-side `label:` filter the fetched total already equals the visible count, so it renders as e.g. `[3/12 (12)]` — redundant numerically but still a clear "this list is filtered" signal, consistent with client-side filters.

A richer per-resource breakdown (e.g. status value counts) was considered but deferred — it needs per-resource column knowledge and a config model, to be designed separately.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --bin kubetui --all-targets` — no new warnings
- [x] `cargo test --all` — 629 passed / 0 failed (5 `count_indicator` tests: unfiltered, no-selection, filtered-narrowed-with-total, filter-matching-all-still-shows-total, zero-matches)
- [x] Manual: on a list tab, filter to narrow the list → `[sel/visible (total)]`; apply a filter that matches every row → still shows `(total)`; clear the filter → returns to `[sel/total]`; cursor movement updates the numerator.