### PR TITLE
refactor(table-filter): extract shared column-aware filter parser core

### DIFF
--- a/docs/superpowers/plans/2026-05-30-shared-table-filter-parser.md
+++ b/docs/superpowers/plans/2026-05-30-shared-table-filter-parser.md
@@ -1,0 +1,361 @@
+# 共有 column-aware フィルタパーサコア抽出 実装計画 (B-0)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** column-aware フィルタパーサの汎用部分（トークナイザ・quoting・`Term`・`parse_token`・述語組み立て）を共有モジュールに抽出し、Node を載せ替える（挙動不変）。
+
+**Architecture:** 新規 `src/ui/widget/table/filter_parser.rs` に汎用 `parse_table_filter(input, validate_column: impl Fn(&str)->Result<(),String>)` と nom トークナイザを置く。Node の `parse_node_filter` は「`valid_columns` で列検証する closure を渡すだけ」の薄いラッパになる。タブ固有なのは列検証のみ。Pod・Config・Network は本 PR では不変。
+
+**Tech Stack:** Rust 2021、nom、regex、strum、`#[cfg(test)]` インラインテスト、pretty_assertions。
+
+参照 spec: `docs/superpowers/specs/2026-05-29-shared-table-filter-parser-design.md`
+注: kubetui は binary crate。テストは `cargo test <path>` / `cargo test --all`（`--lib` は不可）。
+
+---
+
+## ファイル構成
+
+- Create: `src/ui/widget/table/filter_parser.rs` — quoting/`Term`/`parse_token`（Node から移設）＋汎用 `parse_table_filter`＋単体テスト。
+- Modify: `src/ui/widget/table.rs` — `mod filter_parser;` ＋ `parse_table_filter` を `crate::ui::widget` から使えるよう再エクスポート（`normalize_column_name` と同じ経路）。
+- Modify: `src/features/node/filter/parser.rs` — 移設分を削除、`parse_node_filter` をラッパ化、import 整理。`valid_columns` とテストは維持。
+
+---
+
+## Task 1: 共有モジュール `filter_parser.rs` を新規作成
+
+この時点では Node 側は変更しない（一時的にトークナイザが2箇所に存在するが、両方ともコンパイル可能・Node は従来コードを使用）。
+
+**Files:**
+- Create: `src/ui/widget/table/filter_parser.rs`
+- Modify: `src/ui/widget/table.rs`（`mod filter_parser;` ＋ 再エクスポート）
+
+- [ ] **Step 1: 新規ファイルにトークナイザを移設（verbatim コピー）＋`parse_table_filter` を実装**
+
+`src/ui/widget/table/filter_parser.rs` を新規作成し、先頭に次の import とドックコメントを置く:
+
+```rust
+//! Shared column-aware filter parser core.
+//!
+//! Tokenizer + quoting + `Term` + `parse_table_filter`, used by every
+//! column-aware tab filter (Node now; Pod/Config/Network later). The only
+//! tab-specific part is the `validate_column` closure passed by the caller.
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+
+use nom::{
+    branch::alt,
+    bytes::complete::{is_not, tag},
+    character::complete::{anychar, char, multispace0, multispace1},
+    combinator::{map, value, verify},
+    error::{ContextError, ParseError},
+    multi::{fold_many0, separated_list0},
+    sequence::{delimited, preceded},
+    IResult,
+    Parser,
+};
+use regex::Regex;
+
+use crate::ui::widget::{normalize_column_name, TableFilterPredicate};
+```
+
+続けて、`src/features/node/filter/parser.rs` から次の項目を **verbatim（一字一句そのまま）コピー**する:
+- `quoted`（現 node parser.rs 33-99 行）
+- `unquoted`（103-109 行）
+- `value_string`（112-116 行）
+- `column_name`（119-123 行）
+- `enum Term`（130-140 行、`#[derive(Debug)]` 付き）
+- `parse_token`（151-208 行）
+
+（コメント行 `// Quoting helpers (copied from pod/kube/filter/parser.rs ...)` 等は適宜残してよい。これらは Node 側から後の Task 2 で削除する。）
+
+その後に、新規の汎用パース関数を追加する:
+
+```rust
+/// Parse a column-aware filter string into a `TableFilterPredicate`.
+///
+/// `validate_column` is called with each `COL:`/`!COL:` column token (already
+/// lowercased by the tokenizer) and returns `Ok(())` if acceptable, or
+/// `Err(message)` to abort parsing with that message — the only tab-specific
+/// part. Stored predicate keys are normalized via `normalize_column_name`.
+/// Bare values map to the `name` include; `label:` is captured verbatim (last
+/// wins); values may be quoted with the log-query escape rules.
+pub fn parse_table_filter(
+    input: &str,
+    validate_column: impl Fn(&str) -> Result<(), String>,
+) -> Result<TableFilterPredicate, String> {
+    let trimmed = input.trim();
+    let mut column_includes: HashMap<String, Vec<Regex>> = HashMap::new();
+    let mut column_excludes: HashMap<String, Vec<Regex>> = HashMap::new();
+    let mut label_selector: Option<String> = None;
+
+    if trimmed.is_empty() {
+        return Ok(TableFilterPredicate {
+            column_includes,
+            column_excludes,
+            label_selector,
+            raw: trimmed.to_string(),
+        });
+    }
+
+    // Parse the whole trimmed input as whitespace-separated tokens.
+    type E<'a> = nom::error::Error<&'a str>;
+    let parse_result = delimited(
+        multispace0,
+        separated_list0(multispace1, parse_token::<E>),
+        multispace0,
+    )
+    .parse(trimmed);
+
+    let (remaining, terms) = parse_result.map_err(|e| format!("parse error: {}", e))?;
+
+    if !remaining.is_empty() {
+        return Err(format!("unexpected input near: {:?}", remaining));
+    }
+
+    for term in terms {
+        match term {
+            Term::Bare(v) => {
+                let rx = Regex::new(&v).map_err(|e| format!("invalid regex '{}': {}", v, e))?;
+                column_includes
+                    .entry("name".to_string())
+                    .or_default()
+                    .push(rx);
+            }
+            Term::Include { column, value } => {
+                validate_column(&column)?;
+                let rx =
+                    Regex::new(&value).map_err(|e| format!("invalid regex '{}': {}", value, e))?;
+                column_includes
+                    .entry(normalize_column_name(&column))
+                    .or_default()
+                    .push(rx);
+            }
+            Term::Exclude { column, value } => {
+                validate_column(&column)?;
+                let rx =
+                    Regex::new(&value).map_err(|e| format!("invalid regex '{}': {}", value, e))?;
+                column_excludes
+                    .entry(normalize_column_name(&column))
+                    .or_default()
+                    .push(rx);
+            }
+            Term::Label(sel) => {
+                // Last label: term wins (k8s API accepts only one labelSelector value).
+                label_selector = Some(sel);
+            }
+        }
+    }
+
+    Ok(TableFilterPredicate {
+        column_includes,
+        column_excludes,
+        label_selector,
+        raw: trimmed.to_string(),
+    })
+}
+```
+
+- [ ] **Step 2: `mod filter_parser;` 宣言と再エクスポートを追加**
+
+`src/ui/widget/table.rs` の先頭付近、既存の `mod filter_applicator;` の隣に `mod filter_parser;` を追加する。そして `normalize_column_name` が `crate::ui::widget::normalize_column_name` として使える経路と同じ形で、`parse_table_filter` を再エクスポートする。具体的には、table.rs に既にある `pub use filter_applicator::{ … };` の近くに次を追加する:
+
+```rust
+pub use filter_parser::parse_table_filter;
+```
+
+`crate::ui::widget` から `parse_table_filter` を import できることを次の grep/ビルドで確認する。`src/ui/widget.rs`（または `src/ui/widget/mod.rs`）が table モジュールの pub アイテムを再エクスポートしている（`normalize_column_name` がそこ経由で届いている）。同じ仕組みで `parse_table_filter` も届くはず。もし届かなければ、`normalize_column_name` を再エクスポートしている行に `parse_table_filter` を追記する。
+
+- [ ] **Step 3: `parse_table_filter` の単体テストを追加**
+
+`src/ui/widget/table/filter_parser.rs` の末尾に追加する。`validate_column` には「全許可」と「特定列を弾く」の2種クロージャを使う。
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    fn allow_all(_: &str) -> Result<(), String> {
+        Ok(())
+    }
+
+    #[test]
+    fn empty_input_yields_empty_predicate() {
+        let p = parse_table_filter("", allow_all).unwrap();
+        assert!(p.column_includes.is_empty());
+        assert!(p.column_excludes.is_empty());
+        assert_eq!(p.label_selector, None);
+        assert_eq!(p.raw, "");
+    }
+
+    #[test]
+    fn bare_value_becomes_name_include() {
+        let p = parse_table_filter("worker", allow_all).unwrap();
+        assert!(p.column_includes.contains_key("name"));
+    }
+
+    #[test]
+    fn include_and_exclude_store_normalized_keys() {
+        let p = parse_table_filter("Status:Ready !INTERNAL-IP:10.", allow_all).unwrap();
+        assert!(p.column_includes.contains_key("status"));
+        assert!(p.column_excludes.contains_key("internalip"));
+    }
+
+    #[test]
+    fn label_is_captured_last_wins() {
+        let p = parse_table_filter("label:a=1 label:b=2", allow_all).unwrap();
+        assert_eq!(p.label_selector.as_deref(), Some("b=2"));
+    }
+
+    #[test]
+    fn quoted_value_with_whitespace() {
+        let p = parse_table_filter(r#"name:"foo bar""#, allow_all).unwrap();
+        let patterns = p.column_includes.get("name").unwrap();
+        assert!(patterns[0].is_match("foo bar"));
+    }
+
+    #[test]
+    fn validate_column_error_aborts_parse() {
+        let reject_status = |c: &str| {
+            if c == "status" {
+                Err("nope".to_string())
+            } else {
+                Ok(())
+            }
+        };
+        let err = parse_table_filter("status:Ready", reject_status).unwrap_err();
+        assert_eq!(err, "nope");
+    }
+
+    #[test]
+    fn invalid_regex_errors() {
+        let err = parse_table_filter("name:[", allow_all).unwrap_err();
+        assert!(err.contains("invalid regex"), "got: {}", err);
+    }
+}
+```
+
+- [ ] **Step 4: ビルドとテストを実行**
+
+Run: `cargo test ui::widget::table::filter_parser 2>&1 | tail -30`
+Expected: コンパイル成功、新規テスト全て PASS。Node 側は未変更なので `cargo build` も通る。
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/ui/widget/table/filter_parser.rs src/ui/widget/table.rs
+git commit -m "feat(table-filter): add shared parse_table_filter core (tokenizer + quoting)"
+```
+
+---
+
+## Task 2: Node パーサを共有コアへ載せ替え＋重複削除
+
+**Files:**
+- Modify: `src/features/node/filter/parser.rs`
+
+- [ ] **Step 1: 移設済みヘルパーを削除し import を整理**
+
+`src/features/node/filter/parser.rs` から次を**削除**する（Task 1 で共有モジュールへ移したもの）:
+- `quoted` / `unquoted` / `value_string` / `column_name` の各関数（およびその上の `// Quoting helpers ...` コメントブロック）。
+- `enum Term`。
+- `parse_token`。
+
+先頭の import を次に置き換える（不要になった nom 群・`Cow`・`HashMap`・`Regex` を除去。`HashSet`/`strum`/`NodeColumn`/`NodeLabelColumn` は `valid_columns` で使用、`parse_table_filter`/`normalize_column_name`/`TableFilterPredicate` を追加）:
+
+```rust
+use std::collections::HashSet;
+
+use strum::IntoEnumIterator;
+
+use crate::{
+    features::node::node_columns::{NodeColumn, NodeLabelColumn},
+    ui::widget::{normalize_column_name, parse_table_filter, TableFilterPredicate},
+};
+```
+
+- [ ] **Step 2: `parse_node_filter` をラッパ化**
+
+`valid_columns`（builtin `NodeColumn::iter()` の display 正規化＋registry header 正規化）は**そのまま残す**。`parse_node_filter` を次に置き換える:
+
+```rust
+/// Parse a Node-filter input string into a `TableFilterPredicate`.
+///
+/// Column references are validated against the set of *known* columns (builtin
+/// Node columns plus defined label columns in `label_registry`); an unknown
+/// column produces a parse error. A known column that is not currently
+/// displayed is accepted here and becomes inactive at match time. Tokenization
+/// and predicate building are delegated to the shared `parse_table_filter`.
+pub fn parse_node_filter(
+    input: &str,
+    label_registry: &[NodeLabelColumn],
+) -> Result<TableFilterPredicate, String> {
+    let valid = valid_columns(label_registry);
+    parse_table_filter(input, |column| {
+        if valid.contains(&normalize_column_name(column)) {
+            Ok(())
+        } else {
+            Err(format!("unknown column '{}'", column))
+        }
+    })
+}
+```
+
+（`#[cfg(test)] mod tests { … }` ブロックは**一切変更しない** — これが挙動不変の証明。テストは `parse_node_filter(input, &registry)` を呼び続け、quoting/escape/未定義列エラー等を網羅している。）
+
+- [ ] **Step 3: テストを実行（Node 挙動不変の確認）**
+
+Run: `cargo test features::node::filter 2>&1 | tail -30`
+Expected: Node parser の既存テストが**変更なしで全て PASS**。
+
+- [ ] **Step 4: 全体ビルド・clippy**
+
+Run: `cargo test --all 2>&1 | tail -20`
+Expected: 全テスト PASS。
+
+Run: `cargo clippy --all-targets 2>&1 | rg "filter_parser|node/filter|widget/table"`
+Expected: 変更ファイルに新規警告なし（特に node parser.rs に未使用 import が残っていないこと）。
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/features/node/filter/parser.rs
+git commit -m "refactor(node-filter): delegate to shared parse_table_filter (behavior-preserving)"
+```
+
+---
+
+## Task 3: 全体検証
+
+**Files:** なし（検証のみ）
+
+- [ ] **Step 1: 全テスト**
+
+Run: `cargo test --all 2>&1 | rg "test result:"`
+Expected: 全テスト PASS。
+
+- [ ] **Step 2: clippy**
+
+Run: `cargo clippy --all-targets 2>&1 | tail -30`
+Expected: 変更ファイル（filter_parser.rs / table.rs / node/filter/parser.rs）に新規警告なし。
+
+- [ ] **Step 3: format**
+
+Run: `cargo +nightly fmt --check 2>&1 | tail -30`
+Expected: 差分なし。出たら `cargo +nightly fmt` を実行して再コミット。注: 既存の無関係な fmt drift があれば変更ファイルに限定して確認する。
+
+- [ ] **Step 4:（必要なら）fmt 修正をコミット**
+
+```bash
+git add -A
+git commit -m "style: cargo fmt"
+```
+
+---
+
+## Self-Review（計画作成者によるチェック結果）
+
+- **Spec カバレッジ:** 共有モジュール＋`parse_table_filter`（spec §1）→ Task 1。mod 宣言・再エクスポート（spec §2）→ Task 1 Step 2。Node 載せ替え＋import 整理＋valid_columns 維持（spec §3）→ Task 2。テスト（spec §4：Node 既存テスト不変＋共有モジュール単体テスト）→ Task 1 Step 3／Task 2 Step 3／Task 3。全項目に対応タスクあり。
+- **プレースホルダ:** TBD/TODO なし。移設は「node parser.rs の該当関数を verbatim コピー」という一意・機械的指示（行番号付き）。新規コード（imports・`parse_table_filter`・テスト）は全文記載。
+- **型整合:** `parse_table_filter(&str, impl Fn(&str)->Result<(),String>) -> Result<TableFilterPredicate, String>`（Task 1）と Node のラッパ呼び出し（Task 2 Step 2、closure が `Fn(&str)->Result<(),String>`）一致。`normalize_column_name`/`TableFilterPredicate`/`parse_table_filter` は `crate::ui::widget` 経由で両モジュールから参照。`valid_columns(&[NodeLabelColumn])->HashSet<String>`（維持）と closure 内 `valid.contains(&normalize_column_name(column))` 一致。

--- a/docs/superpowers/specs/2026-05-29-shared-table-filter-parser-design.md
+++ b/docs/superpowers/specs/2026-05-29-shared-table-filter-parser-design.md
@@ -1,0 +1,111 @@
+# 共有 column-aware フィルタパーサコアの抽出（refactor）
+
+- 日付: 2026-05-29
+- ステータス: Proposed（提案中）
+- 種別: behavior-preserving refactor（ユーザー向け変更なし）
+- 対象範囲: 共有 Table widget（`src/ui/widget/table/`）＋ Node フィルタパーサ（`src/features/node/filter/parser.rs`）の載せ替え
+- 位置づけ: Pod の column-aware 移行（別 spec, PR B）の**先行 PR（B-0）**。本 PR では Pod は変更しない。
+
+## 背景・動機
+
+column-aware フィルタの構文（`COL:val` / `!COL:val` / `label:sel` / bare→NAME、quoting）を解釈する nom パーサが、現状 Node の `src/features/node/filter/parser.rs` に閉じている。ここには汎用的な部分（トークナイザ・quoting・`Term`・述語組み立て）と Node 固有の部分（既知列＝builtin `NodeColumn` ＋ label registry の検証）が混在している。
+
+Pod を column-aware 化する（PR B）と**2つ目の同型パーサ**が必要になる。実際 Node parser には「Quoting helpers (copied from pod/kube/filter/parser.rs to avoid cross-feature dep)」という注記があり、既に重複が始まっている。Pod でさらに複製すると、将来の Config/Network 移行でも増殖する。
+
+そこで Pod 移行の前に、**汎用部分を共有モジュールへ抽出**し、Node をその上に載せ替える。タブ固有なのは「どの列名を既知とみなすか（列バリデータ）」だけにする。
+
+## ゴール
+
+1. column-aware パーサの汎用コア（トークナイザ・quoting・`Term`・`parse_token`・述語組み立て）を1箇所に集約し、複数タブが**列検証だけ差し替えて**再利用できるようにする。
+2. Node をその共有コアに載せ替える。**Node の挙動は不変**（既存パーサテストが変更なしで通ることが証明）。
+3. Pod（PR B）/ 将来の Config/Network が同コアを使える土台を用意する。
+
+## 非ゴール
+
+- Pod の column-aware 移行（PR B、別 spec）。本 PR では Pod・Config・Network は一切変更しない。
+- 構文・挙動の変更。あくまで抽出のみ。
+
+## 設計
+
+### 1. 共有モジュール `src/ui/widget/table/filter_parser.rs`（新規）
+
+`src/features/node/filter/parser.rs` から以下を**移設**する:
+- quoting ヘルパー: `quoted` / `unquoted` / `value_string` / `column_name`（現 parser.rs:33-123）。
+- `Term` enum（`Bare` / `Include` / `Exclude` / `Label`、現 131-140）。
+- `parse_token`（現 151-208）。
+
+加えて、現 `parse_node_filter` の本体から**列検証を除いた汎用部分**を、次の関数として共有モジュールに置く:
+
+```rust
+/// Parse a column-aware filter string into a `TableFilterPredicate`.
+///
+/// `validate_column` is called with each `COL:`/`!COL:` column token (original
+/// casing) and returns `Ok(())` if the column is acceptable, or `Err(message)`
+/// to abort parsing with that message — this is the only tab-specific part.
+/// Stored predicate keys are normalized via `normalize_column_name`. Bare values
+/// map to the `name` include; `label:` is captured verbatim (last wins);
+/// values may be quoted with the log-query escape rules.
+pub fn parse_table_filter(
+    input: &str,
+    validate_column: impl Fn(&str) -> Result<(), String>,
+) -> Result<TableFilterPredicate, String>
+```
+
+挙動（現 `parse_node_filter` と等価）:
+- 空入力 → 空 predicate。
+- nom でホワイトスペース区切りトークン化（`parse_token`）。残余があれば `unexpected input near` エラー。
+- `Term::Bare(v)` → `column_includes["name"]` に regex を push。
+- `Term::Include{column,value}` → `validate_column(&column)?`、`normalize_column_name(&column)` をキーに regex を push。regex 不正は `invalid regex` エラー。
+- `Term::Exclude{...}` → 同様に `column_excludes` へ。
+- `Term::Label(sel)` → `label_selector = Some(sel)`（最後勝ち）。
+
+`TableFilterPredicate` と `normalize_column_name` は同じ `src/ui/widget/table/` 配下（`filter_applicator.rs`）にあり参照可能。
+
+### 2. モジュール配線
+
+`src/ui/widget/table.rs` に `mod filter_parser;` を追加し、`pub use filter_parser::parse_table_filter;`（および `crate::ui::widget` 経由の再エクスポート、`normalize_column_name` と同様）。`Term` / `parse_token` / quoting ヘルパーは共有モジュール内に閉じる（`pub` 不要、必要なら `pub(crate)`）。
+
+### 3. Node パーサの載せ替え（`src/features/node/filter/parser.rs`）
+
+- 移設した quoting/`Term`/`parse_token` を削除。不要になった nom 系 import（`branch`/`bytes`/`character`/`combinator`/`multi`/`sequence` など）と `Cow` を整理。`Regex`/`HashSet`/`strum`/`NodeColumn`/`NodeLabelColumn` は valid_columns で引き続き使用。
+- `valid_columns(label_registry: &[NodeLabelColumn]) -> HashSet<String>` は**そのまま残す**（builtin `NodeColumn::iter()` の display 正規化＋registry header 正規化）。
+- `parse_node_filter` を薄いラッパに:
+
+```rust
+pub fn parse_node_filter(
+    input: &str,
+    label_registry: &[NodeLabelColumn],
+) -> Result<TableFilterPredicate, String> {
+    let valid = valid_columns(label_registry);
+    parse_table_filter(input, |column| {
+        if valid.contains(&normalize_column_name(column)) {
+            Ok(())
+        } else {
+            Err(format!("unknown column '{}'", column))
+        }
+    })
+}
+```
+
+- `parse_table_filter` と `normalize_column_name` を `crate::ui::widget` から import。
+
+### 4. テスト
+
+- **Node の既存テストは変更しない**（`parse_node_filter` のシグネチャ・挙動は不変）。これが behavior-preservation の主たる証明。
+- 共有モジュールに `parse_table_filter` の単体テストを追加: bare→name、include/exclude、label（最後勝ち）、quoting（`"..."`/`'...'`/escape）、`validate_column` が `Err` を返すと parse error になる、不正 regex エラー、空入力。
+- `cargo test --all` / `cargo clippy --all-targets` / `cargo +nightly fmt --check`。
+
+## 影響を受けるファイル
+
+- `src/ui/widget/table/filter_parser.rs` — 新規（quoting/`Term`/`parse_token`/`parse_table_filter`＋テスト）。
+- `src/ui/widget/table.rs` — `mod filter_parser;` ＋ `parse_table_filter` の再エクスポート。
+- `src/features/node/filter/parser.rs` — 移設分を削除、`parse_node_filter` をラッパ化、import 整理。`valid_columns` は維持。
+
+## リスク / 後方互換
+
+- behavior-preserving。Node の挙動は不変で、既存テストが回帰検知になる。
+- 主なリスクは「抽出時のトークナイザ/quoting の取りこぼし」だが、Node テスト（quoting/escape ケース含む）が網羅しているため検出可能。
+
+## フォローアップ（PR B、別 spec）
+
+Pod の column-aware 移行は本共有コアの上に構築する: `parse_pod_filter` = `parse_table_filter(input, |col| PodColumn 既知列検証＋namespace 案内メッセージ)`、`pod_filter_applicator`、`PodMessage::Filter(Option<String>)`＋`SharedPodFilter`＋poller の per-namespace `?labelSelector=`、`POD_FILTER_HELP_DIALOG_ID` help dialog、widget 載せ替え。namespace はフィルタ列にせず（スコープ＝選択軸）、`namespace:` には専用案内を返す。

--- a/src/features/node/filter/parser.rs
+++ b/src/features/node/filter/parser.rs
@@ -1,211 +1,11 @@
-use std::{
-    borrow::Cow,
-    collections::{HashMap, HashSet},
-};
+use std::collections::HashSet;
 
-use nom::{
-    branch::alt,
-    bytes::complete::{is_not, tag},
-    character::complete::{anychar, char, multispace0, multispace1},
-    combinator::{map, value, verify},
-    error::{ContextError, ParseError},
-    multi::{fold_many0, separated_list0},
-    sequence::{delimited, preceded},
-    IResult,
-    Parser,
-};
-use regex::Regex;
 use strum::IntoEnumIterator;
 
 use crate::{
     features::node::node_columns::{NodeColumn, NodeLabelColumn},
-    ui::widget::{normalize_column_name, TableFilterPredicate},
+    ui::widget::{normalize_column_name, parse_table_filter, TableFilterPredicate},
 };
-
-// ---------------------------------------------------------------------------
-// Quoting helpers (copied from pod/kube/filter/parser.rs to avoid cross-feature dep)
-// ---------------------------------------------------------------------------
-
-/// Parse a quoted string (`"..."` or `'...'`), handling escape sequences.
-///
-/// Escape rules inside quotes:
-///   `\"` → `"`   `\'` → `'`   `\\` → `\`   `\<other>` → `\<other>` (verbatim)
-fn quoted<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
-    s: &'a str,
-) -> IResult<&'a str, Cow<'a, str>, E> {
-    #[inline]
-    fn multispace<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
-    ) -> impl Parser<&'a str, Output = Cow<'a, str>, Error = E> {
-        map(multispace1, Cow::Borrowed)
-    }
-
-    #[inline]
-    fn escaped_char<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
-    ) -> impl Parser<&'a str, Output = Cow<'a, str>, Error = E> {
-        preceded(
-            char('\\'),
-            alt((
-                value(Cow::Borrowed("\""), char('"')),
-                value(Cow::Borrowed("'"), char('\'')),
-                value(Cow::Borrowed("\\"), char('\\')),
-                map(anychar, |c| Cow::Owned(format!(r"\{}", c))),
-            )),
-        )
-    }
-
-    #[inline]
-    fn not_quote_slash<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
-        quote_slash: &'a str,
-    ) -> impl Parser<&'a str, Output = Cow<'a, str>, Error = E> {
-        map(
-            verify(is_not(quote_slash), |s: &str| !s.is_empty()),
-            Cow::Borrowed,
-        )
-    }
-
-    #[inline]
-    fn fold<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
-        parser: impl Parser<&'a str, Output = Cow<'a, str>, Error = E>,
-    ) -> impl Parser<&'a str, Output = String, Error = E> {
-        fold_many0(parser, String::default, |mut s, parsed| {
-            s.push_str(&parsed);
-            s
-        })
-    }
-
-    let double_quoted = delimited(
-        char('"'),
-        fold(alt((
-            escaped_char(),
-            not_quote_slash(r#""\"#),
-            multispace(),
-        ))),
-        char('"'),
-    );
-
-    let single_quoted = delimited(
-        char('\''),
-        fold(alt((
-            escaped_char(),
-            not_quote_slash(r#"\'"#),
-            multispace(),
-        ))),
-        char('\''),
-    );
-
-    let (remaining, value) = alt((double_quoted, single_quoted)).parse(s)?;
-
-    Ok((remaining, Cow::Owned(value)))
-}
-
-/// Parse an unquoted value: any non-whitespace characters that do not start
-/// with a quote character. Mirrors `non_space` in the pod filter parser.
-fn unquoted<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
-    s: &'a str,
-) -> IResult<&'a str, Cow<'a, str>, E> {
-    let (remaining, value) =
-        verify(is_not(" \t\r\n"), |s: &str| !s.starts_with(['"', '\''])).parse(s)?;
-    Ok((remaining, Cow::Borrowed(value)))
-}
-
-/// Parse a value that may be quoted or unquoted.
-fn value_string<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
-    s: &'a str,
-) -> IResult<&'a str, String, E> {
-    map(alt((quoted, unquoted)), |c| c.into_owned()).parse(s)
-}
-
-/// Parse a column name token: non-empty, stops at whitespace, `:`, `!`, or quote chars.
-fn column_name<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
-    s: &'a str,
-) -> IResult<&'a str, &'a str, E> {
-    verify(is_not(" \t\r\n:!\"'"), |s: &str| !s.is_empty()).parse(s)
-}
-
-// ---------------------------------------------------------------------------
-// Term types and token parser
-// ---------------------------------------------------------------------------
-
-/// One parsed term from the input.
-#[derive(Debug)]
-enum Term {
-    /// Bare value (no prefix) → defaults to NAME include.
-    Bare(String),
-    /// `<col>:<value>` include.
-    Include { column: String, value: String },
-    /// `!<col>:<value>` exclude.
-    Exclude { column: String, value: String },
-    /// `label:<selector>` → passed verbatim to the k8s API as labelSelector.
-    Label(String),
-}
-
-/// Parse one whitespace-delimited token into a `Term`.
-///
-/// Priority order:
-///   1. `label:<value>` → Label (special-cased before generic Include)
-///   2. `!<col>:<value>` → Exclude
-///   3. `<col>:<value>` → Include
-///   4. `<value>` → Bare
-///
-/// For (3)/(4) the value may be quoted (`"..."` / `'...'`) or unquoted.
-fn parse_token<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
-    s: &'a str,
-) -> IResult<&'a str, Term, E> {
-    // 1. label: (must be tried before the generic include path)
-    let label_result = preceded(tag("label:"), value_string::<E>).parse(s);
-    if let Ok((rem, sel)) = label_result {
-        return Ok((rem, Term::Label(sel)));
-    }
-
-    // 2. !col:value  (exclude)
-    let exclude_result = preceded(char::<&'a str, E>('!'), |s: &'a str| {
-        // We need col:value after the `!`
-        let (s2, col) = column_name::<E>(s)?;
-        let (s3, _) = char::<&'a str, E>(':').parse(s2)?;
-        let (s4, val) = value_string::<E>(s3)?;
-        Ok((s4, (col.to_lowercase(), val)))
-    })
-    .parse(s);
-    if let Ok((rem, (col, val))) = exclude_result {
-        return Ok((
-            rem,
-            Term::Exclude {
-                column: col,
-                value: val,
-            },
-        ));
-    }
-
-    // 3. col:value  (include) — but only if input is NOT starting with a quote
-    //    (otherwise `"bare quoted"` would fail column_name and fall to Bare correctly)
-    if !s.starts_with(['"', '\'']) {
-        // Try to parse col:value.  If we successfully match `col:` followed by a
-        // quote character, we MUST parse it as a quoted value — do not fall through
-        // to Bare, which would silently read the whole token as unquoted.
-        let col_colon_result = (|s: &'a str| -> IResult<&'a str, (&'a str, &'a str), E> {
-            let (s2, col) = column_name::<E>(s)?;
-            let (s3, _) = char::<&'a str, E>(':').parse(s2)?;
-            Ok((s3, (s, col)))
-        })(s);
-
-        if let Ok((after_colon, (_orig, col))) = col_colon_result {
-            // We have `col:` consumed.  Now parse the value — this will fail hard
-            // if the value is an unclosed quote (nom Err::Error propagated).
-            let (rem, val) = value_string::<E>(after_colon)?;
-            return Ok((
-                rem,
-                Term::Include {
-                    column: col.to_lowercase(),
-                    value: val,
-                },
-            ));
-        }
-    }
-
-    // 4. Bare value (quoted or unquoted)
-    let (rem, val) = value_string::<E>(s)?;
-    Ok((rem, Term::Bare(val)))
-}
 
 // ---------------------------------------------------------------------------
 // Column validation helpers
@@ -232,84 +32,19 @@ fn valid_columns(label_registry: &[NodeLabelColumn]) -> HashSet<String> {
 /// Column references are validated against the set of *known* columns (builtin
 /// Node columns plus defined label columns in `label_registry`); an unknown
 /// column produces a parse error. A known column that is not currently
-/// displayed is accepted here and becomes inactive at match time.
-///
-/// Values may be quoted (`"..."` / `'...'`) with the same escape rules as the
-/// Pod log query parser: `\"` → `"`  `\'` → `'`  `\\` → `\`  `\<other>` verbatim.
+/// displayed is accepted here and becomes inactive at match time. Tokenization
+/// and predicate building are delegated to the shared `parse_table_filter`.
 pub fn parse_node_filter(
     input: &str,
     label_registry: &[NodeLabelColumn],
 ) -> Result<TableFilterPredicate, String> {
     let valid = valid_columns(label_registry);
-
-    let trimmed = input.trim();
-    let mut column_includes: HashMap<String, Vec<Regex>> = HashMap::new();
-    let mut column_excludes: HashMap<String, Vec<Regex>> = HashMap::new();
-    let mut label_selector: Option<String> = None;
-
-    if trimmed.is_empty() {
-        return Ok(TableFilterPredicate {
-            column_includes,
-            column_excludes,
-            label_selector,
-            raw: trimmed.to_string(),
-        });
-    }
-
-    // Parse the whole trimmed input as whitespace-separated tokens.
-    type E<'a> = nom::error::Error<&'a str>;
-    let parse_result = delimited(
-        multispace0,
-        separated_list0(multispace1, parse_token::<E>),
-        multispace0,
-    )
-    .parse(trimmed);
-
-    let (remaining, terms) = parse_result.map_err(|e| format!("parse error: {}", e))?;
-
-    if !remaining.is_empty() {
-        return Err(format!("unexpected input near: {:?}", remaining));
-    }
-
-    for term in terms {
-        match term {
-            Term::Bare(v) => {
-                let rx = Regex::new(&v).map_err(|e| format!("invalid regex '{}': {}", v, e))?;
-                column_includes
-                    .entry("name".to_string())
-                    .or_default()
-                    .push(rx);
-            }
-            Term::Include { column, value } => {
-                let col = normalize_column_name(&column);
-                if !valid.contains(&col) {
-                    return Err(format!("unknown column '{}'", column));
-                }
-                let rx =
-                    Regex::new(&value).map_err(|e| format!("invalid regex '{}': {}", value, e))?;
-                column_includes.entry(col).or_default().push(rx);
-            }
-            Term::Exclude { column, value } => {
-                let col = normalize_column_name(&column);
-                if !valid.contains(&col) {
-                    return Err(format!("unknown column '{}'", column));
-                }
-                let rx =
-                    Regex::new(&value).map_err(|e| format!("invalid regex '{}': {}", value, e))?;
-                column_excludes.entry(col).or_default().push(rx);
-            }
-            Term::Label(sel) => {
-                // Last label: term wins (k8s API accepts only one labelSelector value).
-                label_selector = Some(sel);
-            }
+    parse_table_filter(input, |column| {
+        if valid.contains(&normalize_column_name(column)) {
+            Ok(())
+        } else {
+            Err(format!("unknown column '{}'", column))
         }
-    }
-
-    Ok(TableFilterPredicate {
-        column_includes,
-        column_excludes,
-        label_selector,
-        raw: trimmed.to_string(),
     })
 }
 

--- a/src/ui/widget/table.rs
+++ b/src/ui/widget/table.rs
@@ -1,6 +1,7 @@
 // mod filter_form;
 mod filter;
 mod filter_applicator;
+mod filter_parser;
 mod item;
 
 use std::rc::Rc;
@@ -57,6 +58,8 @@ pub use filter_applicator::{
     TableFilterParser,
     TableFilterPredicate,
 };
+#[allow(unused_imports)]
+pub use filter_parser::parse_table_filter;
 
 use item::InnerItem;
 

--- a/src/ui/widget/table.rs
+++ b/src/ui/widget/table.rs
@@ -58,7 +58,6 @@ pub use filter_applicator::{
     TableFilterParser,
     TableFilterPredicate,
 };
-#[allow(unused_imports)]
 pub use filter_parser::parse_table_filter;
 
 use item::InnerItem;

--- a/src/ui/widget/table/filter_parser.rs
+++ b/src/ui/widget/table/filter_parser.rs
@@ -1,0 +1,360 @@
+//! Shared column-aware filter parser core.
+//!
+//! Tokenizer + quoting + `Term` + `parse_table_filter`, used by every
+//! column-aware tab filter (Node now; Pod/Config/Network later). The only
+//! tab-specific part is the `validate_column` closure passed by the caller.
+
+// The private helpers (quoted, unquoted, value_string, column_name, Term,
+// parse_token) are only reachable via parse_table_filter, which is re-exported
+// but not yet consumed outside of tests (Task 2 wires actual callers).
+#![allow(dead_code)]
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+
+use nom::{
+    branch::alt,
+    bytes::complete::{is_not, tag},
+    character::complete::{anychar, char, multispace0, multispace1},
+    combinator::{map, value, verify},
+    error::{ContextError, ParseError},
+    multi::{fold_many0, separated_list0},
+    sequence::{delimited, preceded},
+    IResult,
+    Parser,
+};
+use regex::Regex;
+
+use crate::ui::widget::{normalize_column_name, TableFilterPredicate};
+
+// ---------------------------------------------------------------------------
+// Quoting helpers (copied from pod/kube/filter/parser.rs to avoid cross-feature dep)
+// ---------------------------------------------------------------------------
+
+/// Parse a quoted string (`"..."` or `'...'`), handling escape sequences.
+///
+/// Escape rules inside quotes:
+///   `\"` → `"`   `\'` → `'`   `\\` → `\`   `\<other>` → `\<other>` (verbatim)
+fn quoted<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+    s: &'a str,
+) -> IResult<&'a str, Cow<'a, str>, E> {
+    #[inline]
+    fn multispace<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+    ) -> impl Parser<&'a str, Output = Cow<'a, str>, Error = E> {
+        map(multispace1, Cow::Borrowed)
+    }
+
+    #[inline]
+    fn escaped_char<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+    ) -> impl Parser<&'a str, Output = Cow<'a, str>, Error = E> {
+        preceded(
+            char('\\'),
+            alt((
+                value(Cow::Borrowed("\""), char('"')),
+                value(Cow::Borrowed("'"), char('\'')),
+                value(Cow::Borrowed("\\"), char('\\')),
+                map(anychar, |c| Cow::Owned(format!(r"\{}", c))),
+            )),
+        )
+    }
+
+    #[inline]
+    fn not_quote_slash<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+        quote_slash: &'a str,
+    ) -> impl Parser<&'a str, Output = Cow<'a, str>, Error = E> {
+        map(
+            verify(is_not(quote_slash), |s: &str| !s.is_empty()),
+            Cow::Borrowed,
+        )
+    }
+
+    #[inline]
+    fn fold<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+        parser: impl Parser<&'a str, Output = Cow<'a, str>, Error = E>,
+    ) -> impl Parser<&'a str, Output = String, Error = E> {
+        fold_many0(parser, String::default, |mut s, parsed| {
+            s.push_str(&parsed);
+            s
+        })
+    }
+
+    let double_quoted = delimited(
+        char('"'),
+        fold(alt((
+            escaped_char(),
+            not_quote_slash(r#""\"#),
+            multispace(),
+        ))),
+        char('"'),
+    );
+
+    let single_quoted = delimited(
+        char('\''),
+        fold(alt((
+            escaped_char(),
+            not_quote_slash(r#"\'"#),
+            multispace(),
+        ))),
+        char('\''),
+    );
+
+    let (remaining, value) = alt((double_quoted, single_quoted)).parse(s)?;
+
+    Ok((remaining, Cow::Owned(value)))
+}
+
+/// Parse an unquoted value: any non-whitespace characters that do not start
+/// with a quote character. Mirrors `non_space` in the pod filter parser.
+fn unquoted<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+    s: &'a str,
+) -> IResult<&'a str, Cow<'a, str>, E> {
+    let (remaining, value) =
+        verify(is_not(" \t\r\n"), |s: &str| !s.starts_with(['"', '\''])).parse(s)?;
+    Ok((remaining, Cow::Borrowed(value)))
+}
+
+/// Parse a value that may be quoted or unquoted.
+fn value_string<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+    s: &'a str,
+) -> IResult<&'a str, String, E> {
+    map(alt((quoted, unquoted)), |c| c.into_owned()).parse(s)
+}
+
+/// Parse a column name token: non-empty, stops at whitespace, `:`, `!`, or quote chars.
+fn column_name<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+    s: &'a str,
+) -> IResult<&'a str, &'a str, E> {
+    verify(is_not(" \t\r\n:!\"'"), |s: &str| !s.is_empty()).parse(s)
+}
+
+// ---------------------------------------------------------------------------
+// Term types and token parser
+// ---------------------------------------------------------------------------
+
+/// One parsed term from the input.
+#[derive(Debug)]
+enum Term {
+    /// Bare value (no prefix) → defaults to NAME include.
+    Bare(String),
+    /// `<col>:<value>` include.
+    Include { column: String, value: String },
+    /// `!<col>:<value>` exclude.
+    Exclude { column: String, value: String },
+    /// `label:<selector>` → passed verbatim to the k8s API as labelSelector.
+    Label(String),
+}
+
+/// Parse one whitespace-delimited token into a `Term`.
+///
+/// Priority order:
+///   1. `label:<value>` → Label (special-cased before generic Include)
+///   2. `!<col>:<value>` → Exclude
+///   3. `<col>:<value>` → Include
+///   4. `<value>` → Bare
+///
+/// For (3)/(4) the value may be quoted (`"..."` / `'...'`) or unquoted.
+fn parse_token<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+    s: &'a str,
+) -> IResult<&'a str, Term, E> {
+    // 1. label: (must be tried before the generic include path)
+    let label_result = preceded(tag("label:"), value_string::<E>).parse(s);
+    if let Ok((rem, sel)) = label_result {
+        return Ok((rem, Term::Label(sel)));
+    }
+
+    // 2. !col:value  (exclude)
+    let exclude_result = preceded(char::<&'a str, E>('!'), |s: &'a str| {
+        // We need col:value after the `!`
+        let (s2, col) = column_name::<E>(s)?;
+        let (s3, _) = char::<&'a str, E>(':').parse(s2)?;
+        let (s4, val) = value_string::<E>(s3)?;
+        Ok((s4, (col.to_lowercase(), val)))
+    })
+    .parse(s);
+    if let Ok((rem, (col, val))) = exclude_result {
+        return Ok((
+            rem,
+            Term::Exclude {
+                column: col,
+                value: val,
+            },
+        ));
+    }
+
+    // 3. col:value  (include) — but only if input is NOT starting with a quote
+    //    (otherwise `"bare quoted"` would fail column_name and fall to Bare correctly)
+    if !s.starts_with(['"', '\'']) {
+        // Try to parse col:value.  If we successfully match `col:` followed by a
+        // quote character, we MUST parse it as a quoted value — do not fall through
+        // to Bare, which would silently read the whole token as unquoted.
+        let col_colon_result = (|s: &'a str| -> IResult<&'a str, (&'a str, &'a str), E> {
+            let (s2, col) = column_name::<E>(s)?;
+            let (s3, _) = char::<&'a str, E>(':').parse(s2)?;
+            Ok((s3, (s, col)))
+        })(s);
+
+        if let Ok((after_colon, (_orig, col))) = col_colon_result {
+            // We have `col:` consumed.  Now parse the value — this will fail hard
+            // if the value is an unclosed quote (nom Err::Error propagated).
+            let (rem, val) = value_string::<E>(after_colon)?;
+            return Ok((
+                rem,
+                Term::Include {
+                    column: col.to_lowercase(),
+                    value: val,
+                },
+            ));
+        }
+    }
+
+    // 4. Bare value (quoted or unquoted)
+    let (rem, val) = value_string::<E>(s)?;
+    Ok((rem, Term::Bare(val)))
+}
+
+/// Parse a column-aware filter string into a `TableFilterPredicate`.
+///
+/// `validate_column` is called with each `COL:`/`!COL:` column token (already
+/// lowercased by the tokenizer) and returns `Ok(())` if acceptable, or
+/// `Err(message)` to abort parsing with that message — the only tab-specific
+/// part. Stored predicate keys are normalized via `normalize_column_name`.
+/// Bare values map to the `name` include; `label:` is captured verbatim (last
+/// wins); values may be quoted with the log-query escape rules.
+pub fn parse_table_filter(
+    input: &str,
+    validate_column: impl Fn(&str) -> Result<(), String>,
+) -> Result<TableFilterPredicate, String> {
+    let trimmed = input.trim();
+    let mut column_includes: HashMap<String, Vec<Regex>> = HashMap::new();
+    let mut column_excludes: HashMap<String, Vec<Regex>> = HashMap::new();
+    let mut label_selector: Option<String> = None;
+
+    if trimmed.is_empty() {
+        return Ok(TableFilterPredicate {
+            column_includes,
+            column_excludes,
+            label_selector,
+            raw: trimmed.to_string(),
+        });
+    }
+
+    // Parse the whole trimmed input as whitespace-separated tokens.
+    type E<'a> = nom::error::Error<&'a str>;
+    let parse_result = delimited(
+        multispace0,
+        separated_list0(multispace1, parse_token::<E>),
+        multispace0,
+    )
+    .parse(trimmed);
+
+    let (remaining, terms) = parse_result.map_err(|e| format!("parse error: {}", e))?;
+
+    if !remaining.is_empty() {
+        return Err(format!("unexpected input near: {:?}", remaining));
+    }
+
+    for term in terms {
+        match term {
+            Term::Bare(v) => {
+                let rx = Regex::new(&v).map_err(|e| format!("invalid regex '{}': {}", v, e))?;
+                column_includes
+                    .entry("name".to_string())
+                    .or_default()
+                    .push(rx);
+            }
+            Term::Include { column, value } => {
+                validate_column(&column)?;
+                let rx =
+                    Regex::new(&value).map_err(|e| format!("invalid regex '{}': {}", value, e))?;
+                column_includes
+                    .entry(normalize_column_name(&column))
+                    .or_default()
+                    .push(rx);
+            }
+            Term::Exclude { column, value } => {
+                validate_column(&column)?;
+                let rx =
+                    Regex::new(&value).map_err(|e| format!("invalid regex '{}': {}", value, e))?;
+                column_excludes
+                    .entry(normalize_column_name(&column))
+                    .or_default()
+                    .push(rx);
+            }
+            Term::Label(sel) => {
+                // Last label: term wins (k8s API accepts only one labelSelector value).
+                label_selector = Some(sel);
+            }
+        }
+    }
+
+    Ok(TableFilterPredicate {
+        column_includes,
+        column_excludes,
+        label_selector,
+        raw: trimmed.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    fn allow_all(_: &str) -> Result<(), String> {
+        Ok(())
+    }
+
+    #[test]
+    fn empty_input_yields_empty_predicate() {
+        let p = parse_table_filter("", allow_all).unwrap();
+        assert!(p.column_includes.is_empty());
+        assert!(p.column_excludes.is_empty());
+        assert_eq!(p.label_selector, None);
+        assert_eq!(p.raw, "");
+    }
+
+    #[test]
+    fn bare_value_becomes_name_include() {
+        let p = parse_table_filter("worker", allow_all).unwrap();
+        assert!(p.column_includes.contains_key("name"));
+    }
+
+    #[test]
+    fn include_and_exclude_store_normalized_keys() {
+        let p = parse_table_filter("Status:Ready !INTERNAL-IP:10.", allow_all).unwrap();
+        assert!(p.column_includes.contains_key("status"));
+        assert!(p.column_excludes.contains_key("internalip"));
+    }
+
+    #[test]
+    fn label_is_captured_last_wins() {
+        let p = parse_table_filter("label:a=1 label:b=2", allow_all).unwrap();
+        assert_eq!(p.label_selector.as_deref(), Some("b=2"));
+    }
+
+    #[test]
+    fn quoted_value_with_whitespace() {
+        let p = parse_table_filter(r#"name:"foo bar""#, allow_all).unwrap();
+        let patterns = p.column_includes.get("name").unwrap();
+        assert!(patterns[0].is_match("foo bar"));
+    }
+
+    #[test]
+    fn validate_column_error_aborts_parse() {
+        let reject_status = |c: &str| {
+            if c == "status" {
+                Err("nope".to_string())
+            } else {
+                Ok(())
+            }
+        };
+        let err = parse_table_filter("status:Ready", reject_status).unwrap_err();
+        assert_eq!(err, "nope");
+    }
+
+    #[test]
+    fn invalid_regex_errors() {
+        let err = parse_table_filter("name:[", allow_all).unwrap_err();
+        assert!(err.contains("invalid regex"), "got: {}", err);
+    }
+}

--- a/src/ui/widget/table/filter_parser.rs
+++ b/src/ui/widget/table/filter_parser.rs
@@ -4,11 +4,6 @@
 //! column-aware tab filter (Node now; Pod/Config/Network later). The only
 //! tab-specific part is the `validate_column` closure passed by the caller.
 
-// The private helpers (quoted, unquoted, value_string, column_name, Term,
-// parse_token) are only reachable via parse_table_filter, which is re-exported
-// but not yet consumed outside of tests (Task 2 wires actual callers).
-#![allow(dead_code)]
-
 use std::borrow::Cow;
 use std::collections::HashMap;
 
@@ -187,13 +182,13 @@ fn parse_token<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
         // Try to parse col:value.  If we successfully match `col:` followed by a
         // quote character, we MUST parse it as a quoted value — do not fall through
         // to Bare, which would silently read the whole token as unquoted.
-        let col_colon_result = (|s: &'a str| -> IResult<&'a str, (&'a str, &'a str), E> {
+        let col_colon_result = (|s: &'a str| -> IResult<&'a str, &'a str, E> {
             let (s2, col) = column_name::<E>(s)?;
             let (s3, _) = char::<&'a str, E>(':').parse(s2)?;
-            Ok((s3, (s, col)))
+            Ok((s3, col))
         })(s);
 
-        if let Ok((after_colon, (_orig, col))) = col_colon_result {
+        if let Ok((after_colon, col)) = col_colon_result {
             // We have `col:` consumed.  Now parse the value — this will fail hard
             // if the value is an unclosed quote (nom Err::Error propagated).
             let (rem, val) = value_string::<E>(after_colon)?;


### PR DESCRIPTION
## Summary

Behavior-preserving refactor that extracts the generic column-aware filter parser out of the Node-specific parser into a shared module, so upcoming tabs (Pod next, then Config/Network) reuse it instead of duplicating the nom tokenizer.

- **New `src/ui/widget/table/filter_parser.rs`**: the nom tokenizer + quoting helpers + `Term` + `parse_token` (moved from the Node parser) plus a generic `parse_table_filter(input, validate_column: impl Fn(&str) -> Result<(), String>) -> Result<TableFilterPredicate, String>`. The only tab-specific part is the `validate_column` closure (the caller decides which column names are known and what error to return).
- **`src/features/node/filter/parser.rs`**: the duplicated tokenizer is deleted; `parse_node_filter` becomes a thin wrapper that builds `valid_columns(label_registry)` (builtin `NodeColumn` + label registry, normalized) and delegates to `parse_table_filter`, returning `unknown column '<x>'` for columns not in the known set. **The Node parser's test module is unchanged** — the behavior-preservation proof.
- **`src/ui/widget/table.rs`**: `mod filter_parser;` + re-export of `parse_table_filter`.

Net: the Node parser shrinks by ~280 lines; the tokenizer now has a single source of truth.

This is PR **B-0**, the prerequisite for the Pod column-aware migration (PR B), so the parser isn't duplicated again.

Spec: `docs/superpowers/specs/2026-05-29-shared-table-filter-parser-design.md`
Plan: `docs/superpowers/plans/2026-05-30-shared-table-filter-parser.md`

## Test Plan

- [x] `cargo test --all` (648 passed / 0 failed; Node parser's 30 existing tests pass **unchanged** = behavior preserved; 7 new `parse_table_filter` unit tests)
- [x] `cargo clippy --all-targets` (no new warnings in the changed files)
- [x] `cargo +nightly fmt --check` (changed files clean; a pre-existing unrelated `store.rs` drift on main is not part of this branch)
- [x] No user-facing behavior change (pure refactor); Node filter behaves identically (same syntax, same `unknown column` error, same normalization)

## Follow-up

- PR B: Pod column-aware migration on top of this shared core (`parse_pod_filter` = `parse_table_filter` + PodColumn validator + namespace guidance; `label:` server-side; help dialog).