### PR TITLE
feat(label-selector): URL-encode the value before adding to request URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,6 +1478,7 @@ dependencies = [
  "nucleo-matcher",
  "once_cell",
  "paste",
+ "percent-encoding",
  "pretty_assertions",
  "ratatui",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ jaq-json = { version = "1.1.3", features = ["serde_json"] }
 jmespath = { version = "0.5.0", features = ["sync"] }
 hyper-util = { version = "0.1.20", features = ["client-proxy"] }
 jiff = { version = "0.2.20", default-features = false }
+percent-encoding = "2.3.2"
 
 
 [dev-dependencies]

--- a/src/features/node/kube/node.rs
+++ b/src/features/node/kube/node.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use crossbeam::channel::Sender;
 use k8s_openapi::{api::core::v1::Node, Resource as _};
 use kube::Resource;
+use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use tokio::sync::RwLock;
 
 use crate::{
@@ -96,7 +97,13 @@ async fn get_node_table<C: KubeClientRequest>(
     let path = {
         let filter = shared_node_filter.read().await;
         match filter.as_deref().filter(|s| !s.is_empty()) {
-            Some(sel) => format!("{}?labelSelector={}", base_path, sel),
+            Some(sel) => {
+                format!(
+                    "{}?labelSelector={}",
+                    base_path,
+                    utf8_percent_encode(sel, NON_ALPHANUMERIC)
+                )
+            }
             None => base_path,
         }
     };
@@ -287,8 +294,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn url_includes_label_selector_when_set() {
+    async fn url_encodes_label_selector_equality_expression() {
         let mut client = crate::kube::mock::MockTestKubeClient::new();
+        // `env=prod` の `=` は URL の sub-delim だが、percent-encoding でも
+        // k8s API server は decode して labelSelector 文法として解釈する。
         mock_expect!(
             client,
             request_table,
@@ -298,7 +307,50 @@ mod tests {
         );
 
         let shared = Arc::new(RwLock::new(NodeColumns::default()));
-        let shared_filter = Arc::new(RwLock::new(Some("env%3Dprod".to_string())));
+        let shared_filter = Arc::new(RwLock::new(Some("env=prod".to_string())));
+        let table = get_node_table(&client, &shared, &shared_filter)
+            .await
+            .unwrap();
+        assert_eq!(table.rows.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn url_encodes_comma_separated_and_expression() {
+        // k8s labelSelector の AND 区切りはカンマ。`,` も `=` も URL の sub-delim
+        // だが、percent-encoding でも k8s API server は decode して文法どおり
+        // 解釈するので往復性が保たれる。
+        let mut client = crate::kube::mock::MockTestKubeClient::new();
+        mock_expect!(
+            client,
+            request_table,
+            Table,
+            eq("/api/v1/nodes?labelSelector=env%3Dprod%2Ctier%3Dfrontend"),
+            Ok(node_table_fixture())
+        );
+
+        let shared = Arc::new(RwLock::new(NodeColumns::default()));
+        let shared_filter = Arc::new(RwLock::new(Some("env=prod,tier=frontend".to_string())));
+        let table = get_node_table(&client, &shared, &shared_filter)
+            .await
+            .unwrap();
+        assert_eq!(table.rows.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn url_encodes_space_in_set_based_expression() {
+        // `key in (a, b)` は labelSelector の set-based 構文。
+        // 空白 / カンマ / カッコは全て URL-encode される。
+        let mut client = crate::kube::mock::MockTestKubeClient::new();
+        mock_expect!(
+            client,
+            request_table,
+            Table,
+            eq("/api/v1/nodes?labelSelector=env%20in%20%28prod%2Cdev%29"),
+            Ok(node_table_fixture())
+        );
+
+        let shared = Arc::new(RwLock::new(NodeColumns::default()));
+        let shared_filter = Arc::new(RwLock::new(Some("env in (prod,dev)".to_string())));
         let table = get_node_table(&client, &shared, &shared_filter)
             .await
             .unwrap();

--- a/src/features/pod/kube/pod.rs
+++ b/src/features/pod/kube/pod.rs
@@ -6,6 +6,7 @@ use crossbeam::channel::Sender;
 use futures::future::try_join_all;
 use k8s_openapi::{api::core::v1::Pod, Resource as _};
 use kube::Resource;
+use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use ratatui::style::{Color, Style};
 use regex::Regex;
 
@@ -202,7 +203,13 @@ impl PodPoller {
             let pod_columns_specs = pod_columns_specs.clone();
             let base_path = Pod::url_path(&Default::default(), Some(ns));
             let path = match label_selector.as_deref().filter(|s| !s.is_empty()) {
-                Some(sel) => format!("{}?labelSelector={}", base_path, sel),
+                Some(sel) => {
+                    format!(
+                        "{}?labelSelector={}",
+                        base_path,
+                        utf8_percent_encode(sel, NON_ALPHANUMERIC)
+                    )
+                }
                 None => base_path,
             };
             get_resource_per_namespace(


### PR DESCRIPTION
## Summary

Pod and Node pollers used to interpolate the raw user-typed labelSelector value into the request URL:

```rust
format!("{}?labelSelector={}", base_path, sel)
```

The [k8s labelSelector grammar](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) uses several URL sub-delim characters as syntax: `=` for equality, `,` for AND, space and `(`/`)` for the `key in (a,b)` set-based form. Sub-delims are technically legal in URL query values, but interpolating them raw is fragile (relies on server-side leniency) and any whitespace simply breaks the URL.

Run the value through `percent_encoding::utf8_percent_encode(..., NON_ALPHANUMERIC)`. The k8s API server URL-decodes the query value before parsing it as labelSelector syntax, so encoding is transparent on the server side.

## Example transformations

| User input | k8s grammar | Encoded URL value |
|---|---|---|
| `env=prod` | equality | `env%3Dprod` |
| `env=prod,tier=frontend` | AND (comma-separated) | `env%3Dprod%2Ctier%3Dfrontend` |
| `env in (prod,dev)` | set-based with spaces/parens | `env%20in%20%28prod%2Cdev%29` |

## What changed

- Added `percent-encoding` as a direct dep (was already pulled in transitively via `url`/`reqwest`/`kube`). It's the Servo-maintained de-facto standard for percent-encoding in Rust.
- Pod poller (`src/features/pod/kube/pod.rs`) and Node poller (`src/features/node/kube/node.rs`) wrap the selector with `utf8_percent_encode(sel, NON_ALPHANUMERIC)` at the only URL construction site.
- Node tests cover the three labelSelector forms users actually type (equality, comma-AND, set-based). The pre-existing `url_includes_label_selector_when_set` test had a pre-encoded fixture (`env%3Dprod`) which masked what should have been tested; it is renamed/rewritten to feed raw user input.

Pod side uses the same one-liner; encoding semantics are verified once via the Node tests. (Pod's poller goes through `get_resource_per_namespace` which doesn't have unit-test infrastructure for URL construction.)

## Dep choice notes

- `urlencoding` (the obvious alternative) is a standalone dep-free implementation, but its Cargo.toml explicitly declares `status = "looking-for-maintainer"` — formally seeking new maintainership. Rejected in favor of `percent-encoding`.
- `form_urlencoded` was considered (kube-rs uses it for query construction) but rejected because our use case is "encode a single value" not "build a query string from pairs" — `Serializer` would be over-engineering for this site.
- `NON_ALPHANUMERIC` is more aggressive than `urlencoding`'s RFC 3986 unreserved set (it encodes `-._~` too), but the difference is purely cosmetic — k8s API server URL-decodes regardless.

## Test plan

- [x] `cargo build`: clean (only pre-existing `try_from_kubeconfig` warning)
- [x] `cargo test --all`: 688 passed / 0 failed (was 686 + 2 new tests)
- [x] `cargo clippy --all-targets`: no new warnings
- [x] `cargo +nightly fmt --check`: clean
- [x] Manual GKE smoke (reviewer): `label:app=nginx`, `label:env=prod,tier=frontend`, `label:env in (prod,dev)` all narrow the pod list as expected.

## Related

- Memory note `pod-filter-migration.md` had `?labelSelector=` URL encoding hardening listed as a follow-up; this PR consumes that item.