### PR TITLE
fix(table-filter): header-aware column validation & name normalization

### DIFF
--- a/docs/superpowers/plans/2026-05-29-table-filter-header-aware-validation.md
+++ b/docs/superpowers/plans/2026-05-29-table-filter-header-aware-validation.md
@@ -1,0 +1,626 @@
+# Table フィルタ header ベース列検証 実装計画
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 共有 Table フィルタの列検証を live header に対して行い、列名を正規化（空白・`-`・`_` 除去）することで、複数語の列をフィルタ可能にし（課題 I）、非表示列の指定を「全行が消える」から明示的な parse error に変える（課題 II）。
+
+**Architecture:** `TableFilterParser` コールバックに現在の表示 header を渡すようシグネチャを拡張し、共有 `normalize_column_name` ヘルパーで `cell_of`（マッチ側）と Node パーサ（検証側）の列名比較を正規化で統一する。Node パーサは builtin enum / label registry のスナップショットではなく live header に対して検証するようになり、`node_filter_applicator` の `label_registry` 引数は不要になって削除される。`substring_applicator`（Pod/Config/Network）は header を無視するだけで挙動不変。Pod の column-aware 移行は本計画の対象外（Phase B）。
+
+**Tech Stack:** Rust 2021、nom（パーサ）、regex、ratatui、strum、`#[cfg(test)]` インラインユニットテスト、pretty_assertions。
+
+参照 spec: `docs/superpowers/specs/2026-05-29-table-filter-header-aware-validation-design.md`
+
+---
+
+## ファイル構成
+
+修正対象（新規ファイルは無し）:
+
+- `src/ui/widget/table/filter_applicator.rs` — `normalize_column_name` ヘルパー追加、`cell_of` を正規化比較に変更、`TableFilterParser` のシグネチャ変更、`substring_applicator` のクロージャ更新、ユニットテスト追加。
+- `src/ui/widget/table.rs` — `run_parser_and_update_state` でパーサに `&header` を渡す。モジュール内テスト用パーサのクロージャ更新。
+- `src/features/node/filter.rs` — `node_filter_applicator` から `label_registry` 引数を削除、クロージャが header を受け取り `parse_node_filter(input, header)` を呼ぶ。`NodeLabelColumn` import 削除。テスト更新。
+- `src/features/node/filter/parser.rs` — `parse_node_filter` が `header: &[String]` を受け取る、`valid_columns` を header ベースに変更、列キーを正規化、エラー文言変更、空 header で検証スキップ。import 整理。テスト群を header ベースへ移行＋新規テスト追加。
+- `src/features/node/view/widgets/node.rs` — `node_widget` から `label_registry` 引数を削除、`node_filter_applicator(tx.clone())` 呼び出しに変更。`NodeLabelColumn` import 削除。
+- `src/features/node/view/tab.rs` — `node_widget` 呼び出しから `label_registry.clone()` を外す（`label_registry` は引き続き `node_columns_dialog` で使うため `NodeTab::new` の引数は残す）。
+- `src/features/node/view/widgets/node_filter_help.rs` — ヘルプ文言を「表示中の列だけがフィルタ可能」へ更新。
+
+---
+
+## Task 1: `normalize_column_name` ヘルパーと `cell_of` の正規化
+
+**Files:**
+- Modify: `src/ui/widget/table/filter_applicator.rs:80-89`（`cell_of`）, 新規ヘルパー追加, テストモジュール `src/ui/widget/table/filter_applicator.rs:244-`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`src/ui/widget/table/filter_applicator.rs` のテストモジュール（`mod tests { use super::*; ... }`、`make_item` ヘルパーがある箇所）に以下を追加する。
+
+```rust
+    #[test]
+    fn normalize_column_name_strips_space_hyphen_underscore_and_lowercases() {
+        assert_eq!(normalize_column_name("NOMINATED NODE"), "nominatednode");
+        assert_eq!(normalize_column_name("Internal-IP"), "internalip");
+        assert_eq!(normalize_column_name("Readiness_Gates"), "readinessgates");
+        assert_eq!(normalize_column_name("name"), "name");
+    }
+
+    #[test]
+    fn matches_resolves_multiword_column_via_normalized_key() {
+        let header = vec!["NAME".to_string(), "NOMINATED NODE".to_string()];
+        let item = make_item(&["pod-a", "node-x"]);
+
+        let mut includes = HashMap::new();
+        includes.insert(
+            "nominatednode".to_string(),
+            vec![Regex::new("node-x").unwrap()],
+        );
+        let pred = TableFilterPredicate {
+            column_includes: includes,
+            ..Default::default()
+        };
+
+        assert!(pred.matches(&item, &header));
+    }
+
+    #[test]
+    fn matches_resolves_hyphenated_header_from_compact_key() {
+        let header = vec!["NAME".to_string(), "INTERNAL-IP".to_string()];
+        let item = make_item(&["pod-a", "10.0.0.1"]);
+
+        let mut includes = HashMap::new();
+        includes.insert(
+            "internalip".to_string(),
+            vec![Regex::new(r"10\.0").unwrap()],
+        );
+        let pred = TableFilterPredicate {
+            column_includes: includes,
+            ..Default::default()
+        };
+
+        assert!(pred.matches(&item, &header));
+    }
+```
+
+注: テストモジュール冒頭は `use super::*;` で、親モジュールは `HashMap`（`std::collections`）と `Regex`（`regex`）を import 済み。`make_item(&[...])` は既存ヘルパー（`TableItem` を作る）。
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `cargo test --lib ui::widget::table::filter_applicator 2>&1 | tail -30`
+Expected: コンパイルエラー `cannot find function 'normalize_column_name'`（まだ未定義のため）。
+
+- [ ] **Step 3: `normalize_column_name` を実装し `cell_of` を更新**
+
+`src/ui/widget/table/filter_applicator.rs` の `cell_of` 関数（現状 80-89 行）を以下に置き換える。
+
+```rust
+/// Normalize a column name for case/format-insensitive comparison: lowercase,
+/// with spaces, hyphens, and underscores removed. This lets `nominatednode`,
+/// `nominated-node`, and `Nominated_Node` all match the `NOMINATED NODE`
+/// header, and keeps hyphenated headers (e.g. `INTERNAL-IP`) matchable from a
+/// single whitespace-delimited token.
+pub fn normalize_column_name(s: &str) -> String {
+    s.to_lowercase().replace([' ', '-', '_'], "")
+}
+
+/// Returns the ANSI-stripped text of the column named `col_name` in `item`,
+/// or `None` if no header column normalizes to the same key.
+fn cell_of(item: &TableItem, header: &[String], col_name: &str) -> Option<String> {
+    let key = normalize_column_name(col_name);
+    let idx = header
+        .iter()
+        .position(|h| normalize_column_name(h) == key)?;
+
+    item.item
+        .get(idx)
+        .map(|c| c.styled_graphemes_symbols().concat())
+}
+```
+
+（既存の `cell_of` 上にあった `// TODO(perf): ...` コメントはそのまま残してよい。`pub fn normalize_column_name` は後続 Task で Node パーサからも使う。）
+
+- [ ] **Step 4: テストを実行して成功を確認**
+
+Run: `cargo test --lib ui::widget::table::filter_applicator 2>&1 | tail -30`
+Expected: PASS（新規3テスト＋既存テストすべて green）。
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/ui/widget/table/filter_applicator.rs
+git commit -m "feat(table-filter): normalize column names (space/-/_) in cell_of matching"
+```
+
+---
+
+## Task 2: `TableFilterParser` に header を渡す（挙動不変のプラミング）
+
+このタスクはコールバックのシグネチャ変更で、Rust のコンパイル単位として原子的（全クロージャを同時に更新しないとビルドできない）。挙動は変えない（Node は引き続き `label_registry` で検証、header は無視）。
+
+**Files:**
+- Modify: `src/ui/widget/table/filter_applicator.rs`（`define_callback!` 行, `substring_applicator`）
+- Modify: `src/ui/widget/table.rs`（`run_parser_and_update_state`, テスト用パーサ）
+- Modify: `src/features/node/filter.rs`（クロージャに `_header` 引数追加）
+
+- [ ] **Step 1: `TableFilterParser` のシグネチャを変更**
+
+`src/ui/widget/table/filter_applicator.rs` の define_callback 行（現状 102 行付近）:
+
+```rust
+define_callback!(pub TableFilterParser, Fn(&str) -> Result<TableFilterPredicate, String>);
+```
+
+を次に変更:
+
+```rust
+define_callback!(pub TableFilterParser, Fn(&str, &[String]) -> Result<TableFilterPredicate, String>);
+```
+
+- [ ] **Step 2: `substring_applicator` のクロージャを更新**
+
+同ファイルの `substring_applicator`（現状 216-242 行）のクロージャ先頭:
+
+```rust
+    let parser: TableFilterParser = (move |input: &str| {
+```
+
+を次に変更（header を受け取って無視する）:
+
+```rust
+    let parser: TableFilterParser = (move |input: &str, _header: &[String]| {
+```
+
+（クロージャ本体・`ApplyStrategy::Live` はそのまま。）
+
+- [ ] **Step 3: `run_parser_and_update_state` で header を渡す**
+
+`src/ui/widget/table.rs` の `run_parser_and_update_state`（現状 831-850 行）を次に置き換える。
+
+```rust
+    fn run_parser_and_update_state(&mut self) -> Option<TableFilterPredicate> {
+        let header = self.items.header().original().to_vec();
+        let applicator = self.filter_applicator.as_ref()?;
+        let input = self
+            .filter_form
+            .as_ref()
+            .map(|f| f.content())
+            .unwrap_or_default();
+
+        match (applicator.parser.closure)(&input, &header) {
+            Ok(predicate) => {
+                self.filter_error = None;
+                self.filter_state = Some(predicate.clone());
+                Some(predicate)
+            }
+            Err(msg) => {
+                self.filter_error = Some(msg);
+                None
+            }
+        }
+    }
+```
+
+（`self.items.header().original().to_vec()` は同ファイルの `filter_items` 等で既に使われている既存 API。header を先に owned で取得してから `applicator` を借用することで借用衝突を避ける。）
+
+- [ ] **Step 4: table.rs のテスト用パーサを更新**
+
+`src/ui/widget/table.rs` のテスト内（`filter_cancel_returns_some_callback_when_applicator_has_on_cancel`、現状 1120 行付近）:
+
+```rust
+                TableFilterParser::from(move |_: &str| {
+                    Ok(crate::ui::widget::TableFilterPredicate::default())
+                }),
+```
+
+を次に変更:
+
+```rust
+                TableFilterParser::from(move |_: &str, _: &[String]| {
+                    Ok(crate::ui::widget::TableFilterPredicate::default())
+                }),
+```
+
+- [ ] **Step 5: Node のクロージャを更新（挙動不変）**
+
+`src/features/node/filter.rs` の `node_filter_applicator` 内のパーサ構築（現状 47-48 行）:
+
+```rust
+    let parser: TableFilterParser =
+        (move |input: &str| parse_node_filter(input, &label_registry)).into();
+```
+
+を次に変更（header 引数を受け取るが、この Task ではまだ無視して従来どおり `label_registry` で検証）:
+
+```rust
+    let parser: TableFilterParser =
+        (move |input: &str, _header: &[String]| parse_node_filter(input, &label_registry)).into();
+```
+
+- [ ] **Step 6: ビルドと全テストを実行して green を確認**
+
+Run: `cargo test --all 2>&1 | tail -30`
+Expected: コンパイル成功、全テスト PASS（挙動不変のため既存テストはそのまま通る）。
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add src/ui/widget/table/filter_applicator.rs src/ui/widget/table.rs src/features/node/filter.rs
+git commit -m "refactor(table-filter): thread live header through TableFilterParser"
+```
+
+---
+
+## Task 3: Node パーサを header ベース検証へ＋`label_registry` 削除
+
+課題 I/II の本体。Node パーサが live header に対して列を検証し、列キーを正規化し、非表示/未知列を「not in the current view」エラーにする。`label_registry` 引数は不要になり、`node_filter_applicator` → `node_widget` → `tab.rs` のカスケードで削除する（`tab.rs` はダイアログ用に保持して止まる）。
+
+**Files:**
+- Modify: `src/features/node/filter/parser.rs`（`parse_node_filter`, `valid_columns`, imports, テスト群）
+- Modify: `src/features/node/filter.rs`（`node_filter_applicator` から `label_registry` 削除）
+- Modify: `src/features/node/view/widgets/node.rs`（`node_widget` から `label_registry` 削除）
+- Modify: `src/features/node/view/tab.rs`（`node_widget` 呼び出し更新）
+
+- [ ] **Step 1: parser.rs のテストを header ベースへ移行＋新規テスト追加**
+
+`src/features/node/filter/parser.rs` のテストモジュール（`mod tests`）で以下を行う。
+
+(a) ヘルパー `no_label_cols`（現状 322-324 行）と `registry_with`（現状 466-472 行）を削除し、代わりに次の `header` ヘルパーを追加する。
+
+```rust
+    fn header() -> Vec<String> {
+        [
+            "NAME",
+            "STATUS",
+            "ROLES",
+            "AGE",
+            "VERSION",
+            "INTERNAL-IP",
+            "EXTERNAL-IP",
+            "OS-IMAGE",
+            "KERNEL-VERSION",
+            "CONTAINER-RUNTIME",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect()
+    }
+```
+
+(b) テストモジュール内の `parse_node_filter(..., &no_label_cols())` の呼び出しをすべて `parse_node_filter(..., &header())` に置換する（quoting/escape テストを含む全箇所）。
+
+(c) `registered_label_column_header_is_accepted` テスト（現状 500-505 行）を次に置き換える。
+
+```rust
+    #[test]
+    fn header_column_is_accepted() {
+        let mut h = header();
+        h.push("ZONE".to_string());
+        let p = parse_node_filter("zone:us-west", &h).unwrap();
+        assert!(p.column_includes.contains_key("zone"));
+    }
+```
+
+(d) 2つのエラーテストのアサーションを新エラー文言に合わせる。
+
+`unknown_column_produces_parse_error`（現状 474-482 行）:
+
+```rust
+    #[test]
+    fn unknown_column_produces_parse_error() {
+        let err = parse_node_filter("statusu:Ready", &header()).unwrap_err();
+        assert!(
+            err.contains("not in the current view") && err.contains("statusu"),
+            "error should explain the column is not shown: {}",
+            err
+        );
+    }
+```
+
+`unknown_column_in_exclude_also_errors`（現状 484-492 行）:
+
+```rust
+    #[test]
+    fn unknown_column_in_exclude_also_errors() {
+        let err = parse_node_filter("!agee:1h", &header()).unwrap_err();
+        assert!(
+            err.contains("not in the current view") && err.contains("agee"),
+            "error should explain the column is not shown: {}",
+            err
+        );
+    }
+```
+
+(e) 新規テストを3つ追加する（課題 I/II ＋空 header）。
+
+```rust
+    #[test]
+    fn multiword_column_with_space_is_filterable_via_compact_token() {
+        // 課題 I: 空白入りの列名（例 NOMINATED NODE）が圧縮トークンで指定でき、
+        // 正規化キーで格納される。
+        let h = vec!["NAME".to_string(), "NOMINATED NODE".to_string()];
+        let p = parse_node_filter("nominatednode:foo", &h).unwrap();
+        assert!(p.column_includes.contains_key("nominatednode"));
+    }
+
+    #[test]
+    fn column_not_in_header_produces_not_in_view_error() {
+        // 課題 II: VERSION は実在する builtin 列名だが header に無ければエラー。
+        let h = vec!["NAME".to_string(), "STATUS".to_string()];
+        let err = parse_node_filter("version:1.2", &h).unwrap_err();
+        assert!(
+            err.contains("not in the current view") && err.contains("version"),
+            "error should explain the column is not shown: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn empty_header_skips_column_validation() {
+        // 最初のポーリング前は header が空になり得る。その間は検証しない。
+        let p = parse_node_filter("status:Ready", &[]).unwrap();
+        assert!(p.column_includes.contains_key("status"));
+    }
+```
+
+- [ ] **Step 2: テストを実行して失敗（コンパイルエラー）を確認**
+
+Run: `cargo test --lib features::node::filter 2>&1 | tail -30`
+Expected: コンパイルエラー（`parse_node_filter` のシグネチャが旧来 `&[NodeLabelColumn]` のままで、`&header()`（`&Vec<String>`）/`&[]` を渡せない、また削除した `no_label_cols`/`registry_with` 参照の不整合）。
+
+- [ ] **Step 3: `parse_node_filter` と `valid_columns` を header ベースに実装**
+
+`src/features/node/filter/parser.rs` の import（現状 18-23 行）を次に整理する。
+
+```rust
+use regex::Regex;
+
+use crate::ui::widget::{normalize_column_name, TableFilterPredicate};
+```
+
+（`use strum::IntoEnumIterator;` と `use crate::features::node::node_columns::{NodeColumn, NodeLabelColumn};` を削除。nom 系の import（1-16 行）はそのまま。`std::collections::{HashMap, HashSet}` と `std::borrow::Cow` はそのまま使う。）
+
+`valid_columns`（現状 217-225 行）を次に置き換える。
+
+```rust
+/// Build the set of valid column names from the current table header,
+/// normalized so matching is case/format-insensitive.
+fn valid_columns(header: &[String]) -> HashSet<String> {
+    header.iter().map(|h| normalize_column_name(h)).collect()
+}
+```
+
+`parse_node_filter`（現状 241-315 行、`#[allow(dead_code)]` 含む）を次に置き換える。
+
+```rust
+/// Parse a Node-filter input string into a `TableFilterPredicate`.
+///
+/// `header` is the table's current display header. Column references are
+/// validated (case/format-insensitive) against it; a column not in the current
+/// view produces a parse error. When `header` is empty (e.g. before the first
+/// poll populates the table) column validation is skipped.
+///
+/// Values may be quoted (`"..."` / `'...'`) with the same escape rules as the
+/// Pod log query parser: `\"` → `"`  `\'` → `'`  `\\` → `\`  `\<other>` verbatim.
+pub fn parse_node_filter(
+    input: &str,
+    header: &[String],
+) -> Result<TableFilterPredicate, String> {
+    let valid = valid_columns(header);
+    let validate = !header.is_empty();
+
+    let trimmed = input.trim();
+    let mut column_includes: HashMap<String, Vec<Regex>> = HashMap::new();
+    let mut column_excludes: HashMap<String, Vec<Regex>> = HashMap::new();
+    let mut label_selector: Option<String> = None;
+
+    if trimmed.is_empty() {
+        return Ok(TableFilterPredicate {
+            column_includes,
+            column_excludes,
+            label_selector,
+            raw: trimmed.to_string(),
+        });
+    }
+
+    // Parse the whole trimmed input as whitespace-separated tokens.
+    type E<'a> = nom::error::Error<&'a str>;
+    let parse_result = delimited(
+        multispace0,
+        separated_list0(multispace1, parse_token::<E>),
+        multispace0,
+    )
+    .parse(trimmed);
+
+    let (remaining, terms) = parse_result.map_err(|e| format!("parse error: {}", e))?;
+
+    if !remaining.is_empty() {
+        return Err(format!("unexpected input near: {:?}", remaining));
+    }
+
+    for term in terms {
+        match term {
+            Term::Bare(v) => {
+                let rx = Regex::new(&v).map_err(|e| format!("invalid regex '{}': {}", v, e))?;
+                column_includes
+                    .entry("name".to_string())
+                    .or_default()
+                    .push(rx);
+            }
+            Term::Include { column, value } => {
+                let col = normalize_column_name(&column);
+                if validate && !valid.contains(&col) {
+                    return Err(format!("column '{}' is not in the current view", column));
+                }
+                let rx =
+                    Regex::new(&value).map_err(|e| format!("invalid regex '{}': {}", value, e))?;
+                column_includes.entry(col).or_default().push(rx);
+            }
+            Term::Exclude { column, value } => {
+                let col = normalize_column_name(&column);
+                if validate && !valid.contains(&col) {
+                    return Err(format!("column '{}' is not in the current view", column));
+                }
+                let rx =
+                    Regex::new(&value).map_err(|e| format!("invalid regex '{}': {}", value, e))?;
+                column_excludes.entry(col).or_default().push(rx);
+            }
+            Term::Label(sel) => {
+                // Last label: term wins (k8s API accepts only one labelSelector value).
+                label_selector = Some(sel);
+            }
+        }
+    }
+
+    Ok(TableFilterPredicate {
+        column_includes,
+        column_excludes,
+        label_selector,
+        raw: trimmed.to_string(),
+    })
+}
+```
+
+（`parse_token` / `Term` / quoting ヘルパー群はそのまま。`#[allow(dead_code)]` は不要なので削除する — `node_filter_applicator` から実際に使われる。）
+
+- [ ] **Step 4: `node_filter_applicator` から `label_registry` を削除**
+
+`src/features/node/filter.rs` を更新する。import から `NodeLabelColumn` を削除する（現状 17 行の `node::{message::NodeMessage, node_columns::NodeLabelColumn}` を `node::message::NodeMessage` に）。
+
+関数シグネチャとパーサ構築（現状 43-48 行）を次に置き換える。
+
+```rust
+pub fn node_filter_applicator(tx: Sender<Message>) -> TableFilterApplicator {
+    let parser: TableFilterParser =
+        (move |input: &str, header: &[String]| parse_node_filter(input, header)).into();
+```
+
+（`tx_apply` / `tx_cancel` / `on_apply` / `on_cancel` / `TableFilterApplicator::new(...)` 以降はそのまま。）
+
+同ファイルのテスト（現状 78-82 行付近）を次に更新する。
+
+```rust
+    #[test]
+    fn applicator_constructs_without_panic() {
+        let (tx, _rx) = crossbeam::channel::bounded(1);
+        let _ = node_filter_applicator(tx);
+    }
+```
+
+- [ ] **Step 5: `node_widget` から `label_registry` を削除**
+
+`src/features/node/view/widgets/node.rs` を更新する。import から `NodeLabelColumn` を削除する（現状 7-11 行の `node::{ filter::node_filter_applicator, message::NodeDetailMessage, node_columns::NodeLabelColumn }` を `node::{ filter::node_filter_applicator, message::NodeDetailMessage }` に）。
+
+関数シグネチャ（現状 31-35 行）と filter 配線（現状 51 行）を更新する。
+
+```rust
+pub fn node_widget(tx: Sender<Message>, theme: WidgetThemeConfig) -> Widget<'static> {
+```
+
+```rust
+        .filter_applicator(node_filter_applicator(tx.clone()))
+```
+
+- [ ] **Step 6: `tab.rs` の `node_widget` 呼び出しを更新**
+
+`src/features/node/view/tab.rs:44` を次に変更する（`label_registry` は 47 行の `node_columns_dialog` で引き続き使うため `NodeTab::new` の引数・import はそのまま）。
+
+```rust
+        let node_widget = node_widget(tx.clone(), theme.clone());
+```
+
+- [ ] **Step 7: テストを実行して green を確認**
+
+Run: `cargo test --all 2>&1 | tail -40`
+Expected: コンパイル成功、全テスト PASS（移行・新規した Node parser テストを含む）。
+
+- [ ] **Step 8: コミット**
+
+```bash
+git add src/features/node/filter/parser.rs src/features/node/filter.rs src/features/node/view/widgets/node.rs src/features/node/view/tab.rs
+git commit -m "feat(node-filter): validate columns against live header; drop label_registry"
+```
+
+---
+
+## Task 4: Node フィルタヘルプ文言の更新
+
+**Files:**
+- Modify: `src/features/node/view/widgets/node_filter_help.rs:38-79`（`content()`）
+
+- [ ] **Step 1: ヘルプ末尾の説明を更新**
+
+`src/features/node/view/widgets/node_filter_help.rs` の `content()` 内、末尾の段落（現状 72-74 行）:
+
+```
+        Column names are case-insensitive. Unknown columns produce a
+        parse error. Press Enter to apply, Esc to cancel. Type ? or
+        help in the filter input to open this help.
+```
+
+を次に置き換える（空白・`-`・`_` が無視されること、フィルタ可能なのは表示中の列だけであることを明示）。
+
+```
+        Filterable columns are the ones currently shown in the table.
+        Column names ignore case, spaces, '-' and '_'. A column not in
+        the current view produces an error (add it via the columns
+        dialog). Press Enter to apply, Esc to cancel. Type ? or help in
+        the filter input to open this help.
+```
+
+- [ ] **Step 2: ビルドを確認**
+
+Run: `cargo build 2>&1 | tail -15`
+Expected: コンパイル成功（文字列リテラルのみの変更）。
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add src/features/node/view/widgets/node_filter_help.rs
+git commit -m "docs(node-filter): help text reflects header-based filterable columns"
+```
+
+---
+
+## Task 5: 全体検証（テスト / lint / format / 手動スモーク）
+
+**Files:** なし（検証のみ）
+
+- [ ] **Step 1: 全テスト**
+
+Run: `cargo test --all 2>&1 | tail -20`
+Expected: 全テスト PASS。
+
+- [ ] **Step 2: clippy**
+
+Run: `cargo clippy --all-targets 2>&1 | tail -30`
+Expected: 警告・エラー無し（特に未使用 import / 未使用変数が残っていないこと。`NodeLabelColumn`/`NodeColumn`/`strum::IntoEnumIterator` を消し残していないか確認）。
+
+- [ ] **Step 3: format**
+
+Run: `cargo +nightly fmt --check 2>&1 | tail -20`
+Expected: 差分無し。差分が出たら `cargo +nightly fmt` を実行して再コミット。
+
+- [ ] **Step 4: 手動スモーク（実クラスタまたは KIND）**
+
+実行できる環境があれば `cargo run` で起動し Node タブで以下を確認する（TUI のため自動テスト不可、不可なら省略する旨を明記）。
+
+1. デフォルト列で `status:Ready` → STATUS が Ready の行だけ残る。
+2. デフォルト列（INTERNAL-IP 非表示）で `internalip:10.` → 「not in the current view」エラーがテーブル本体に表示され、全行が消えない（課題 II）。
+3. 列ダイアログ（`t`）で INTERNAL-IP を表示に追加 → 再度 `internalip:10.` がエラーにならずフィルタされる。
+4. `internal-ip:10.` と `internalip:10.`（ハイフン有無）が同じ結果になる（課題 I・正規化）。
+5. `label:role=worker` がサーバーサイドで効く（既存挙動の非回帰）。
+6. `?` でヘルプダイアログが開き、更新後の文言が表示される。
+
+- [ ] **Step 5: （必要なら）format 修正をコミット**
+
+```bash
+git add -A
+git commit -m "style: cargo fmt"
+```
+
+---
+
+## Self-Review（計画作成者によるチェック結果）
+
+- **Spec カバレッジ:** 課題 I（正規化）→ Task 1＋Task 3、課題 II（非表示列→parse error）→ Task 3、header をパーサへ渡す → Task 2、`substring_applicator` 挙動不変 → Task 2 Step 2、`label_registry` 削除 → Task 3 Step 4-6、ヘルプ文言 → Task 4、テスト → 各 Task ＋ Task 5。spec の全項目に対応タスクあり。
+- **プレースホルダ:** TBD/TODO 無し（既存コードの `// TODO(perf)` は意図的に保持）。全コードステップに実コードを記載。テストの一括置換（Task 3 Step 1(b)）は機械的で対象文字列が一意（`&no_label_cols()` → `&header()`）。
+- **型整合:** `normalize_column_name(&str) -> String`（Task 1 で定義、Task 3 で `crate::ui::widget` から import して使用）一致。`TableFilterParser` のシグネチャ `Fn(&str, &[String]) -> Result<TableFilterPredicate, String>` は Task 2 の全クロージャ・呼び出し（`(closure)(&input, &header)`）と一致。`parse_node_filter(&str, &[String])` は filter.rs クロージャ・テストと一致。`node_filter_applicator(Sender<Message>)`／`node_widget(Sender<Message>, WidgetThemeConfig)` は呼び出し側（node.rs/tab.rs）と一致。

--- a/docs/superpowers/specs/2026-05-29-table-filter-header-aware-validation-design.md
+++ b/docs/superpowers/specs/2026-05-29-table-filter-header-aware-validation-design.md
@@ -1,206 +1,201 @@
-# Table filter: header-aware column validation & name normalization
+# Table フィルタ: header ベースの列検証と列名正規化
 
-- Date: 2026-05-29
-- Status: Proposed
-- Scope: shared Table filter framework (`src/ui/widget/table/`) + Node tab filter (`src/features/node/filter/`) as the proving ground
-- Out of scope: Pod tab migration to column-aware filtering (tracked as a separate Phase B spec)
+- 日付: 2026-05-29
+- ステータス: Proposed（提案中）
+- 対象範囲: 共有 Table フィルタ framework（`src/ui/widget/table/`）＋ 検証台としての Node タブフィルタ（`src/features/node/filter/`）
+- 対象外: Pod タブの column-aware フィルタへの移行（別途 Phase B spec として管理）
 
-## Background
+## 背景
 
-The shared Table filter framework (`TableFilterApplicator`, introduced in PRs #980/#982,
-design `docs/superpowers/specs/2026-05-27-table-filter-redesign.md`) lets a tab parse a
-raw filter string into a `TableFilterPredicate` and match it against table rows. The Node
-tab uses a column-aware parser (`COL:val` / `!COL:val` / `label:sel` / bare→NAME); Pod /
-Config / Network still use the simpler `substring_applicator`.
+共有 Table フィルタ framework（`TableFilterApplicator`、PR #980/#982 で導入、設計は
+`docs/superpowers/specs/2026-05-27-table-filter-redesign.md`）は、各タブが生のフィルタ文字列を
+`TableFilterPredicate` にパースし、テーブル行に対してマッチさせる仕組みである。Node タブは
+column-aware なパーサ（`COL:val` / `!COL:val` / `label:sel` / bare→NAME）を使い、Pod / Config /
+Network は今もよりシンプルな `substring_applicator` を使っている。
 
-While planning the Pod migration we found two pre-existing defects in the shared framework.
-They are already reachable from the Node tab today; they are not Pod-specific.
+Pod 移行を計画する過程で、共有 framework に既存の欠陥が2つ見つかった。これらは Pod 固有では
+なく、Node タブから今すでに踏める問題である。
 
-### 課題 I — column names containing spaces are unfilterable
+### 課題 I — 空白を含む列名がフィルタ不能
 
-- The parser splits the input on whitespace (`separated_list0(multispace1, parse_token)`,
-  `src/features/node/filter/parser.rs:264-269`), so a column token can never contain a space.
-- Matching looks up the column by **plain** lowercase string equality:
-  `cell_of` compares `h.to_lowercase() == col_name_lower`
-  (`src/ui/widget/table/filter_applicator.rs:80-89`).
-- Node builtin columns are hyphenated (`INTERNAL-IP`, `OS-IMAGE`, …) so they tokenize fine,
-  but a Node **label** column header is `def.name.to_uppercase()` with no space stripping
-  (`src/app.rs:272`). A label column whose name contains a space (e.g. `"my label"` →
-  header `"MY LABEL"`) is registered as a valid column (`valid_columns` inserts
-  `lc.header.to_lowercase()`, `parser.rs:217-225`) yet can never be matched, because the
-  user cannot type the space and `cell_of` does exact-with-space comparison.
+- パーサは入力を空白で分割する（`separated_list0(multispace1, parse_token)`、
+  `src/features/node/filter/parser.rs:264-269`）ため、列トークンに空白を含められない。
+- マッチングは列名を**素の** lowercase 文字列の完全一致で引く。`cell_of` は
+  `h.to_lowercase() == col_name_lower` で比較する
+  （`src/ui/widget/table/filter_applicator.rs:80-89`）。
+- Node の builtin 列はハイフン区切り（`INTERNAL-IP`、`OS-IMAGE` …）なので問題なくトークン化
+  できるが、Node の **label** 列の header は `def.name.to_uppercase()` で空白除去をしない
+  （`src/app.rs:272`）。name に空白を含む label 列（例: `"my label"` → header `"MY LABEL"`）は
+  有効な列として登録される（`valid_columns` が `lc.header.to_lowercase()` を入れる、
+  `parser.rs:217-225`）が、ユーザーは空白を打てず、かつ `cell_of` は空白込みの完全一致比較を
+  するため、決してマッチしない。
 
-In short: there is no existing solution to copy. The Pod migration *needs* one because Pod's
-default builtin columns include `NOMINATED NODE` and `READINESS GATES` (spaces by default).
+要するに、コピーできる既存解は存在しない。Pod 移行ではこれが必須になる。Pod の default builtin
+列に `NOMINATED NODE` と `READINESS GATES`（既定で空白入り）が含まれるためである。
 
-### 課題 II — filtering a valid-but-hidden column silently hides every row
+### 課題 II — 有効だが非表示の列を指定すると全行が消える
 
-- `valid_columns` is built from the full `NodeColumn::iter()` enum plus the label registry
-  (`parser.rs:217-225`), independent of which columns are currently displayed.
-- Node columns are runtime-configurable via the column dialog
-  (`NodeMessage::Request` → `shared_node_columns`, `src/workers/kube/controller.rs:616-621`);
-  the default display is 5 of 10 builtin columns (`DEFAULT_NODE_COLUMNS`).
-- Matching uses `cell_of(...).unwrap_or_default()`: a column not present in the live header
-  yields `""`, so an `include` pattern fails for every row
-  (`filter_applicator.rs:53-71`). Result: filtering on a real-but-hidden column (e.g.
-  `internalip:10.` with the default Node columns) parses OK and then makes the whole table
-  appear empty — looks like a bug, with no feedback.
+- `valid_columns` は全 `NodeColumn::iter()` enum ＋ label registry から構築され
+  （`parser.rs:217-225`）、現在どの列が表示されているかに依存しない。
+- Node の列は列ダイアログで実行時に変更できる
+  （`NodeMessage::Request` → `shared_node_columns`、`src/workers/kube/controller.rs:616-621`）。
+  default 表示は builtin 10 列のうち 5 列（`DEFAULT_NODE_COLUMNS`）。
+- マッチングは `cell_of(...).unwrap_or_default()` を使う。live header に存在しない列は `""` を
+  返すため、`include` パターンが全行で失敗する（`filter_applicator.rs:53-71`）。結果、実在する
+  が非表示の列でフィルタすると（例: default の Node 列で `internalip:10.`）、パースは成功した
+  うえでテーブル全体が空に見える ── フィードバックも無くバグに見える。
 
-## Goals
+## ゴール
 
-1. Make column-name matching tolerant of spaces / `-` / `_` so multi-word columns are filterable.
-2. Replace the "all rows vanish" behavior for non-displayed columns with an explicit, helpful
-   parse error.
-3. Unify both fixes at the framework level so every tab (Node now; Pod / Config / Network
-   later) benefits, with no per-tab workaround.
-4. Keep the change behaviorally safe for the existing `substring_applicator` tabs.
+1. 列名マッチングを空白 / `-` / `_` に寛容にし、複数語の列をフィルタ可能にする。
+2. 非表示列に対する「全行が消える」挙動を、明示的で親切な parse error に置き換える。
+3. 両修正を framework レベルで統一し、全タブ（今は Node、後で Pod / Config / Network）が恩恵を
+   受けられるようにする（タブごとの場当たり的対処を不要にする）。
+4. 既存の `substring_applicator` 系タブにとって挙動上安全な変更に留める。
 
-## Non-goals
+## 非ゴール
 
-- Migrating Pod (or Config / Network) to the column-aware parser — Phase B.
-- Server-side `labelSelector` plumbing for Pod — Phase B.
-- Auto-adding a hidden column to the view when it is referenced in a filter.
+- Pod（および Config / Network）の column-aware パーサへの移行 ── Phase B。
+- Pod 向けのサーバーサイド `labelSelector` 配線 ── Phase B。
+- フィルタで参照された非表示列を自動的に表示へ追加すること。
 
-## Mental model
+## メンタルモデル
 
-The rule we are encoding: **you can filter exactly the columns you can see.** This matches how
-TUI users (k9s, fzf, less) expect filtering to work — it narrows the visible representation.
-A reference to a column that is not in the current view is reported as an error that tells the
-user the column is not shown (so they can add it via the column dialog), rather than silently
-returning nothing or silently ignoring the term.
+ここで表現するルール: **見えている列だけをフィルタできる**。これは TUI ユーザー（k9s, fzf,
+less）が期待するフィルタの挙動 ── 見えている表現を絞り込む ── に一致する。現在の表示に無い列を
+参照した場合は、（列ダイアログで追加できるよう）その列が表示されていない旨を伝えるエラーとして
+報告する。サイレントに何も返さない／サイレントに項を無視する、のいずれでもない。
 
-## Design
+## 設計
 
-### 1. The parser receives the live header
+### 1. パーサが live header を受け取る
 
-Change the `TableFilterParser` callback signature from
+`TableFilterParser` コールバックのシグネチャを
 
 ```
 Fn(&str) -> Result<TableFilterPredicate, String>
 ```
 
-to
+から
 
 ```
 Fn(&str, &[String]) -> Result<TableFilterPredicate, String>
 ```
 
-where the second argument is the table's current display header
-(`self.items.header().original()`). The Table widget already holds this and uses it for
-matching; `run_parser_and_update_state` (`src/ui/widget/table.rs:831-839`) is a `&mut self`
-method with access to it, so it passes `&header` into the parser closure.
+へ変更する。第2引数はテーブルの現在の表示 header（`self.items.header().original()`）である。
+Table ウィジェットはこれを既に保持しマッチングに使っている。`run_parser_and_update_state`
+（`src/ui/widget/table.rs:831-839`）は `&mut self` メソッドで header にアクセスできるため、
+`&header` をパーサクロージャに渡す。
 
-The header is the single source of truth for "what is displayed," is already what matching
-compares against, and is available synchronously on the render thread — which sidesteps the
-async `RwLock` around the per-tab column config.
+header は「何が表示されているか」の唯一の真実の源であり、すでにマッチングが比較対象とするもので
+あり、かつ render スレッド上で同期的に取得できる ── これによりタブごとの列設定を包む async
+`RwLock` を回避できる。
 
-### 2. Shared column-name normalization
+### 2. 共有の列名正規化
 
-Introduce one normalization function in the filter framework:
+フィルタ framework に正規化関数を1つ導入する:
 
 ```
-normalize_column_name(s) = s.to_lowercase() with all ' ', '-', '_' removed
+normalize_column_name(s) = s を小文字化し、' ' / '-' / '_' をすべて除去
 ```
 
-(`PodColumn::normalize_column` already implements exactly this and can be the reference; the
-shared helper lives in the filter module so all tabs use the same rule.)
+（`PodColumn::normalize_column` がまさにこれを実装済みで参照にできる。共有ヘルパーは全タブが同じ
+ルールを使えるようフィルタモジュールに置く。）
 
-Apply it on **both** sides of every column-name comparison:
+これを列名比較の**両側**に適用する:
 
-- In `cell_of`: normalize each header entry and the looked-up key before comparing, instead of
-  plain `to_lowercase()`. Hyphenated names keep working (`internal-ip` → `internalip`);
-  hyphens/underscores/spaces become insignificant.
-- In the parser: normalize the user's column token and each header entry to validate, and store
-  the **normalized** column name as the predicate key. Because `cell_of` also normalizes, the
-  stored key resolves back to the right header column.
+- `cell_of` 内: 素の `to_lowercase()` の代わりに、各 header エントリと引くキーを正規化してから
+  比較する。ハイフン入りの名前は引き続き動作し（`internal-ip` → `internalip`）、
+  ハイフン / アンダースコア / 空白は無視されるようになる。
+- パーサ内: ユーザーの列トークンと各 header エントリを正規化して検証し、predicate のキーには
+  **正規化済み**の列名を格納する。`cell_of` も正規化するため、格納したキーは正しい header 列へ
+  解決される。
 
-This makes `nominatednode`, `nominated-node`, `Nominated_Node` all match the `NOMINATED NODE`
-header, and makes spaced Node label columns filterable.
+これにより `nominatednode` / `nominated-node` / `Nominated_Node` がすべて `NOMINATED NODE`
+header にマッチし、空白入りの Node label 列もフィルタ可能になる。
 
-### 3. Validate column references against the live header (課題 II)
+### 3. live header に対して列参照を検証する（課題 II）
 
-In the parser, the valid column set is the set of **normalized header entries** (not the
-builtin enum, not the label-registry snapshot). For each `COL:val` / `!COL:val` term:
+パーサ内で、有効な列集合は**正規化された header エントリの集合**とする（builtin enum でも、
+label registry のスナップショットでもない）。各 `COL:val` / `!COL:val` 項について:
 
-- If `normalize_column_name(COL)` is not among the normalized header entries → return a parse
-  error: `column '<COL>' is not in the current view` (the existing `filter_error` channel
-  renders it in place of the table body — sticky until corrected).
-- `label:sel` is always accepted (it is a server-side selector, not a display column).
-- A bare value maps to the NAME column include; NAME is guaranteed present
-  (`ensure_name_column`), so this never errors in practice.
+- `normalize_column_name(COL)` が正規化済み header エントリに含まれない場合 → parse error を返す:
+  `column '<COL>' is not in the current view`（既存の `filter_error` チャネルがこれをテーブル本体
+  の代わりに描画する ── 修正されるまで sticky）。
+- `label:sel` は常に受理する（これは表示列ではなくサーバーサイド selector であるため）。
+- bare 値は NAME 列の include に対応する。NAME は常に存在する（`ensure_name_column`）ので、
+  実際にはこれがエラーになることはない。
 
-Consequence: the Node parser no longer needs `NodeColumn::iter()` or the `label_registry`
-argument for validation. `node_filter_applicator`'s `label_registry` parameter becomes unused
-for validation and is removed; the parser is simplified to validate purely against the header.
+帰結: Node パーサは検証のために `NodeColumn::iter()` や label registry スナップショットを必要と
+しなくなる。`node_filter_applicator` の `label_registry` 引数は検証に使われなくなり削除する。
+パーサは header に対してのみ検証するよう簡素化される。
 
-Edge case — empty header (before the first poll populates the table): if the header is empty,
-skip column validation (accept the term) so the user does not get spurious "not in the current
-view" errors before any data has arrived. (In Node the header is built from the configured
-column specs and is populated as soon as the table is built once, so this only affects the
-brief pre-first-render window.)
+エッジケース ── 空の header（最初のポーリングがテーブルを埋める前）: header が空の場合は列検証を
+スキップ（項を受理）し、データ到着前にユーザーが誤って「not in the current view」エラーを受け
+ないようにする。（Node では header は設定済みの列 spec から構築され、テーブルが一度構築されれば
+すぐ埋まるため、これが影響するのは最初の描画前の短い区間のみ。）
 
-### 4. Error-message wording
+### 4. エラー文言
 
-Use "not in the current view" rather than "unknown column", because from the filter's
-perspective the only knowable columns are the displayed ones; a real-but-hidden k8s column and
-a genuine typo are indistinguishable and both correctly resolve to "that column is not shown".
+「unknown column（未知の列）」ではなく「not in the current view（現在の表示に無い）」を使う。
+フィルタの視点で知り得る列は表示中のものだけであり、実在するが非表示の k8s 列と単なるタイプミスは
+区別できず、両者とも正しく「その列は表示されていない」に解決されるためである。
 
-### 5. Help dialog
+### 5. ヘルプダイアログ
 
-Update the Node filter help (`src/features/node/view/widgets/node_filter_help.rs`) so the
-"valid columns" guidance reads as "the columns currently shown in the table" instead of a fixed
-enumeration. Dynamically listing the current header in the dialog is optional polish and may be
-deferred.
+Node フィルタのヘルプ（`src/features/node/view/widgets/node_filter_help.rs`）を更新し、「有効な
+列」の案内を固定列挙ではなく「現在テーブルに表示されている列」と読めるようにする。現在の header を
+ダイアログに動的に列挙するのは任意の磨き込みであり、後回しにしてよい。
 
-### 6. `substring_applicator` and other tabs
+### 6. `substring_applicator` と他タブ
 
-`substring_applicator(column)` (`src/ui/widget/table/filter_applicator.rs`) produces a
-`TableFilterParser`; its closure signature is updated to accept and ignore the header argument
-(it filters a single fixed column — NAME — which is always present, so its behavior is
-unchanged). The shared `cell_of` normalization is a no-op for single-word `NAME`, so Pod /
-Config / Network matching is unaffected until their own Phase B migration.
+`substring_applicator(column)`（`src/ui/widget/table/filter_applicator.rs`）は
+`TableFilterParser` を生成する。そのクロージャのシグネチャを更新して header 引数を受け取りつつ
+無視する（固定の単一列 ── NAME ── をフィルタし、NAME は常に存在するため挙動は不変）。共有
+`cell_of` の正規化は単一語の `NAME` に対しては no-op なので、Pod / Config / Network のマッチング
+は各自の Phase B 移行まで影響を受けない。
 
-## Affected files
+## 影響を受けるファイル
 
-- `src/ui/widget/table/filter_applicator.rs` — `TableFilterParser` signature; `cell_of`
-  normalization; new `normalize_column_name` helper; `substring_applicator` closure signature.
-- `src/ui/widget/table.rs` — pass `&header` into the parser in `run_parser_and_update_state`;
-  update the in-module test parser (`table.rs:~1120`).
-- `src/features/node/filter.rs` — drop `label_registry` from `node_filter_applicator`; update
-  the parser wiring; update callers that pass the registry.
-- `src/features/node/filter/parser.rs` — `parse_node_filter` takes the header instead of the
-  label registry; validate against normalized header; store normalized keys; update tests.
-- `src/features/node/view/widgets/node_filter_help.rs` — help wording.
-- Callers of `node_filter_applicator` (e.g. `src/features/node/view/widgets/node.rs`,
-  `tab.rs`, render wiring) — drop the now-unused registry argument.
+- `src/ui/widget/table/filter_applicator.rs` ── `TableFilterParser` シグネチャ、`cell_of` の
+  正規化、新規 `normalize_column_name` ヘルパー、`substring_applicator` のクロージャシグネチャ。
+- `src/ui/widget/table.rs` ── `run_parser_and_update_state` でパーサに `&header` を渡す、
+  モジュール内テスト用パーサ（`table.rs:~1120`）の更新。
+- `src/features/node/filter.rs` ── `node_filter_applicator` から `label_registry` を削除、
+  パーサ配線の更新、registry を渡している呼び出し元の更新。
+- `src/features/node/filter/parser.rs` ── `parse_node_filter` が label registry ではなく header
+  を受け取る、正規化済み header に対する検証、正規化済みキーの格納、テスト更新。
+- `src/features/node/view/widgets/node_filter_help.rs` ── ヘルプ文言。
+- `node_filter_applicator` の呼び出し元（例: `src/features/node/view/widgets/node.rs`、
+  `tab.rs`、render 配線）── 不要になった registry 引数の削除。
 
-## Testing
+## テスト
 
-- Unit tests for `normalize_column_name` (spaces / `-` / `_` / case).
-- `cell_of` tests: multi-word header matches normalized key; hyphenated header still matches.
-- `parse_node_filter` tests (header-driven): valid displayed column; multi-word column via
-  normalized token; `!COL` exclude; `label:`; bare→NAME; **hidden column → parse error**;
-  empty-header → no validation error.
-- Confirm `substring_applicator` behavior is unchanged (existing Pod/Config/Network filter
-  tests still pass).
-- `cargo test --all`, `cargo clippy`, `cargo +nightly fmt --check`.
+- `normalize_column_name` の単体テスト（空白 / `-` / `_` / 大小文字）。
+- `cell_of` のテスト: 複数語 header が正規化キーにマッチする、ハイフン入り header も引き続き
+  マッチする。
+- `parse_node_filter` のテスト（header 駆動）: 有効な表示列、正規化トークン経由の複数語列、
+  `!COL` exclude、`label:`、bare→NAME、**非表示列 → parse error**、空 header → 検証エラー無し。
+- `substring_applicator` の挙動が不変であることの確認（既存の Pod/Config/Network フィルタ
+  テストが通り続ける）。
+- `cargo test --all`、`cargo clippy`、`cargo +nightly fmt --check`。
 
-## Risks / backward incompatibility
+## リスク / 後方非互換
 
-- Node matching semantics change slightly: `-` / `_` / spaces in column names become
-  insignificant (e.g. `internalip` now matches `INTERNAL-IP`). This is a strict superset of
-  current matches; existing `internal-ip` queries keep working. Node parser tests must be
-  updated to reflect normalized comparison.
-- Removing `label_registry` from `node_filter_applicator` touches its call sites; mechanical.
+- Node のマッチング意味論がわずかに変わる: 列名中の `-` / `_` / 空白が無意味になる
+  （例: `internalip` が `INTERNAL-IP` にマッチするようになる）。これは現在のマッチの厳密な
+  上位集合であり、既存の `internal-ip` クエリは引き続き動作する。Node パーサのテストは正規化
+  比較を反映するよう更新が必要。
+- `node_filter_applicator` から `label_registry` を削除すると呼び出し箇所に波及する（機械的）。
 
-## Follow-up (Phase B — separate spec)
+## フォローアップ（Phase B ── 別 spec）
 
-Migrate the Pod tab from `substring_applicator("NAME")` to a column-aware
-`pod_filter_applicator`, riding on this fixed framework:
-- `parse_pod_filter` validates against the live header (incl. `NAMESPACE` when shown), so Pod's
-  multi-word builtin columns work with no Pod-local normalization hack.
-- `label:` server-side selector: add `PodMessage::Filter(Option<String>)` + `SharedPodFilter`,
-  wire `?labelSelector=` into the per-namespace pod fetch (`get_pods_per_namespace`), handle the
-  message in the controller; `EnterToConfirm` strategy + help dialog, mirroring Node.
-- The Pod log-query parser (`src/features/pod/kube/filter.rs`) is unrelated (filters log lines,
-  different pane) and is left untouched.
+Pod タブを `substring_applicator("NAME")` から column-aware な `pod_filter_applicator` へ移行し、
+この修正済み framework に乗せる:
+- `parse_pod_filter` は live header（表示時は `NAMESPACE` も含む）に対して検証するので、Pod の
+  複数語 builtin 列が Pod-local な正規化ハックなしで動作する。
+- `label:` サーバーサイド selector: `PodMessage::Filter(Option<String>)` ＋ `SharedPodFilter` を
+  追加し、namespace ごとの pod 取得（`get_pods_per_namespace`）に `?labelSelector=` を配線、
+  controller でメッセージを処理。Node に倣い `EnterToConfirm` strategy ＋ ヘルプダイアログ。
+- Pod のログクエリパーサ（`src/features/pod/kube/filter.rs`）は無関係（ログ行のフィルタ・別ペイン）
+  であり、手を加えない。

--- a/docs/superpowers/specs/2026-05-29-table-filter-header-aware-validation-design.md
+++ b/docs/superpowers/specs/2026-05-29-table-filter-header-aware-validation-design.md
@@ -1,0 +1,206 @@
+# Table filter: header-aware column validation & name normalization
+
+- Date: 2026-05-29
+- Status: Proposed
+- Scope: shared Table filter framework (`src/ui/widget/table/`) + Node tab filter (`src/features/node/filter/`) as the proving ground
+- Out of scope: Pod tab migration to column-aware filtering (tracked as a separate Phase B spec)
+
+## Background
+
+The shared Table filter framework (`TableFilterApplicator`, introduced in PRs #980/#982,
+design `docs/superpowers/specs/2026-05-27-table-filter-redesign.md`) lets a tab parse a
+raw filter string into a `TableFilterPredicate` and match it against table rows. The Node
+tab uses a column-aware parser (`COL:val` / `!COL:val` / `label:sel` / bare→NAME); Pod /
+Config / Network still use the simpler `substring_applicator`.
+
+While planning the Pod migration we found two pre-existing defects in the shared framework.
+They are already reachable from the Node tab today; they are not Pod-specific.
+
+### 課題 I — column names containing spaces are unfilterable
+
+- The parser splits the input on whitespace (`separated_list0(multispace1, parse_token)`,
+  `src/features/node/filter/parser.rs:264-269`), so a column token can never contain a space.
+- Matching looks up the column by **plain** lowercase string equality:
+  `cell_of` compares `h.to_lowercase() == col_name_lower`
+  (`src/ui/widget/table/filter_applicator.rs:80-89`).
+- Node builtin columns are hyphenated (`INTERNAL-IP`, `OS-IMAGE`, …) so they tokenize fine,
+  but a Node **label** column header is `def.name.to_uppercase()` with no space stripping
+  (`src/app.rs:272`). A label column whose name contains a space (e.g. `"my label"` →
+  header `"MY LABEL"`) is registered as a valid column (`valid_columns` inserts
+  `lc.header.to_lowercase()`, `parser.rs:217-225`) yet can never be matched, because the
+  user cannot type the space and `cell_of` does exact-with-space comparison.
+
+In short: there is no existing solution to copy. The Pod migration *needs* one because Pod's
+default builtin columns include `NOMINATED NODE` and `READINESS GATES` (spaces by default).
+
+### 課題 II — filtering a valid-but-hidden column silently hides every row
+
+- `valid_columns` is built from the full `NodeColumn::iter()` enum plus the label registry
+  (`parser.rs:217-225`), independent of which columns are currently displayed.
+- Node columns are runtime-configurable via the column dialog
+  (`NodeMessage::Request` → `shared_node_columns`, `src/workers/kube/controller.rs:616-621`);
+  the default display is 5 of 10 builtin columns (`DEFAULT_NODE_COLUMNS`).
+- Matching uses `cell_of(...).unwrap_or_default()`: a column not present in the live header
+  yields `""`, so an `include` pattern fails for every row
+  (`filter_applicator.rs:53-71`). Result: filtering on a real-but-hidden column (e.g.
+  `internalip:10.` with the default Node columns) parses OK and then makes the whole table
+  appear empty — looks like a bug, with no feedback.
+
+## Goals
+
+1. Make column-name matching tolerant of spaces / `-` / `_` so multi-word columns are filterable.
+2. Replace the "all rows vanish" behavior for non-displayed columns with an explicit, helpful
+   parse error.
+3. Unify both fixes at the framework level so every tab (Node now; Pod / Config / Network
+   later) benefits, with no per-tab workaround.
+4. Keep the change behaviorally safe for the existing `substring_applicator` tabs.
+
+## Non-goals
+
+- Migrating Pod (or Config / Network) to the column-aware parser — Phase B.
+- Server-side `labelSelector` plumbing for Pod — Phase B.
+- Auto-adding a hidden column to the view when it is referenced in a filter.
+
+## Mental model
+
+The rule we are encoding: **you can filter exactly the columns you can see.** This matches how
+TUI users (k9s, fzf, less) expect filtering to work — it narrows the visible representation.
+A reference to a column that is not in the current view is reported as an error that tells the
+user the column is not shown (so they can add it via the column dialog), rather than silently
+returning nothing or silently ignoring the term.
+
+## Design
+
+### 1. The parser receives the live header
+
+Change the `TableFilterParser` callback signature from
+
+```
+Fn(&str) -> Result<TableFilterPredicate, String>
+```
+
+to
+
+```
+Fn(&str, &[String]) -> Result<TableFilterPredicate, String>
+```
+
+where the second argument is the table's current display header
+(`self.items.header().original()`). The Table widget already holds this and uses it for
+matching; `run_parser_and_update_state` (`src/ui/widget/table.rs:831-839`) is a `&mut self`
+method with access to it, so it passes `&header` into the parser closure.
+
+The header is the single source of truth for "what is displayed," is already what matching
+compares against, and is available synchronously on the render thread — which sidesteps the
+async `RwLock` around the per-tab column config.
+
+### 2. Shared column-name normalization
+
+Introduce one normalization function in the filter framework:
+
+```
+normalize_column_name(s) = s.to_lowercase() with all ' ', '-', '_' removed
+```
+
+(`PodColumn::normalize_column` already implements exactly this and can be the reference; the
+shared helper lives in the filter module so all tabs use the same rule.)
+
+Apply it on **both** sides of every column-name comparison:
+
+- In `cell_of`: normalize each header entry and the looked-up key before comparing, instead of
+  plain `to_lowercase()`. Hyphenated names keep working (`internal-ip` → `internalip`);
+  hyphens/underscores/spaces become insignificant.
+- In the parser: normalize the user's column token and each header entry to validate, and store
+  the **normalized** column name as the predicate key. Because `cell_of` also normalizes, the
+  stored key resolves back to the right header column.
+
+This makes `nominatednode`, `nominated-node`, `Nominated_Node` all match the `NOMINATED NODE`
+header, and makes spaced Node label columns filterable.
+
+### 3. Validate column references against the live header (課題 II)
+
+In the parser, the valid column set is the set of **normalized header entries** (not the
+builtin enum, not the label-registry snapshot). For each `COL:val` / `!COL:val` term:
+
+- If `normalize_column_name(COL)` is not among the normalized header entries → return a parse
+  error: `column '<COL>' is not in the current view` (the existing `filter_error` channel
+  renders it in place of the table body — sticky until corrected).
+- `label:sel` is always accepted (it is a server-side selector, not a display column).
+- A bare value maps to the NAME column include; NAME is guaranteed present
+  (`ensure_name_column`), so this never errors in practice.
+
+Consequence: the Node parser no longer needs `NodeColumn::iter()` or the `label_registry`
+argument for validation. `node_filter_applicator`'s `label_registry` parameter becomes unused
+for validation and is removed; the parser is simplified to validate purely against the header.
+
+Edge case — empty header (before the first poll populates the table): if the header is empty,
+skip column validation (accept the term) so the user does not get spurious "not in the current
+view" errors before any data has arrived. (In Node the header is built from the configured
+column specs and is populated as soon as the table is built once, so this only affects the
+brief pre-first-render window.)
+
+### 4. Error-message wording
+
+Use "not in the current view" rather than "unknown column", because from the filter's
+perspective the only knowable columns are the displayed ones; a real-but-hidden k8s column and
+a genuine typo are indistinguishable and both correctly resolve to "that column is not shown".
+
+### 5. Help dialog
+
+Update the Node filter help (`src/features/node/view/widgets/node_filter_help.rs`) so the
+"valid columns" guidance reads as "the columns currently shown in the table" instead of a fixed
+enumeration. Dynamically listing the current header in the dialog is optional polish and may be
+deferred.
+
+### 6. `substring_applicator` and other tabs
+
+`substring_applicator(column)` (`src/ui/widget/table/filter_applicator.rs`) produces a
+`TableFilterParser`; its closure signature is updated to accept and ignore the header argument
+(it filters a single fixed column — NAME — which is always present, so its behavior is
+unchanged). The shared `cell_of` normalization is a no-op for single-word `NAME`, so Pod /
+Config / Network matching is unaffected until their own Phase B migration.
+
+## Affected files
+
+- `src/ui/widget/table/filter_applicator.rs` — `TableFilterParser` signature; `cell_of`
+  normalization; new `normalize_column_name` helper; `substring_applicator` closure signature.
+- `src/ui/widget/table.rs` — pass `&header` into the parser in `run_parser_and_update_state`;
+  update the in-module test parser (`table.rs:~1120`).
+- `src/features/node/filter.rs` — drop `label_registry` from `node_filter_applicator`; update
+  the parser wiring; update callers that pass the registry.
+- `src/features/node/filter/parser.rs` — `parse_node_filter` takes the header instead of the
+  label registry; validate against normalized header; store normalized keys; update tests.
+- `src/features/node/view/widgets/node_filter_help.rs` — help wording.
+- Callers of `node_filter_applicator` (e.g. `src/features/node/view/widgets/node.rs`,
+  `tab.rs`, render wiring) — drop the now-unused registry argument.
+
+## Testing
+
+- Unit tests for `normalize_column_name` (spaces / `-` / `_` / case).
+- `cell_of` tests: multi-word header matches normalized key; hyphenated header still matches.
+- `parse_node_filter` tests (header-driven): valid displayed column; multi-word column via
+  normalized token; `!COL` exclude; `label:`; bare→NAME; **hidden column → parse error**;
+  empty-header → no validation error.
+- Confirm `substring_applicator` behavior is unchanged (existing Pod/Config/Network filter
+  tests still pass).
+- `cargo test --all`, `cargo clippy`, `cargo +nightly fmt --check`.
+
+## Risks / backward incompatibility
+
+- Node matching semantics change slightly: `-` / `_` / spaces in column names become
+  insignificant (e.g. `internalip` now matches `INTERNAL-IP`). This is a strict superset of
+  current matches; existing `internal-ip` queries keep working. Node parser tests must be
+  updated to reflect normalized comparison.
+- Removing `label_registry` from `node_filter_applicator` touches its call sites; mechanical.
+
+## Follow-up (Phase B — separate spec)
+
+Migrate the Pod tab from `substring_applicator("NAME")` to a column-aware
+`pod_filter_applicator`, riding on this fixed framework:
+- `parse_pod_filter` validates against the live header (incl. `NAMESPACE` when shown), so Pod's
+  multi-word builtin columns work with no Pod-local normalization hack.
+- `label:` server-side selector: add `PodMessage::Filter(Option<String>)` + `SharedPodFilter`,
+  wire `?labelSelector=` into the per-namespace pod fetch (`get_pods_per_namespace`), handle the
+  message in the controller; `EnterToConfirm` strategy + help dialog, mirroring Node.
+- The Pod log-query parser (`src/features/pod/kube/filter.rs`) is unrelated (filters log lines,
+  different pane) and is left untouched.

--- a/src/features/node/filter.rs
+++ b/src/features/node/filter.rs
@@ -14,7 +14,7 @@ use crossbeam::channel::Sender;
 use crate::{
     features::{
         component_id::NODE_FILTER_HELP_DIALOG_ID,
-        node::{message::NodeMessage, node_columns::NodeLabelColumn},
+        node::message::NodeMessage,
     },
     message::Message,
     ui::{
@@ -33,19 +33,15 @@ pub use parser::parse_node_filter;
 
 /// Build the Node tab's filter applicator.
 ///
-/// `label_registry` is captured by value and used by the parser for
-/// column-name validation. `tx` is captured by the `on_apply` callback to
-/// forward the parsed `label_selector` to the Node poller via
-/// `NodeMessage::Filter`.
+/// `tx` is captured by the `on_apply` callback to forward the parsed
+/// `label_selector` to the Node poller via `NodeMessage::Filter`.
 ///
 /// The applicator uses `EnterToConfirm` strategy so that the parser only
-/// runs on Enter (avoids spamming the kube API mid-typing).
-pub fn node_filter_applicator(
-    label_registry: Vec<NodeLabelColumn>,
-    tx: Sender<Message>,
-) -> TableFilterApplicator {
+/// runs on Enter (avoids spamming the kube API mid-typing). Column
+/// validation is performed against the live header passed by the framework.
+pub fn node_filter_applicator(tx: Sender<Message>) -> TableFilterApplicator {
     let parser: TableFilterParser =
-        (move |input: &str, _header: &[String]| parse_node_filter(input, &label_registry)).into();
+        (move |input: &str, header: &[String]| parse_node_filter(input, header)).into();
 
     let tx_apply = tx.clone();
     let tx_cancel = tx;
@@ -78,6 +74,6 @@ mod tests {
     #[test]
     fn applicator_constructs_without_panic() {
         let (tx, _rx) = crossbeam::channel::bounded(1);
-        let _ = node_filter_applicator(Vec::new(), tx);
+        let _ = node_filter_applicator(tx);
     }
 }

--- a/src/features/node/filter.rs
+++ b/src/features/node/filter.rs
@@ -45,7 +45,7 @@ pub fn node_filter_applicator(
     tx: Sender<Message>,
 ) -> TableFilterApplicator {
     let parser: TableFilterParser =
-        (move |input: &str| parse_node_filter(input, &label_registry)).into();
+        (move |input: &str, _header: &[String]| parse_node_filter(input, &label_registry)).into();
 
     let tx_apply = tx.clone();
     let tx_cancel = tx;

--- a/src/features/node/filter.rs
+++ b/src/features/node/filter.rs
@@ -12,10 +12,7 @@ mod parser;
 use crossbeam::channel::Sender;
 
 use crate::{
-    features::{
-        component_id::NODE_FILTER_HELP_DIALOG_ID,
-        node::message::NodeMessage,
-    },
+    features::{component_id::NODE_FILTER_HELP_DIALOG_ID, node::message::NodeMessage},
     message::Message,
     ui::{
         widget::{

--- a/src/features/node/filter/parser.rs
+++ b/src/features/node/filter/parser.rs
@@ -226,10 +226,7 @@ fn valid_columns(header: &[String]) -> HashSet<String> {
 ///
 /// Values may be quoted (`"..."` / `'...'`) with the same escape rules as the
 /// Pod log query parser: `\"` → `"`  `\'` → `'`  `\\` → `\`  `\<other>` verbatim.
-pub fn parse_node_filter(
-    input: &str,
-    header: &[String],
-) -> Result<TableFilterPredicate, String> {
+pub fn parse_node_filter(input: &str, header: &[String]) -> Result<TableFilterPredicate, String> {
     let valid = valid_columns(header);
     let validate = !header.is_empty();
 
@@ -583,8 +580,7 @@ mod tests {
 
     #[test]
     fn mixed_quoted_and_unquoted_tokens() {
-        let p =
-            parse_node_filter(r#"status:Ready os-image:"Ubuntu 22.04""#, &header()).unwrap();
+        let p = parse_node_filter(r#"status:Ready os-image:"Ubuntu 22.04""#, &header()).unwrap();
         assert_eq!(p.column_includes.len(), 2);
         assert!(p.column_includes.get("osimage").unwrap()[0].is_match("Ubuntu 22.04"));
     }

--- a/src/features/node/filter/parser.rs
+++ b/src/features/node/filter/parser.rs
@@ -15,12 +15,8 @@ use nom::{
     Parser,
 };
 use regex::Regex;
-use strum::IntoEnumIterator;
 
-use crate::{
-    features::node::node_columns::{NodeColumn, NodeLabelColumn},
-    ui::widget::TableFilterPredicate,
-};
+use crate::ui::widget::{normalize_column_name, TableFilterPredicate};
 
 // ---------------------------------------------------------------------------
 // Quoting helpers (copied from pod/kube/filter/parser.rs to avoid cross-feature dep)
@@ -211,17 +207,10 @@ fn parse_token<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
 // Column validation helpers
 // ---------------------------------------------------------------------------
 
-/// Build the set of valid column names from the builtin `NodeColumn` variants
-/// plus any headers registered in `label_registry`. All names are lowercased
-/// so matching is case-insensitive.
-fn valid_columns(label_registry: &[NodeLabelColumn]) -> HashSet<String> {
-    let mut set: HashSet<String> = NodeColumn::iter()
-        .map(|c| c.display().to_lowercase())
-        .collect();
-    for lc in label_registry {
-        set.insert(lc.header.to_lowercase());
-    }
-    set
+/// Build the set of valid column names from the current table header,
+/// normalized so matching is case/format-insensitive.
+fn valid_columns(header: &[String]) -> HashSet<String> {
+    header.iter().map(|h| normalize_column_name(h)).collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -230,20 +219,19 @@ fn valid_columns(label_registry: &[NodeLabelColumn]) -> HashSet<String> {
 
 /// Parse a Node-filter input string into a `TableFilterPredicate`.
 ///
-/// `label_registry` supplies the set of valid label-column headers (in
-/// addition to the builtin Node column headers). Unknown column names
-/// produce a parse error.
+/// `header` is the table's current display header. Column references are
+/// validated (case/format-insensitive) against it; a column not in the current
+/// view produces a parse error. When `header` is empty (e.g. before the first
+/// poll populates the table) column validation is skipped.
 ///
-/// Values may be quoted (`"..."` / `'...'`) to include whitespace, with the
-/// same escape rules as the Pod log query parser:
-///   `\"` → `"`   `\'` → `'`   `\\` → `\`   `\<other>` → `\<other>`
-// Consumed by the node_filter_applicator factory in Task 6 (this PR).
-#[allow(dead_code)]
+/// Values may be quoted (`"..."` / `'...'`) with the same escape rules as the
+/// Pod log query parser: `\"` → `"`  `\'` → `'`  `\\` → `\`  `\<other>` verbatim.
 pub fn parse_node_filter(
     input: &str,
-    label_registry: &[NodeLabelColumn],
+    header: &[String],
 ) -> Result<TableFilterPredicate, String> {
-    let valid = valid_columns(label_registry);
+    let valid = valid_columns(header);
+    let validate = !header.is_empty();
 
     let trimmed = input.trim();
     let mut column_includes: HashMap<String, Vec<Regex>> = HashMap::new();
@@ -284,20 +272,22 @@ pub fn parse_node_filter(
                     .push(rx);
             }
             Term::Include { column, value } => {
-                if !valid.contains(&column) {
-                    return Err(format!("unknown column '{}'", column));
+                let col = normalize_column_name(&column);
+                if validate && !valid.contains(&col) {
+                    return Err(format!("column '{}' is not in the current view", column));
                 }
                 let rx =
                     Regex::new(&value).map_err(|e| format!("invalid regex '{}': {}", value, e))?;
-                column_includes.entry(column).or_default().push(rx);
+                column_includes.entry(col).or_default().push(rx);
             }
             Term::Exclude { column, value } => {
-                if !valid.contains(&column) {
-                    return Err(format!("unknown column '{}'", column));
+                let col = normalize_column_name(&column);
+                if validate && !valid.contains(&col) {
+                    return Err(format!("column '{}' is not in the current view", column));
                 }
                 let rx =
                     Regex::new(&value).map_err(|e| format!("invalid regex '{}': {}", value, e))?;
-                column_excludes.entry(column).or_default().push(rx);
+                column_excludes.entry(col).or_default().push(rx);
             }
             Term::Label(sel) => {
                 // Last label: term wins (k8s API accepts only one labelSelector value).
@@ -319,13 +309,27 @@ mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
 
-    fn no_label_cols() -> Vec<NodeLabelColumn> {
-        Vec::new()
+    fn header() -> Vec<String> {
+        [
+            "NAME",
+            "STATUS",
+            "ROLES",
+            "AGE",
+            "VERSION",
+            "INTERNAL-IP",
+            "EXTERNAL-IP",
+            "OS-IMAGE",
+            "KERNEL-VERSION",
+            "CONTAINER-RUNTIME",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect()
     }
 
     #[test]
     fn empty_input_yields_empty_predicate() {
-        let p = parse_node_filter("", &no_label_cols()).unwrap();
+        let p = parse_node_filter("", &header()).unwrap();
         assert!(p.column_includes.is_empty());
         assert!(p.column_excludes.is_empty());
         assert_eq!(p.label_selector, None);
@@ -334,14 +338,14 @@ mod tests {
 
     #[test]
     fn whitespace_only_input_yields_empty_predicate() {
-        let p = parse_node_filter("   \t  ", &no_label_cols()).unwrap();
+        let p = parse_node_filter("   \t  ", &header()).unwrap();
         assert!(p.column_includes.is_empty());
         assert_eq!(p.raw, "");
     }
 
     #[test]
     fn single_bare_value_becomes_name_include() {
-        let p = parse_node_filter("worker", &no_label_cols()).unwrap();
+        let p = parse_node_filter("worker", &header()).unwrap();
         assert_eq!(p.column_includes.len(), 1);
         let patterns = p.column_includes.get("name").expect("name column");
         assert_eq!(patterns.len(), 1);
@@ -352,7 +356,7 @@ mod tests {
 
     #[test]
     fn multiple_bare_values_become_name_or() {
-        let p = parse_node_filter("foo bar", &no_label_cols()).unwrap();
+        let p = parse_node_filter("foo bar", &header()).unwrap();
         let patterns = p.column_includes.get("name").expect("name column");
         assert_eq!(patterns.len(), 2);
         assert_eq!(p.raw, "foo bar");
@@ -360,7 +364,7 @@ mod tests {
 
     #[test]
     fn explicit_column_include_creates_column_entry() {
-        let p = parse_node_filter("status:Ready", &no_label_cols()).unwrap();
+        let p = parse_node_filter("status:Ready", &header()).unwrap();
         assert_eq!(p.column_includes.len(), 1);
         let patterns = p.column_includes.get("status").expect("status column");
         assert_eq!(patterns.len(), 1);
@@ -370,14 +374,14 @@ mod tests {
 
     #[test]
     fn column_names_are_case_insensitive_canonicalized_lowercase() {
-        let p = parse_node_filter("STATUS:Ready Name:worker", &no_label_cols()).unwrap();
+        let p = parse_node_filter("STATUS:Ready Name:worker", &header()).unwrap();
         assert!(p.column_includes.contains_key("status"));
         assert!(p.column_includes.contains_key("name"));
     }
 
     #[test]
     fn same_column_includes_accumulate_in_order() {
-        let p = parse_node_filter("status:Ready status:Pending", &no_label_cols()).unwrap();
+        let p = parse_node_filter("status:Ready status:Pending", &header()).unwrap();
         let patterns = p.column_includes.get("status").expect("status column");
         assert_eq!(patterns.len(), 2);
         assert!(patterns[0].is_match("Ready"));
@@ -386,14 +390,14 @@ mod tests {
 
     #[test]
     fn different_columns_coexist_in_predicate() {
-        let p = parse_node_filter("status:Ready name:worker", &no_label_cols()).unwrap();
+        let p = parse_node_filter("status:Ready name:worker", &header()).unwrap();
         assert_eq!(p.column_includes.len(), 2);
     }
 
     #[test]
     fn bare_and_column_includes_mix() {
         // `foo status:Ready` → NAME has `foo`, STATUS has `Ready`
-        let p = parse_node_filter("foo status:Ready", &no_label_cols()).unwrap();
+        let p = parse_node_filter("foo status:Ready", &header()).unwrap();
         assert_eq!(p.column_includes.len(), 2);
         assert_eq!(p.column_includes.get("name").unwrap().len(), 1);
         assert_eq!(p.column_includes.get("status").unwrap().len(), 1);
@@ -401,7 +405,7 @@ mod tests {
 
     #[test]
     fn excludes_prefixed_with_bang_populate_column_excludes() {
-        let p = parse_node_filter("!name:kube-system", &no_label_cols()).unwrap();
+        let p = parse_node_filter("!name:kube-system", &header()).unwrap();
         assert!(p.column_includes.is_empty());
         let patterns = p.column_excludes.get("name").expect("name column");
         assert_eq!(patterns.len(), 1);
@@ -410,7 +414,7 @@ mod tests {
 
     #[test]
     fn includes_and_excludes_coexist() {
-        let p = parse_node_filter("status:Ready !name:kube-system", &no_label_cols()).unwrap();
+        let p = parse_node_filter("status:Ready !name:kube-system", &header()).unwrap();
         assert_eq!(p.column_includes.len(), 1);
         assert_eq!(p.column_excludes.len(), 1);
     }
@@ -418,7 +422,7 @@ mod tests {
     #[test]
     fn bang_without_colon_is_treated_as_bare_value() {
         // `!worker` は `!name:worker` の省略形ではない。bang は明示的な column と組でのみ意味を持つ。
-        let p = parse_node_filter("!worker", &no_label_cols()).unwrap();
+        let p = parse_node_filter("!worker", &header()).unwrap();
         // 文字列 `!worker` がそのまま NAME 列の regex になる。regex crate は `!worker` をリテラル `!worker` のマッチとして受け入れる。
         let patterns = p.column_includes.get("name").expect("name column");
         assert_eq!(patterns.len(), 1);
@@ -428,7 +432,7 @@ mod tests {
 
     #[test]
     fn label_selector_is_captured_verbatim() {
-        let p = parse_node_filter("label:role=worker", &no_label_cols()).unwrap();
+        let p = parse_node_filter("label:role=worker", &header()).unwrap();
         assert_eq!(p.label_selector.as_deref(), Some("role=worker"));
         assert!(p.column_includes.is_empty());
         assert!(p.column_excludes.is_empty());
@@ -436,7 +440,7 @@ mod tests {
 
     #[test]
     fn label_selector_supports_kubectl_comma_and() {
-        let p = parse_node_filter("label:role=worker,zone=us-west", &no_label_cols()).unwrap();
+        let p = parse_node_filter("label:role=worker,zone=us-west", &header()).unwrap();
         assert_eq!(
             p.label_selector.as_deref(),
             Some("role=worker,zone=us-west")
@@ -447,7 +451,7 @@ mod tests {
     fn multiple_label_terms_keep_the_last() {
         // The k8s API accepts only one labelSelector value; spec requires
         // last-wins to match the Pod log query convention.
-        let p = parse_node_filter("label:a=1 label:b=2", &no_label_cols()).unwrap();
+        let p = parse_node_filter("label:a=1 label:b=2", &header()).unwrap();
         assert_eq!(p.label_selector.as_deref(), Some("b=2"));
     }
 
@@ -455,7 +459,7 @@ mod tests {
     fn label_and_column_terms_coexist() {
         let p = parse_node_filter(
             "status:Ready label:role=worker !name:kube-system",
-            &no_label_cols(),
+            &header(),
         )
         .unwrap();
         assert_eq!(p.column_includes.len(), 1);
@@ -463,30 +467,22 @@ mod tests {
         assert_eq!(p.label_selector.as_deref(), Some("role=worker"));
     }
 
-    fn registry_with(name: &str, header: &str) -> Vec<NodeLabelColumn> {
-        vec![NodeLabelColumn {
-            name: name.to_string(),
-            key: "irrelevant.example.com/key".to_string(),
-            header: header.to_string(),
-        }]
-    }
-
     #[test]
     fn unknown_column_produces_parse_error() {
-        let err = parse_node_filter("statusu:Ready", &no_label_cols()).unwrap_err();
+        let err = parse_node_filter("statusu:Ready", &header()).unwrap_err();
         assert!(
-            err.contains("unknown column") && err.contains("statusu"),
-            "error should mention the bad column: {}",
+            err.contains("not in the current view") && err.contains("statusu"),
+            "error should explain the column is not shown: {}",
             err
         );
     }
 
     #[test]
     fn unknown_column_in_exclude_also_errors() {
-        let err = parse_node_filter("!agee:1h", &no_label_cols()).unwrap_err();
+        let err = parse_node_filter("!agee:1h", &header()).unwrap_err();
         assert!(
-            err.contains("unknown column") && err.contains("agee"),
-            "error should mention the bad column: {}",
+            err.contains("not in the current view") && err.contains("agee"),
+            "error should explain the column is not shown: {}",
             err
         );
     }
@@ -494,13 +490,14 @@ mod tests {
     #[test]
     fn builtin_columns_are_accepted() {
         // `name` and `status` are builtin headers — must not error.
-        assert!(parse_node_filter("name:n status:s", &no_label_cols()).is_ok());
+        assert!(parse_node_filter("name:n status:s", &header()).is_ok());
     }
 
     #[test]
-    fn registered_label_column_header_is_accepted() {
-        let regs = registry_with("zone", "ZONE");
-        let p = parse_node_filter("zone:us-west", &regs).unwrap();
+    fn header_column_is_accepted() {
+        let mut h = header();
+        h.push("ZONE".to_string());
+        let p = parse_node_filter("zone:us-west", &h).unwrap();
         assert!(p.column_includes.contains_key("zone"));
     }
 
@@ -508,7 +505,36 @@ mod tests {
     fn label_keyword_is_not_treated_as_a_column_lookup() {
         // 'label:role=worker' must NOT trigger unknown-column validation
         // (it's the special-cased k8s labelSelector path).
-        assert!(parse_node_filter("label:role=worker", &no_label_cols()).is_ok());
+        assert!(parse_node_filter("label:role=worker", &header()).is_ok());
+    }
+
+    #[test]
+    fn multiword_column_with_space_is_filterable_via_compact_token() {
+        // 課題 I: a header column with a space (e.g. NOMINATED NODE) is
+        // addressable via a compact token, stored under its normalized key.
+        let h = vec!["NAME".to_string(), "NOMINATED NODE".to_string()];
+        let p = parse_node_filter("nominatednode:foo", &h).unwrap();
+        assert!(p.column_includes.contains_key("nominatednode"));
+    }
+
+    #[test]
+    fn column_not_in_header_produces_not_in_view_error() {
+        // 課題 II: VERSION is a real builtin name, but with a header that omits
+        // it, filtering on it must error rather than hide all rows.
+        let h = vec!["NAME".to_string(), "STATUS".to_string()];
+        let err = parse_node_filter("version:1.2", &h).unwrap_err();
+        assert!(
+            err.contains("not in the current view") && err.contains("version"),
+            "error should explain the column is not shown: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn empty_header_skips_column_validation() {
+        // Before the first poll the header may be empty; don't reject valid input.
+        let p = parse_node_filter("status:Ready", &[]).unwrap();
+        assert!(p.column_includes.contains_key("status"));
     }
 
     // -----------------------------------------------------------------------
@@ -517,22 +543,22 @@ mod tests {
 
     #[test]
     fn double_quoted_value_with_spaces_is_kept_intact() {
-        let p = parse_node_filter(r#"os-image:"Ubuntu 22.04.3 LTS""#, &no_label_cols()).unwrap();
-        let patterns = p.column_includes.get("os-image").expect("os-image col");
+        let p = parse_node_filter(r#"os-image:"Ubuntu 22.04.3 LTS""#, &header()).unwrap();
+        let patterns = p.column_includes.get("osimage").expect("osimage col");
         assert_eq!(patterns.len(), 1);
         assert!(patterns[0].is_match("Ubuntu 22.04.3 LTS"));
     }
 
     #[test]
     fn single_quoted_value_with_spaces_is_kept_intact() {
-        let p = parse_node_filter(r#"os-image:'Ubuntu 22.04 LTS'"#, &no_label_cols()).unwrap();
-        let patterns = p.column_includes.get("os-image").unwrap();
+        let p = parse_node_filter(r#"os-image:'Ubuntu 22.04 LTS'"#, &header()).unwrap();
+        let patterns = p.column_includes.get("osimage").unwrap();
         assert!(patterns[0].is_match("Ubuntu 22.04 LTS"));
     }
 
     #[test]
     fn quoted_value_with_escaped_quote() {
-        let p = parse_node_filter(r#"name:"foo\"bar""#, &no_label_cols()).unwrap();
+        let p = parse_node_filter(r#"name:"foo\"bar""#, &header()).unwrap();
         let patterns = p.column_includes.get("name").unwrap();
         // 値は `foo"bar` という regex
         assert!(patterns[0].is_match(r#"foo"bar"#));
@@ -541,7 +567,7 @@ mod tests {
     #[test]
     fn quoted_value_preserves_regex_backslash_classes() {
         // `\s` をリテラルに残して regex `\s`（空白）になる
-        let p = parse_node_filter(r#"name:"foo\sbar""#, &no_label_cols()).unwrap();
+        let p = parse_node_filter(r#"name:"foo\sbar""#, &header()).unwrap();
         let patterns = p.column_includes.get("name").unwrap();
         assert!(patterns[0].is_match("foo bar")); // regex \s が空白マッチ
         assert!(!patterns[0].is_match("foobar"));
@@ -550,7 +576,7 @@ mod tests {
     #[test]
     fn bare_value_with_quoted_spaces() {
         // bare の場合も quoted value をサポート: "node a" → NAME に regex "node a"
-        let p = parse_node_filter(r#""node a""#, &no_label_cols()).unwrap();
+        let p = parse_node_filter(r#""node a""#, &header()).unwrap();
         let patterns = p.column_includes.get("name").unwrap();
         assert!(patterns[0].is_match("node a"));
     }
@@ -558,13 +584,13 @@ mod tests {
     #[test]
     fn mixed_quoted_and_unquoted_tokens() {
         let p =
-            parse_node_filter(r#"status:Ready os-image:"Ubuntu 22.04""#, &no_label_cols()).unwrap();
+            parse_node_filter(r#"status:Ready os-image:"Ubuntu 22.04""#, &header()).unwrap();
         assert_eq!(p.column_includes.len(), 2);
-        assert!(p.column_includes.get("os-image").unwrap()[0].is_match("Ubuntu 22.04"));
+        assert!(p.column_includes.get("osimage").unwrap()[0].is_match("Ubuntu 22.04"));
     }
 
     #[test]
     fn unclosed_quote_is_a_parse_error() {
-        assert!(parse_node_filter(r#"name:"unterminated"#, &no_label_cols()).is_err());
+        assert!(parse_node_filter(r#"name:"unterminated"#, &header()).is_err());
     }
 }

--- a/src/features/node/view/tab.rs
+++ b/src/features/node/view/tab.rs
@@ -41,7 +41,7 @@ impl NodeTab {
         label_registry: Vec<NodeLabelColumn>,
         theme: WidgetThemeConfig,
     ) -> Self {
-        let node_widget = node_widget(tx.clone(), label_registry.clone(), theme.clone());
+        let node_widget = node_widget(tx.clone(), theme.clone());
         let detail_widget = node_detail_widget(clipboard, theme.clone());
         let node_columns_dialog =
             node_columns_dialog(tx, default_columns, label_registry, theme.clone());

--- a/src/features/node/view/widgets/node.rs
+++ b/src/features/node/view/widgets/node.rs
@@ -4,11 +4,7 @@ use crate::{
     config::theme::WidgetThemeConfig,
     features::{
         component_id::{NODE_COLUMNS_DIALOG_ID, NODE_DETAIL_WIDGET_ID, NODE_WIDGET_ID},
-        node::{
-            filter::node_filter_applicator,
-            message::NodeDetailMessage,
-            node_columns::NodeLabelColumn,
-        },
+        node::{filter::node_filter_applicator, message::NodeDetailMessage},
     },
     message::Message,
     ui::{
@@ -28,11 +24,7 @@ use crate::{
     },
 };
 
-pub fn node_widget(
-    tx: Sender<Message>,
-    label_registry: Vec<NodeLabelColumn>,
-    theme: WidgetThemeConfig,
-) -> Widget<'static> {
+pub fn node_widget(tx: Sender<Message>, theme: WidgetThemeConfig) -> Widget<'static> {
     let widget_theme = WidgetTheme::from(theme.clone());
     let table_theme = TableTheme::from(theme.clone());
 
@@ -48,7 +40,7 @@ pub fn node_widget(
         .id(NODE_WIDGET_ID)
         .widget_base(widget_base)
         .filter_form(filter_form)
-        .filter_applicator(node_filter_applicator(label_registry, tx.clone()))
+        .filter_applicator(node_filter_applicator(tx.clone()))
         .theme(table_theme)
         .action('t', open_node_columns_dialog())
         .block_injection(block_injection())

--- a/src/features/node/view/widgets/node_filter_help.rs
+++ b/src/features/node/view/widgets/node_filter_help.rs
@@ -69,9 +69,11 @@ fn content() -> Vec<String> {
            OS-IMAGE:"Ubuntu 22.04 LTS"     Quoted value with whitespace
            NAME:"foo bar"                  Quote bare value too
 
-        Column names are case-insensitive. Unknown columns produce a
-        parse error. Press Enter to apply, Esc to cancel. Type ? or
-        help in the filter input to open this help.
+        Filterable columns are the ones currently shown in the table.
+        Column names ignore case, spaces, '-' and '_'. A column not in
+        the current view produces an error (add it via the columns
+        dialog). Press Enter to apply, Esc to cancel. Type ? or help in
+        the filter input to open this help.
     "# }
     .lines()
     .map(ToString::to_string)

--- a/src/ui/widget/table.rs
+++ b/src/ui/widget/table.rs
@@ -48,6 +48,7 @@ pub use filter::{FilterForm, FilterFormTheme};
 // PR B. The `unused_imports` warning is therefore expected and silenced here.
 #[allow(unused_imports)]
 pub use filter_applicator::{
+    normalize_column_name,
     substring_applicator,
     ApplyStrategy,
     OnFilterApply,

--- a/src/ui/widget/table.rs
+++ b/src/ui/widget/table.rs
@@ -829,6 +829,7 @@ impl Table<'_> {
     /// 成功時は Some(predicate)、失敗時は None。
     /// Live モードでは毎キー、EnterToConfirm モードでは Enter 時に呼ぶ。
     fn run_parser_and_update_state(&mut self) -> Option<TableFilterPredicate> {
+        let header = self.items.header().original().to_vec();
         let applicator = self.filter_applicator.as_ref()?;
         let input = self
             .filter_form
@@ -836,7 +837,7 @@ impl Table<'_> {
             .map(|f| f.content())
             .unwrap_or_default();
 
-        match (applicator.parser.closure)(&input) {
+        match (applicator.parser.closure)(&input, &header) {
             Ok(predicate) => {
                 self.filter_error = None;
                 self.filter_state = Some(predicate.clone());
@@ -1117,7 +1118,7 @@ mod tests {
             use crate::ui::widget::{ApplyStrategy, TableFilterApplicator, TableFilterParser};
 
             let applicator = TableFilterApplicator::new(
-                TableFilterParser::from(move |_: &str| {
+                TableFilterParser::from(move |_: &str, _: &[String]| {
                     Ok(crate::ui::widget::TableFilterPredicate::default())
                 }),
                 ApplyStrategy::Live,
@@ -1600,7 +1601,7 @@ mod tests {
 
         fn dummy_applicator_with_help() -> TableFilterApplicator {
             let parser: TableFilterParser =
-                (|_input: &str| Ok(TableFilterPredicate::default())).into();
+                (|_input: &str, _header: &[String]| Ok(TableFilterPredicate::default())).into();
             TableFilterApplicator::new(parser, ApplyStrategy::EnterToConfirm)
                 .with_help_dialog("test-help-dialog")
         }
@@ -1657,7 +1658,7 @@ mod tests {
         fn help_does_not_open_without_help_dialog_id() {
             // help_dialog_id を持たない applicator
             let parser: TableFilterParser =
-                (|_input: &str| Ok(TableFilterPredicate::default())).into();
+                (|_input: &str, _header: &[String]| Ok(TableFilterPredicate::default())).into();
             let applicator = TableFilterApplicator::new(parser, ApplyStrategy::Live);
 
             let mut table = Table::builder()

--- a/src/ui/widget/table/filter_applicator.rs
+++ b/src/ui/widget/table/filter_applicator.rs
@@ -108,7 +108,7 @@ use crate::{
 
 // TableFilterParser: parses a raw filter string into a TableFilterPredicate.
 // Returns Ok(predicate) on success, or Err(message) for display to the user.
-define_callback!(pub TableFilterParser, Fn(&str) -> Result<TableFilterPredicate, String>);
+define_callback!(pub TableFilterParser, Fn(&str, &[String]) -> Result<TableFilterPredicate, String>);
 
 // OnFilterApply: called after a filter has been applied (or cleared). Receives
 // the new predicate and a mutable Window reference for side effects (e.g.,
@@ -224,7 +224,7 @@ use EventResult as _;
 ///   意識しなくていい、`.` `*` 等が混入しても安全）
 pub fn substring_applicator(column: &str) -> TableFilterApplicator {
     let col = column.to_string().to_lowercase();
-    let parser: TableFilterParser = (move |input: &str| {
+    let parser: TableFilterParser = (move |input: &str, _header: &[String]| {
         let raw = input.to_string();
         let patterns: Result<Vec<Regex>, _> = input
             .split_whitespace()
@@ -439,7 +439,7 @@ mod tests {
     }
 
     fn invoke_parser(a: &TableFilterApplicator, input: &str) -> TableFilterPredicate {
-        (a.parser.closure)(input).expect("test input must parse")
+        (a.parser.closure)(input, &[]).expect("test input must parse")
     }
 
     #[test]

--- a/src/ui/widget/table/filter_applicator.rs
+++ b/src/ui/widget/table/filter_applicator.rs
@@ -71,17 +71,26 @@ impl TableFilterPredicate {
     }
 }
 
+/// Normalize a column name for case/format-insensitive comparison: lowercase,
+/// with spaces, hyphens, and underscores removed. This lets `nominatednode`,
+/// `nominated-node`, and `Nominated_Node` all match the `NOMINATED NODE`
+/// header, and keeps hyphenated headers (e.g. `INTERNAL-IP`) matchable from a
+/// single whitespace-delimited token.
+pub fn normalize_column_name(s: &str) -> String {
+    s.to_lowercase().replace([' ', '-', '_'], "")
+}
+
 /// Returns the ANSI-stripped text of the column named `col_name` in `item`,
-/// or `None` if the column name is not found in `header`.
+/// or `None` if no header column normalizes to the same key.
 // TODO(perf): cell_of() is called per column × per row × per render. Each
 // invocation re-lowercases the entire header. If profiling shows this in the
 // hot path once Table widget wiring lands (Tasks 5/7), pre-compute a
 // column-name → index map at filter_state set time.
 fn cell_of(item: &TableItem, header: &[String], col_name: &str) -> Option<String> {
-    let col_name_lower = col_name.to_lowercase();
+    let key = normalize_column_name(col_name);
     let idx = header
         .iter()
-        .position(|h| h.to_lowercase() == col_name_lower)?;
+        .position(|h| normalize_column_name(h) == key)?;
 
     item.item
         .get(idx)
@@ -495,5 +504,49 @@ mod tests {
     fn substring_applicator_on_cancel_is_none() {
         let a = substring_applicator("NAME");
         assert!(a.on_cancel.is_none());
+    }
+
+    #[test]
+    fn normalize_column_name_strips_space_hyphen_underscore_and_lowercases() {
+        assert_eq!(normalize_column_name("NOMINATED NODE"), "nominatednode");
+        assert_eq!(normalize_column_name("Internal-IP"), "internalip");
+        assert_eq!(normalize_column_name("Readiness_Gates"), "readinessgates");
+        assert_eq!(normalize_column_name("name"), "name");
+    }
+
+    #[test]
+    fn matches_resolves_multiword_column_via_normalized_key() {
+        let header = vec!["NAME".to_string(), "NOMINATED NODE".to_string()];
+        let item = make_item(&["pod-a", "node-x"]);
+
+        let mut includes = HashMap::new();
+        includes.insert(
+            "nominatednode".to_string(),
+            vec![Regex::new("node-x").unwrap()],
+        );
+        let pred = TableFilterPredicate {
+            column_includes: includes,
+            ..Default::default()
+        };
+
+        assert!(pred.matches(&item, &header));
+    }
+
+    #[test]
+    fn matches_resolves_hyphenated_header_from_compact_key() {
+        let header = vec!["NAME".to_string(), "INTERNAL-IP".to_string()];
+        let item = make_item(&["pod-a", "10.0.0.1"]);
+
+        let mut includes = HashMap::new();
+        includes.insert(
+            "internalip".to_string(),
+            vec![Regex::new(r"10\.0").unwrap()],
+        );
+        let pred = TableFilterPredicate {
+            column_includes: includes,
+            ..Default::default()
+        };
+
+        assert!(pred.matches(&item, &header));
     }
 }


### PR DESCRIPTION
## Summary

Fixes two pre-existing defects in the shared Table filter framework (surfaced in the Node tab). These were discovered while planning the Pod column-aware migration; they are framework-level issues, not Pod-specific.

- **Issue I — column names containing spaces were unfilterable**: the parser splits input on whitespace, and matching (`cell_of`) compared column names by plain lowercase equality, so a column whose name contains a space (e.g. a Node label column with a space) could never be matched.
- **Issue II — filtering a valid-but-hidden column silently emptied the table**: `valid_columns` was built from the full enum + label registry, while matching treats a column not present in the live header as an empty cell. As a result, filtering on a real-but-hidden column (e.g. `internalip:...` with the default 5-of-10 columns) parsed fine and then made the whole table appear empty, with no feedback.

### Approach

- Extend the `TableFilterParser` callback to receive the table's **live header** (`Fn(&str, &[String]) -> ...`).
- Introduce a shared `normalize_column_name` (lowercase + strip spaces, `-`, `_`) and use it on **both** the matching side (`cell_of`) and the validation side (the Node parser), unifying column-name comparison. → fixes Issue I.
- The Node parser now **validates column references against the live header** instead of a builtin-enum / label-registry snapshot. A column not currently shown produces a `column '<x>' is not in the current view` parse error (validation is skipped when the header is empty, e.g. before the first poll). → fixes Issue II.
- Remove the now-obsolete `label_registry` argument from `node_filter_applicator` → `node_widget` → tab.rs (kept in `NodeTab::new` for the columns dialog).
- `substring_applicator` (Pod/Config/Network) simply ignores the header → **behavior unchanged**.

This aligns with the TUI user's mental model of "you can filter the columns you can see," and returns a helpful error when a column is not in view.

### Scope

- Phase A (this PR) = framework fix, validated on the Node tab.
- The Pod column-aware filter migration (including the `label:` server-side selector) is **Phase B (separate PR)**.

### Known limitation (out of scope)

Validation runs at parse time only. If a filter is applied and then its column is hidden via the columns dialog, `filter_state` keeps the stale key and Issue II's symptom can recur through a different path (this is pre-existing behavior; re-opening the filter and pressing Enter correctly produces the error). A future improvement could clear/flag `filter_state` when its referenced columns disappear from the header.

Design: `docs/superpowers/specs/2026-05-29-table-filter-header-aware-validation-design.md`
Plan: `docs/superpowers/plans/2026-05-29-table-filter-header-aware-validation.md`

## Test Plan

- [x] `cargo test --all` (635 passed / 0 failed; new Node-parser tests for multi-word columns, hidden-column error, and empty header)
- [x] `cargo clippy --all-targets` (no new warnings in the changed files)
- [x] `cargo +nightly fmt --check` (no diff)
- [x] Manual smoke test (verified on a real cluster, 2026-05-29):
  - [x] With default columns (INTERNAL-IP hidden), `internalip:10.` shows a "not in the current view" error and does NOT empty the table (Issue II)
  - [x] Recovery from the error (clearing input / Esc returns to the list)
  - [x] After adding INTERNAL-IP via the columns dialog (`t`), `internalip:10.` filters correctly
  - [x] `internalip:` / `internal-ip:` / `INTERNAL_IP:` produce the same result (normalization)
  - [x] `status:Ready` (single column) / bare→NAME / same-column OR / cross-column AND / `!`exclude / quoted value
  - [x] `label:role=worker` works server-side and Esc clears it (no regression)
  - [x] `?` opens help with the updated wording; count indicator `[selected/visible (total)]`
  - [x] Known limitation (rows disappear when a filtered column is hidden) reproduces as expected