### PR TITLE
refactor(node-config): single-source registry for build_node_columns (closes #994)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -40,6 +40,7 @@ impl App {
             build_pod_highlight_rules(&config.theme.pod.highlights);
 
         let pod_label_registry = build_pod_label_registry(&config.theme.pod.label_columns)?;
+        let node_label_registry = build_node_label_registry(&config.theme.node.label_columns)?;
 
         kube_worker_config.pod_config.default_columns = build_pod_columns(
             cmd.pod_columns,
@@ -54,7 +55,7 @@ impl App {
             cmd.node_columns_preset,
             &config.theme.node.default_preset,
             &config.theme.node.column_presets,
-            &config.theme.node.label_columns,
+            &node_label_registry,
         )?;
 
         kube_worker_config.event_config = EventConfig::from(config.theme.clone());
@@ -78,7 +79,6 @@ impl App {
 
         let default_pod_columns = kube_worker_config.pod_config.default_columns.clone();
         let default_node_columns = kube_worker_config.node_config.default_columns.clone();
-        let node_label_columns = build_node_label_registry(&config.theme.node.label_columns)?;
 
         let kube = KubeWorker::new(
             tx_kube.clone(),
@@ -101,7 +101,7 @@ impl App {
             default_pod_columns,
             default_node_columns,
             pod_label_registry,
-            node_label_columns,
+            node_label_registry,
             config.theme.clone(),
             cmd.clipboard,
             config.logging.max_lines,
@@ -225,12 +225,10 @@ fn build_node_columns(
     cmd_node_columns_preset: Option<String>,
     default_preset: &Option<String>,
     column_presets: &Option<HashMap<String, Vec<String>>>,
-    label_columns: &Option<Vec<LabelColumnConfig>>,
+    node_label_registry: &[NodeLabelColumn],
 ) -> Result<Option<NodeColumns>> {
-    let registry = build_node_label_registry(label_columns)?;
-
     if let Some(names) = cmd_node_columns {
-        return Ok(Some(resolve_columns(&names, &registry)?));
+        return Ok(Some(resolve_columns(&names, node_label_registry)?));
     }
 
     let Some(preset_name) = cmd_node_columns_preset.as_ref().or(default_preset.as_ref()) else {
@@ -250,7 +248,7 @@ fn build_node_columns(
         );
     };
 
-    Ok(Some(resolve_columns(entries, &registry)?))
+    Ok(Some(resolve_columns(entries, node_label_registry)?))
 }
 
 /// Build the label-column registry for Pod from config, erroring on builtin
@@ -406,6 +404,14 @@ mod node_columns_tests {
         }]
     }
 
+    fn registry() -> Vec<NodeLabelColumn> {
+        build_node_label_registry(&Some(labels())).unwrap()
+    }
+
+    fn empty_registry() -> Vec<NodeLabelColumn> {
+        Vec::new()
+    }
+
     #[test]
     fn resolves_preset_with_builtin_and_label_interleaved() {
         let cols = build_node_columns(
@@ -413,7 +419,7 @@ mod node_columns_tests {
             None,
             &Some("gpu".to_string()),
             &Some(presets()),
-            &Some(labels()),
+            &registry(),
         )
         .unwrap()
         .unwrap();
@@ -437,7 +443,7 @@ mod node_columns_tests {
             Some("gpu".to_string()),
             &Some("gpu".to_string()),
             &Some(presets()),
-            &Some(labels()),
+            &registry(),
         )
         .unwrap()
         .unwrap();
@@ -455,7 +461,7 @@ mod node_columns_tests {
 
     #[test]
     fn none_when_no_preset() {
-        let actual = build_node_columns(None, None, &None, &None, &None).unwrap();
+        let actual = build_node_columns(None, None, &None, &None, &empty_registry()).unwrap();
         assert!(actual.is_none());
     }
 
@@ -465,26 +471,25 @@ mod node_columns_tests {
             "p".to_string(),
             vec!["name".to_string(), "bogus".to_string()],
         )]);
-        assert!(
-            build_node_columns(None, None, &Some("p".to_string()), &Some(presets), &None).is_err()
-        );
-    }
-
-    #[test]
-    fn error_on_label_name_colliding_with_builtin() {
-        let labels = vec![LabelColumnConfig {
-            name: "status".to_string(),
-            label: "x".to_string(),
-        }];
-        let presets = HashMap::from([("p".to_string(), vec!["name".to_string()])]);
         assert!(build_node_columns(
             None,
             None,
             &Some("p".to_string()),
             &Some(presets),
-            &Some(labels)
+            &empty_registry()
         )
         .is_err());
+    }
+
+    #[test]
+    fn error_on_label_name_colliding_with_builtin() {
+        // build_node_columns はもう registry 構築をしない。collision の検出は
+        // build_node_label_registry の責務に移った。
+        let labels = vec![LabelColumnConfig {
+            name: "status".to_string(),
+            label: "x".to_string(),
+        }];
+        assert!(build_node_label_registry(&Some(labels)).is_err());
     }
 
     #[test]
@@ -505,9 +510,15 @@ mod node_columns_tests {
 
     #[test]
     fn full_returns_all_builtins() {
-        let cols = build_node_columns(Some(vec!["full".to_string()]), None, &None, &None, &None)
-            .unwrap()
-            .unwrap();
+        let cols = build_node_columns(
+            Some(vec!["full".to_string()]),
+            None,
+            &None,
+            &None,
+            &empty_registry(),
+        )
+        .unwrap()
+        .unwrap();
         assert_eq!(cols.specs().len(), NodeColumn::all().count());
     }
 }


### PR DESCRIPTION
## Summary

Mirror the Pod design (PR #993): build the Node label registry **once** in app startup and thread it as `&[NodeLabelColumn]` into `build_node_columns`, instead of having `build_node_columns` re-build the registry internally.

Closes #994.

## What changed

**Before:**
```rust
// src/app.rs main flow
kube_worker_config.node_config.default_columns = build_node_columns(
    cmd.node_columns,
    cmd.node_columns_preset,
    &config.theme.node.default_preset,
    &config.theme.node.column_presets,
    &config.theme.node.label_columns,   // raw config slice
)?;

// ... later, for Render::new
let node_label_columns = build_node_label_registry(&config.theme.node.label_columns)?;

// inside build_node_columns
let registry = build_node_label_registry(label_columns)?;   // 2nd build of same data
```

**After:**
```rust
let pod_label_registry = build_pod_label_registry(&config.theme.pod.label_columns)?;
let node_label_registry = build_node_label_registry(&config.theme.node.label_columns)?;  // built once

kube_worker_config.node_config.default_columns = build_node_columns(
    cmd.node_columns,
    cmd.node_columns_preset,
    &config.theme.node.default_preset,
    &config.theme.node.column_presets,
    &node_label_registry,                // already-built registry
)?;

// Render::new reuses the same `node_label_registry` value, no re-build
```

`build_node_columns` signature change:
```diff
-fn build_node_columns(
-    ...,
-    label_columns: &Option<Vec<LabelColumnConfig>>,
-) -> Result<Option<NodeColumns>> {
-    let registry = build_node_label_registry(label_columns)?;
+fn build_node_columns(
+    ...,
+    node_label_registry: &[NodeLabelColumn],
+) -> Result<Option<NodeColumns>> {
```

Test impact:
- `node_columns_tests::labels()` retained for constructing registry input
- Added `registry()` / `empty_registry()` helpers
- `error_on_label_name_colliding_with_builtin` rewritten to test `build_node_label_registry` directly — the collision check is now its responsibility, not `build_node_columns`'s

## Test plan

- [x] `cargo build`: clean (only pre-existing `try_from_kubeconfig` warning)
- [x] `cargo test --all`: 686 passed / 0 failed (unchanged from main)
- [x] `cargo clippy --all-targets`: no new warnings
- [x] `cargo +nightly fmt --check`: clean
- [x] Behavior-preserving: no public API change, no UX change. Manual smoke not required.

## Acceptance criteria (from #994)

- [x] `build_node_columns` takes `&[NodeLabelColumn]` instead of `&Option<Vec<LabelColumnConfig>>`
- [x] `build_node_label_registry` is called exactly once in app startup
- [x] Existing `node_columns_tests` updated to pass a registry slice
- [x] No behavior change
- [x] All gates clean

## Related

- PR #993 — Pod label_columns (introduced the SSoT pattern Node now follows)
- Issue #994 — Node-Pod asymmetry tracking issue (this PR closes it)