### PR TITLE
fix(kube): force exec auth plugins non-interactive so stderr can't corrupt the TUI

### DIFF
--- a/src/kube.rs
+++ b/src/kube.rs
@@ -1,4 +1,5 @@
 pub mod apis;
+pub mod auth;
 mod client;
 pub mod context;
 pub mod proxy;

--- a/src/kube/auth.rs
+++ b/src/kube/auth.rs
@@ -1,0 +1,89 @@
+use kube::config::ExecInteractiveMode;
+
+use crate::logger;
+
+/// Force any exec credential plugin to run non-interactively.
+///
+/// kube-rs runs exec auth plugins (e.g. `gke-gcloud-auth-plugin`) with
+/// **inherited** stdin/stderr whenever `interactiveMode` is anything but
+/// `Never` (`auth_exec` in kube-client). When such a plugin writes to
+/// stderr during a token refresh — which GKE plugins do on token expiry,
+/// e.g. after the machine resumes from sleep — that output lands directly
+/// on the terminal. Our TUI draws on the alternate screen via stdout and
+/// never redirects stderr, so the plugin's stderr corrupts the display.
+///
+/// Forcing `Never` makes kube-rs capture the plugin's stderr instead: a
+/// failing refresh comes back as an `Err`, which we surface through the
+/// normal `NotifyError` path (shown inside the widget) rather than smeared
+/// across the screen. Interactive prompting would corrupt a TUI anyway, so
+/// non-interactive is the correct mode here — a token that needs a fresh
+/// interactive login simply fails and tells the user to re-authenticate
+/// outside kubetui.
+pub fn force_non_interactive_exec(config: &mut kube::Config) {
+    if let Some(exec) = config.auth_info.exec.as_mut() {
+        logger!(
+            debug,
+            "forcing exec auth interactiveMode=Never (was {:?})",
+            exec.interactive_mode
+        );
+        exec.interactive_mode = Some(ExecInteractiveMode::Never);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use kube::config::{AuthInfo, ExecConfig};
+
+    use super::*;
+
+    fn config_with_exec(interactive_mode: Option<ExecInteractiveMode>) -> kube::Config {
+        let mut config = kube::Config::new("https://example.com".parse().unwrap());
+        config.auth_info = AuthInfo {
+            exec: Some(ExecConfig {
+                api_version: None,
+                command: Some("some-auth-plugin".to_string()),
+                args: None,
+                env: None,
+                drop_env: None,
+                interactive_mode,
+                provide_cluster_info: false,
+                cluster: None,
+            }),
+            ..Default::default()
+        };
+        config
+    }
+
+    #[test]
+    fn sets_interactive_mode_to_never_when_unspecified() {
+        let mut config = config_with_exec(None);
+
+        force_non_interactive_exec(&mut config);
+
+        assert_eq!(
+            config.auth_info.exec.unwrap().interactive_mode,
+            Some(ExecInteractiveMode::Never)
+        );
+    }
+
+    #[test]
+    fn overrides_an_interactive_mode_to_never() {
+        let mut config = config_with_exec(Some(ExecInteractiveMode::IfAvailable));
+
+        force_non_interactive_exec(&mut config);
+
+        assert_eq!(
+            config.auth_info.exec.unwrap().interactive_mode,
+            Some(ExecInteractiveMode::Never)
+        );
+    }
+
+    #[test]
+    fn no_op_when_there_is_no_exec_auth() {
+        let mut config = kube::Config::new("https://example.com".parse().unwrap());
+
+        force_non_interactive_exec(&mut config);
+
+        assert!(config.auth_info.exec.is_none());
+    }
+}

--- a/src/workers/kube/store.rs
+++ b/src/workers/kube/store.rs
@@ -82,6 +82,7 @@ impl KubeStore {
         let mut config = Config::from_custom_kubeconfig(config.clone(), &options).await?;
 
         crate::kube::proxy::clear_proxy_if_no_proxy_matches(&mut config);
+        crate::kube::auth::force_non_interactive_exec(&mut config);
 
         let target_namespace = config.default_namespace.to_string();
 


### PR DESCRIPTION
## Problem

After the machine resumes from sleep, a GKE auth token expires. On the next poll kube-rs re-runs the exec credential plugin (`gke-gcloud-auth-plugin` / `gcloud`) to refresh it, and the plugin writes to **stderr**. The error text is smeared across the whole screen and re-appended on every poll — it does **not** appear inside a widget.

## Root cause

`kube-client`'s `auth_exec` (auth/mod.rs) runs the plugin with inherited stdin/stderr whenever `interactiveMode` is anything but `Never`:

```rust
let interactive = auth.interactive_mode != Some(ExecInteractiveMode::Never);
if interactive {
    cmd.stdin(std::process::Stdio::inherit());
    cmd.stderr(std::process::Stdio::inherit());   // ← inherited → hits the terminal
} else {
    cmd.stdin(std::process::Stdio::piped());        // stderr is captured into the Result
}
```

A GKE kubeconfig typically leaves `interactiveMode` unset, so it is treated as interactive and stderr is inherited. kubetui draws on the **alternate screen via stdout** (`workers/render.rs`) and never redirects stderr, so the plugin's stderr lands directly on the terminal and corrupts the TUI. kubetui's own logger writes to a file only, so it is not involved; and because the leak is raw stderr, it never reaches the normal error-display path.

## Fix

Add `kube::auth::force_non_interactive_exec`, which sets the resolved `Config`'s exec `interactiveMode` to `Never` before `Client::try_from`, right next to the existing `clear_proxy_if_no_proxy_matches` step in `KubeStore::build_state`. With `interactive=false`, kube-rs **captures** the plugin's stderr (into the `Output`) instead of inheriting it to the terminal, so the TUI is never corrupted.

Interactive prompting would corrupt a TUI regardless, so non-interactive is the correct mode: a token that needs a fresh interactive login simply fails and the user re-authenticates outside kubetui.

Only the TUI client path is changed; CLI subcommands (context/namespace listing) are not in a TUI and are left as-is.

## Behavior after the fix (verified with a synthetic exec plugin)

`Client::try_from` runs `auth_exec` **eagerly** at startup (`Auth::try_from`), and `RefreshableToken::Exec` re-runs it lazily on later requests when the token has expired. So an exec failure surfaces differently depending on when it happens:

| When the exec plugin fails | What the user sees |
|---|---|
| **At startup** (initial credential acquisition in `build_state`) | `Client::try_from` → `KubeController::new` returns `Err` → app exits with a clean `Error: auth error: ...` on the shell (no TUI corruption). Acceptable: kubetui cannot start without initial credentials. |
| **At runtime** (lazy refresh inside a poller request, e.g. token expires while running — the actual reported scenario) | The request fails with `ServiceError: auth exec command ... failed` (the captured stderr is in the message). The poller sends it as `Poll(Err)`, which `action.rs` renders **inside the widget body** via `set_widget_error`. The app keeps running and recovers automatically once the plugin succeeds again. |
| Plugin succeeds but the token is rejected by the API | `ApiError: Unauthorized (401)` inside the widget (normal API error path). |

In every case stderr is captured, so the screen is never corrupted — which is the bug this PR fixes.

## Reproduction & verification

A synthetic exec plugin reproduces the exact code path without touching real GKE credentials.

**Original bug (stderr corrupts the TUI), before the fix** — exec succeeds but writes to stderr, with a past `expirationTimestamp` so it re-runs every request:

```yaml
exec:
  apiVersion: client.authentication.k8s.io/v1beta1
  command: sh
  args:
    - -c
    - |
      echo "SIMULATED AUTH PLUGIN STDERR: token expired, reauth required" >&2
      echo '{"apiVersion":"client.authentication.k8s.io/v1beta1","kind":"ExecCredential","status":{"token":"fake","expirationTimestamp":"2000-01-01T00:00:00Z"}}'
  # interactiveMode omitted → kube-rs inherits stderr (the bug)
```

Before the fix the `SIMULATED...` line repeatedly overwrites the TUI. After the fix the screen stays clean.

**Runtime refresh failure surfaces in the widget (verified)** — a marker file flips the plugin to fail after startup:

```yaml
args:
  - -c
  - |
    if [ -f /tmp/kubetui-fail-auth ]; then
      echo "SIMULATED RUNTIME REFRESH FAILURE" >&2
      exit 1
    fi
    echo '{"apiVersion":"client.authentication.k8s.io/v1beta1","kind":"ExecCredential","status":{"token":"fake","expirationTimestamp":"2000-01-01T00:00:00Z"}}'
```

- Start with the marker absent → app starts. `touch /tmp/kubetui-fail-auth` → the widget shows `ServiceError: auth exec command ... failed` (captured `stderr: "SIMULATED RUNTIME REFRESH FAILURE\n"`) and the app keeps running. `rm` the marker → recovers on the next poll. ✅

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --bin kubetui --all-targets` — no new warnings
- [x] `cargo test --all` — 632 passed / 0 failed (3 new `kube::auth` tests: sets Never when unspecified, overrides to Never, no-op without exec auth)
- [x] Manual: TUI no longer corrupted by exec-plugin stderr; runtime refresh failure shows `ServiceError` inside the widget and the app keeps running; startup credential failure exits with a clean error.