### PR TITLE
feat(config): column-aware filter for Config tab (kind:/name:/label:/...)

### DIFF
--- a/src/features/component_id.rs
+++ b/src/features/component_id.rs
@@ -37,6 +37,7 @@ component_id!(
     node_columns_dialog,
     node_filter_help_dialog,
     pod_filter_help_dialog,
+    config_filter_help_dialog,
     pod_log_query_help_dialog,
     context_dialog,
     single_namespace_dialog,

--- a/src/features/config.rs
+++ b/src/features/config.rs
@@ -1,3 +1,6 @@
+mod filter;
 pub mod kube;
 pub mod message;
 pub mod view;
+
+pub use filter::config_filter_applicator;

--- a/src/features/config/filter.rs
+++ b/src/features/config/filter.rs
@@ -1,0 +1,73 @@
+//! Config tab filter: parser + `TableFilterApplicator` factory.
+//!
+//! The applicator wires `parse_config_filter` (which builds on the shared
+//! `parse_table_filter`) into the Table widget with `EnterToConfirm` strategy.
+//! Server-side `labelSelector` is forwarded to the Config poller via
+//! `ConfigMessage::Filter` from `on_apply`/`on_cancel`. Typing `?` or `help`
+//! in the filter input opens the `CONFIG_FILTER_HELP_DIALOG_ID` dialog.
+
+mod parser;
+
+use crossbeam::channel::Sender;
+
+use crate::{
+    features::{component_id::CONFIG_FILTER_HELP_DIALOG_ID, config::message::ConfigMessage},
+    message::Message,
+    ui::{
+        widget::{
+            ApplyStrategy,
+            OnFilterApply,
+            OnFilterCancel,
+            TableFilterApplicator,
+            TableFilterParser,
+        },
+        Window,
+    },
+};
+
+pub use parser::parse_config_filter;
+
+/// Build the Config tab's filter applicator.
+///
+/// `tx` is captured by `on_apply`/`on_cancel` to forward the parsed
+/// `label_selector` to the Config poller via `ConfigMessage::Filter`.
+///
+/// The applicator uses `EnterToConfirm` so the parser only runs on Enter
+/// (avoids server-side roundtrips mid-typing).
+pub fn config_filter_applicator(tx: Sender<Message>) -> TableFilterApplicator {
+    let parser: TableFilterParser = (move |input: &str| parse_config_filter(input)).into();
+
+    let tx_apply = tx.clone();
+    let tx_cancel = tx;
+
+    let on_apply: OnFilterApply = (move |predicate: &crate::ui::widget::TableFilterPredicate,
+                                         _window: &mut Window| {
+        tx_apply
+            .send(ConfigMessage::Filter(predicate.label_selector.clone()).into())
+            .expect("Failed to send ConfigMessage::Filter");
+    })
+    .into();
+
+    let on_cancel: OnFilterCancel = (move |_window: &mut Window| {
+        tx_cancel
+            .send(ConfigMessage::Filter(None).into())
+            .expect("Failed to send ConfigMessage::Filter(None) on cancel");
+    })
+    .into();
+
+    TableFilterApplicator::new(parser, ApplyStrategy::EnterToConfirm)
+        .with_help_dialog(CONFIG_FILTER_HELP_DIALOG_ID)
+        .with_on_apply(on_apply)
+        .with_on_cancel(on_cancel)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn applicator_constructs_without_panic() {
+        let (tx, _rx) = crossbeam::channel::bounded(1);
+        let _ = config_filter_applicator(tx);
+    }
+}

--- a/src/features/config/filter/parser.rs
+++ b/src/features/config/filter/parser.rs
@@ -1,0 +1,119 @@
+//! Config filter parser.
+//!
+//! Delegates tokenization/quoting/predicate-building to the shared
+//! `parse_table_filter`. The Config-specific part is the column validator:
+//! `namespace:` returns a guidance message (namespace is a scope, not a
+//! column-level filter — use the namespace selector); other unknown columns
+//! return `unknown column '<x>'`; the builtin Config columns (`name`, `kind`,
+//! `data`, `age`) are accepted.
+
+use std::collections::HashSet;
+
+use crate::ui::widget::{normalize_column_name, parse_table_filter, TableFilterPredicate};
+
+/// Builtin Config columns (header form). The Config tab aggregates ConfigMap
+/// and Secret rows; all columns are fixed in code (no dialog, no preset).
+const BUILTIN_COLUMNS: &[&str] = &["NAME", "KIND", "DATA", "AGE"];
+
+/// Parse a Config-filter input string into a `TableFilterPredicate`.
+///
+/// `namespace:` is rejected with a guidance message that points users to the
+/// namespace selector (namespace is a scope, not a row attribute). This check
+/// fires *before* the builtin lookup. Other columns are validated against
+/// `BUILTIN_COLUMNS`; a column not in that set produces `unknown column '<x>'`.
+pub fn parse_config_filter(input: &str) -> Result<TableFilterPredicate, String> {
+    let valid: HashSet<String> = BUILTIN_COLUMNS
+        .iter()
+        .map(|c| normalize_column_name(c))
+        .collect();
+    parse_table_filter(input, |column| {
+        let normalized = normalize_column_name(column);
+        if normalized == "namespace" {
+            return Err(
+                "namespace is selected via the namespace selector, not the filter".to_string(),
+            );
+        }
+        if valid.contains(&normalized) {
+            Ok(())
+        } else {
+            Err(format!("unknown column '{}'", column))
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn empty_input_yields_empty_predicate() {
+        let p = parse_config_filter("").unwrap();
+        assert!(p.column_includes.is_empty());
+        assert!(p.column_excludes.is_empty());
+        assert_eq!(p.label_selector, None);
+    }
+
+    #[test]
+    fn bare_value_becomes_name_include() {
+        let p = parse_config_filter("my-config").unwrap();
+        let patterns = p.column_includes.get("name").expect("name column");
+        assert!(patterns[0].is_match("my-config-abc"));
+    }
+
+    #[test]
+    fn builtin_columns_are_accepted() {
+        let p = parse_config_filter("kind:ConfigMap !kind:Secret").unwrap();
+        assert!(p.column_includes.contains_key("kind"));
+        assert!(p.column_excludes.contains_key("kind"));
+    }
+
+    #[test]
+    fn data_and_age_columns_are_accepted() {
+        let p = parse_config_filter("data:0 age:1d").unwrap();
+        assert!(p.column_includes.contains_key("data"));
+        assert!(p.column_includes.contains_key("age"));
+    }
+
+    #[test]
+    fn label_selector_is_captured() {
+        let p = parse_config_filter("label:app=nginx").unwrap();
+        assert_eq!(p.label_selector.as_deref(), Some("app=nginx"));
+    }
+
+    #[test]
+    fn unknown_column_produces_parse_error() {
+        let err = parse_config_filter("staus:Active").unwrap_err();
+        assert!(
+            err.contains("unknown column") && err.contains("staus"),
+            "got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn namespace_returns_guidance_message_not_unknown_column() {
+        let err = parse_config_filter("namespace:default").unwrap_err();
+        assert_eq!(
+            err,
+            "namespace is selected via the namespace selector, not the filter"
+        );
+        let err2 = parse_config_filter("NAMESPACE:default").unwrap_err();
+        assert_eq!(
+            err2,
+            "namespace is selected via the namespace selector, not the filter"
+        );
+    }
+
+    #[test]
+    fn label_keyword_is_not_treated_as_a_column_lookup() {
+        assert!(parse_config_filter("label:app=nginx").is_ok());
+    }
+
+    #[test]
+    fn quoted_value_with_whitespace() {
+        let p = parse_config_filter(r#"name:"my config""#).unwrap();
+        let patterns = p.column_includes.get("name").unwrap();
+        assert!(patterns[0].is_match("my config"));
+    }
+}

--- a/src/features/config/kube/config.rs
+++ b/src/features/config/kube/config.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     logger,
     message::Message,
-    workers::kube::{InfiniteWorker, SharedTargetNamespaces},
+    workers::kube::{InfiniteWorker, SharedConfigFilter, SharedTargetNamespaces},
 };
 
 use anyhow::Result;
@@ -18,11 +18,13 @@ use crossbeam::channel::Sender;
 use futures::future::try_join_all;
 use k8s_openapi::api::core::v1::{ConfigMap, Secret};
 use kube::Resource;
+use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 
 #[derive(Clone)]
 pub struct ConfigPoller {
     tx: Sender<Message>,
     shared_target_namespaces: SharedTargetNamespaces,
+    shared_config_filter: SharedConfigFilter,
     kube_client: KubeClient,
 }
 
@@ -30,11 +32,13 @@ impl ConfigPoller {
     pub fn new(
         tx: Sender<Message>,
         shared_target_namespaces: SharedTargetNamespaces,
+        shared_config_filter: SharedConfigFilter,
         kube_client: KubeClient,
     ) -> Self {
         Self {
             tx,
             shared_target_namespaces,
+            shared_config_filter,
             kube_client,
         }
     }
@@ -48,6 +52,7 @@ impl InfiniteWorker for ConfigPoller {
         let Self {
             tx,
             shared_target_namespaces,
+            shared_config_filter,
             kube_client,
         } = self;
 
@@ -55,8 +60,10 @@ impl InfiniteWorker for ConfigPoller {
             interval.tick().await;
 
             let target_namespaces = shared_target_namespaces.read().await;
+            let label_selector = shared_config_filter.read().await.clone();
 
-            let table = fetch_configs(kube_client, &target_namespaces).await;
+            let table =
+                fetch_configs(kube_client, &target_namespaces, label_selector.as_deref()).await;
 
             if let Err(e) = tx.send(ConfigResponse::Table(table).into()) {
                 logger!(error, "Failed to send ConfigResponse::Table: {}", e);
@@ -92,12 +99,25 @@ async fn fetch_configs_per_namespace(
     client: &KubeClient,
     namespaces: &[String],
     ty: Configs,
+    label_selector: Option<&str>,
 ) -> Result<Vec<KubeTableRow>> {
     let insert_ns = insert_ns(namespaces);
+    let label_selector = label_selector.map(|s| s.to_string());
     let jobs = try_join_all(namespaces.iter().map(|ns| {
+        let base_path = ty.url_path(ns);
+        let path = match label_selector.as_deref().filter(|s| !s.is_empty()) {
+            Some(sel) => {
+                format!(
+                    "{}?labelSelector={}",
+                    base_path,
+                    utf8_percent_encode(sel, NON_ALPHANUMERIC)
+                )
+            }
+            None => base_path,
+        };
         get_resource_per_namespace(
             client,
-            ty.url_path(ns),
+            path,
             &["Name", r#"Data"#, "Age"],
             move |row: &TableRow, indexes: &[usize]| {
                 let mut row = vec![
@@ -128,7 +148,11 @@ async fn fetch_configs_per_namespace(
     Ok(jobs.into_iter().flatten().collect())
 }
 
-async fn fetch_configs(client: &KubeClient, namespaces: &[String]) -> Result<KubeTable> {
+async fn fetch_configs(
+    client: &KubeClient,
+    namespaces: &[String],
+    label_selector: Option<&str>,
+) -> Result<KubeTable> {
     let mut table = KubeTable {
         header: if namespaces.len() == 1 {
             ["KIND", "NAME", "DATA", "AGE"]
@@ -145,8 +169,8 @@ async fn fetch_configs(client: &KubeClient, namespaces: &[String]) -> Result<Kub
     };
 
     let jobs = try_join_all([
-        fetch_configs_per_namespace(client, namespaces, Configs::ConfigMap),
-        fetch_configs_per_namespace(client, namespaces, Configs::Secret),
+        fetch_configs_per_namespace(client, namespaces, Configs::ConfigMap, label_selector),
+        fetch_configs_per_namespace(client, namespaces, Configs::Secret, label_selector),
     ])
     .await?;
 

--- a/src/features/config/message.rs
+++ b/src/features/config/message.rs
@@ -14,6 +14,9 @@ pub struct RequestData {
 pub enum ConfigMessage {
     Request(ConfigRequest),
     Response(ConfigResponse),
+    /// Replace the active labelSelector value. `None` clears it (the poller
+    /// stops sending `?labelSelector=` in its sub-fetch URLs).
+    Filter(Option<String>),
 }
 
 #[derive(Debug, Clone)]

--- a/src/features/config/view/tab.rs
+++ b/src/features/config/view/tab.rs
@@ -14,10 +14,13 @@ use crate::{
     },
 };
 
-use super::widgets::{config_widget, raw_data_widget};
+use crate::ui::widget::Widget;
+
+use super::widgets::{config_filter_help_widget, config_widget, raw_data_widget};
 
 pub struct ConfigTab {
     pub tab: Tab<'static>,
+    pub config_filter_help_dialog: Widget<'static>,
 }
 
 impl ConfigTab {
@@ -31,7 +34,8 @@ impl ConfigTab {
         let error_theme = theme.error.clone().into();
 
         let config_widget = config_widget(tx, theme.clone());
-        let raw_data_widget = raw_data_widget(clipboard, theme);
+        let raw_data_widget = raw_data_widget(clipboard, theme.clone());
+        let config_filter_help_dialog = config_filter_help_widget(theme);
 
         let layout = TabLayout::new(layout, split_direction);
 
@@ -43,6 +47,7 @@ impl ConfigTab {
                 layout,
             )
             .error_theme(error_theme),
+            config_filter_help_dialog,
         }
     }
 }

--- a/src/features/config/view/widgets.rs
+++ b/src/features/config/view/widgets.rs
@@ -1,5 +1,7 @@
 mod config;
+mod config_filter_help;
 mod raw_data;
 
 pub(super) use config::*;
+pub(super) use config_filter_help::*;
 pub(super) use raw_data::*;

--- a/src/features/config/view/widgets/config.rs
+++ b/src/features/config/view/widgets/config.rs
@@ -4,13 +4,15 @@ use crate::{
     config::theme::WidgetThemeConfig,
     features::{
         component_id::{CONFIG_RAW_DATA_WIDGET_ID, CONFIG_WIDGET_ID},
-        config::message::{ConfigRequest, RequestData},
+        config::{
+            config_filter_applicator,
+            message::{ConfigRequest, RequestData},
+        },
     },
     message::Message,
     ui::{
         event::EventResult,
         widget::{
-            substring_applicator,
             FilterForm,
             FilterFormTheme,
             Table,
@@ -45,7 +47,7 @@ pub fn config_widget(tx: &Sender<Message>, theme: WidgetThemeConfig) -> Widget<'
         .widget_base(widget_base)
         .filter_form(filter_form)
         .theme(table_theme)
-        .filter_applicator(substring_applicator("NAME"))
+        .filter_applicator(config_filter_applicator(tx.clone()))
         .block_injection(block_injection())
         .on_select(on_select(tx))
         .build()

--- a/src/features/config/view/widgets/config_filter_help.rs
+++ b/src/features/config/view/widgets/config_filter_help.rs
@@ -1,0 +1,87 @@
+use indoc::indoc;
+use ratatui::crossterm::event::KeyCode;
+
+use crate::{
+    config::theme::WidgetThemeConfig,
+    features::component_id::CONFIG_FILTER_HELP_DIALOG_ID,
+    message::UserEvent,
+    ui::{
+        event::EventResult,
+        widget::{SearchForm, SearchFormTheme, Text, TextTheme, Widget, WidgetBase, WidgetTheme},
+        Window,
+    },
+};
+
+pub fn config_filter_help_widget(theme: WidgetThemeConfig) -> Widget<'static> {
+    let widget_theme = WidgetTheme::from(theme.clone());
+    let text_theme = TextTheme::from(theme.clone());
+    let search_theme = SearchFormTheme::from(theme);
+
+    let widget_base = WidgetBase::builder()
+        .title("Config Filter Help")
+        .theme(widget_theme)
+        .build();
+
+    let search_form = SearchForm::builder().theme(search_theme).build();
+
+    Text::builder()
+        .id(CONFIG_FILTER_HELP_DIALOG_ID)
+        .widget_base(widget_base)
+        .search_form(search_form)
+        .theme(text_theme)
+        .items(content())
+        .action(UserEvent::from(KeyCode::Enter), close_dialog())
+        .build()
+        .into()
+}
+
+fn content() -> Vec<String> {
+    indoc! {r#"
+        Usage: TERM [ TERM ]...
+
+        Terms:
+           <value>            Plain value: NAME include (regex).
+           NAME:<regex>       Include rows where NAME matches.
+           KIND:<regex>       Include where KIND matches (ConfigMap, Secret).
+                              Multiple same-column includes are OR (in-list).
+           !<COL>:<regex>     Exclude rows whose COL matches.
+           label:<selector>   Kubernetes labelSelector, applied
+                              server-side (e.g. app=nginx,env=prod).
+                              Last 'label:' wins if repeated.
+
+        Quoting (values with spaces):
+           "value with spaces"           Double-quoted value
+           'value with spaces'           Single-quoted value
+           \" \' \\                      Literal " ' \ inside quotes
+           \<other>                      Backslash preserved (regex \s etc.)
+
+        Combining:
+           Same column, multiple includes  ->  OR (in-list)
+           Different columns, includes     ->  AND across columns
+           Any matching exclude            ->  row excluded
+           Bare values                     ->  treated as NAME includes
+
+        Examples
+           cm-                             NAME contains 'cm-'
+           KIND:ConfigMap                  Only ConfigMaps
+           !KIND:Secret                    Exclude Secrets
+           NAME:web KIND:ConfigMap         AND across columns
+           label:app=nginx                 Server-side label filter
+
+        Columns are the builtin Config columns (NAME / KIND / DATA / AGE);
+        unknown columns produce an error. Column names ignore case, spaces,
+        '-' and '_'. The 'namespace' column is not filterable — use the
+        namespace selector. Press Enter to apply, Esc to cancel. Type ? or
+        help in the filter input to open this help.
+    "# }
+    .lines()
+    .map(ToString::to_string)
+    .collect()
+}
+
+fn close_dialog() -> impl Fn(&mut Window) -> EventResult {
+    move |w: &mut Window| {
+        w.close_dialog();
+        EventResult::Nop
+    }
+}

--- a/src/workers/kube/controller.rs
+++ b/src/workers/kube/controller.rs
@@ -68,6 +68,7 @@ pub type StyledTargetApiResources = Vec<StyledApiResource>;
 
 pub type SharedPodColumns = Arc<RwLock<PodColumns>>;
 pub type SharedPodFilter = Arc<RwLock<Option<String>>>;
+pub type SharedConfigFilter = Arc<RwLock<Option<String>>>;
 
 /// APIタブのダイアログで表示されるAPIリソースのスタイル設定
 #[derive(Debug, Clone)]
@@ -309,6 +310,7 @@ impl KubeController {
                 node_config.default_columns.clone().unwrap_or_default(),
             ));
             let shared_node_filter: SharedNodeFilter = Arc::new(RwLock::new(None));
+            let shared_config_filter: SharedConfigFilter = Arc::new(RwLock::new(None));
 
             let contexts = kubeconfig
                 .contexts
@@ -328,6 +330,7 @@ impl KubeController {
                 shared_pod_filter: shared_pod_filter.clone(),
                 shared_node_columns: shared_node_columns.clone(),
                 shared_node_filter: shared_node_filter.clone(),
+                shared_config_filter: shared_config_filter.clone(),
                 apis_config: apis_config.clone(),
                 yaml_config: yaml_config.clone(),
                 fallback_namespaces: fallback_namespaces.clone(),
@@ -353,9 +356,13 @@ impl KubeController {
             )
             .spawn();
 
-            let config_handle =
-                ConfigPoller::new(tx.clone(), shared_target_namespaces.clone(), client.clone())
-                    .spawn();
+            let config_handle = ConfigPoller::new(
+                tx.clone(),
+                shared_target_namespaces.clone(),
+                shared_config_filter.clone(),
+                client.clone(),
+            )
+            .spawn();
 
             let network_handle = NetworkPoller::new(
                 tx.clone(),
@@ -444,6 +451,7 @@ struct EventControllerArgs {
     shared_pod_filter: SharedPodFilter,
     shared_node_columns: SharedNodeColumns,
     shared_node_filter: SharedNodeFilter,
+    shared_config_filter: SharedConfigFilter,
     apis_config: ApisConfig,
     yaml_config: YamlConfig,
     fallback_namespaces: Option<Vec<String>>,
@@ -462,6 +470,7 @@ struct EventController {
     shared_pod_filter: SharedPodFilter,
     shared_node_columns: SharedNodeColumns,
     shared_node_filter: SharedNodeFilter,
+    shared_config_filter: SharedConfigFilter,
     apis_config: ApisConfig,
     yaml_config: YamlConfig,
     fallback_namespaces: Option<Vec<String>>,
@@ -481,6 +490,7 @@ impl EventController {
             shared_pod_filter: args.shared_pod_filter,
             shared_node_columns: args.shared_node_columns,
             shared_node_filter: args.shared_node_filter,
+            shared_config_filter: args.shared_config_filter,
             apis_config: args.apis_config,
             yaml_config: args.yaml_config,
             fallback_namespaces: args.fallback_namespaces,
@@ -531,6 +541,7 @@ impl Worker for EventController {
             shared_pod_filter,
             shared_node_columns,
             shared_node_filter,
+            shared_config_filter,
             apis_config,
             yaml_config,
             fallback_namespaces,
@@ -668,6 +679,10 @@ impl Worker for EventController {
                                 Some(ConfigsDataWorker::new(tx, kube_client.clone(), req).spawn());
 
                             task::yield_now().await;
+                        }
+
+                        Kube::Config(ConfigMessage::Filter(sel)) => {
+                            *shared_config_filter.write().await = sel;
                         }
 
                         Kube::Api(ApiMessage::Request(req)) => {

--- a/src/workers/render/window.rs
+++ b/src/workers/render/window.rs
@@ -231,7 +231,10 @@ impl WindowInit {
             self.log_max_lines,
         );
 
-        let ConfigTab { tab: config_tab } = ConfigTab::new(
+        let ConfigTab {
+            tab: config_tab,
+            config_filter_help_dialog,
+        } = ConfigTab::new(
             "Config",
             &self.tx,
             &clipboard,
@@ -321,6 +324,7 @@ impl WindowInit {
             log_query_help_dialog,
             pod_columns_dialog,
             pod_filter_help_dialog,
+            config_filter_help_dialog,
             node_columns_dialog,
             node_filter_help_dialog,
             yaml_dialog,


### PR DESCRIPTION
## Summary

Migrate the Config tab from `substring_applicator("NAME")` to the column-aware filter framework, mirroring the Pod migration (PR #992). Since the Config view is an aggregated table of ConfigMaps and Secrets, `kind:` becomes a useful new filter dimension — users can scope to a single resource type with `kind:ConfigMap` or `!kind:Secret`.

## What changed

### New filter capabilities

| Syntax | Meaning |
|---|---|
| `cm-` | bare value → `NAME` include (regex) — same as before |
| `kind:ConfigMap` | only ConfigMaps |
| `!kind:Secret` | exclude Secrets |
| `name:web kind:ConfigMap` | AND across columns |
| `data:0` | filter by DATA value |
| `age:1d` | filter by AGE value |
| `label:app=nginx` | server-side labelSelector, applied to both ConfigMap and Secret sub-fetches |

### NAMESPACE Z-model

Mirrors Pod #992. Typing `namespace:default` returns the guidance message `"namespace is selected via the namespace selector, not the filter"` rather than the generic unknown-column error. Namespace is a scope, not a row attribute.

### Plumbing

- `ConfigMessage::Filter(Option<String>)` added
- `SharedConfigFilter = Arc<RwLock<Option<String>>>` added to `workers/kube/controller.rs`, wired into `ConfigPoller` alongside `shared_target_namespaces`
- Controller's main loop routes `Kube::Config(ConfigMessage::Filter(sel))` into `shared_config_filter`
- `fetch_configs` threads `label_selector` to both `fetch_configs_per_namespace` calls (ConfigMap + Secret)
- Per-sub-fetch URL: `?labelSelector=<percent_encoding::utf8_percent_encode(_, NON_ALPHANUMERIC)>` (consistent with PR #996)
- `config_filter_help_widget` new dialog (Config-specific examples), registered in `window.rs`
- `ConfigTab` grows `config_filter_help_dialog: Widget<'static>` field

### Help dialog

Press `?` or type `help` in the filter input to open `CONFIG_FILTER_HELP_DIALOG_ID`. Contents mirror Pod's help with Config-specific examples (`KIND:ConfigMap`, `!KIND:Secret`, etc.). Help text notes that columns are the builtin Config columns (NAME / KIND / DATA / AGE).

## Test plan

- [x] `cargo build`: clean (only pre-existing `try_from_kubeconfig` warning)
- [x] `cargo test --all`: 698 passed / 0 failed (was 688 + 10 new tests)
- [x] `cargo clippy --all-targets`: no new warnings
- [x] `cargo +nightly fmt --check`: clean
- [x] Manual GKE smoke verified:
  - [x] Bare value `nginx` in the Config tab narrows rows whose NAME contains `nginx` (no regression)
  - [x] `kind:ConfigMap` shows ConfigMaps only
  - [x] `!kind:Secret` excludes Secrets
  - [x] `name:web kind:ConfigMap` applies AND across columns
  - [x] `namespace:default` returns the guidance message
  - [x] `label:app=nginx` applies the server-side filter to both ConfigMap and Secret sub-fetches (rows that match only one resource type appear from that type only; rows that match both appear from both)
  - [x] `?` or `help` in the filter input opens the Config Filter Help dialog
  - [x] Filter persists across the 1-second poll loop
  - [x] Esc clears the filter and the table returns to the full set

## Test coverage added

9 cases for `parse_config_filter`:
- empty input
- bare value → NAME include
- builtin columns (kind: include / !kind: exclude)
- data / age accepted
- label selector capture
- unknown column → error
- namespace → guidance message (NOT generic unknown-column)
- label keyword bypass (`label:` is not treated as a column lookup)
- quoted value with whitespace

1 case for `config_filter_applicator`:
- constructs without panic

## Related

- PR #992 — Pod column-aware filter (this PR mirrors that pattern for Config)
- PR #996 — labelSelector URL encoding (same `utf8_percent_encode` applied here)
- Next: Network tab migration (same scope, more sub-resources)