### PR TITLE
feat(network): column-aware filter for Network tab (kind:/name:/label:/...) + substring_applicator cleanup

### DIFF
--- a/src/features/component_id.rs
+++ b/src/features/component_id.rs
@@ -38,6 +38,7 @@ component_id!(
     node_filter_help_dialog,
     pod_filter_help_dialog,
     config_filter_help_dialog,
+    network_filter_help_dialog,
     pod_log_query_help_dialog,
     context_dialog,
     single_namespace_dialog,

--- a/src/features/network.rs
+++ b/src/features/network.rs
@@ -1,3 +1,6 @@
+mod filter;
 pub mod kube;
 pub mod message;
 pub mod view;
+
+pub use filter::network_filter_applicator;

--- a/src/features/network/filter.rs
+++ b/src/features/network/filter.rs
@@ -1,0 +1,74 @@
+//! Network tab filter: parser + `TableFilterApplicator` factory.
+//!
+//! The applicator wires `parse_network_filter` (which builds on the shared
+//! `parse_table_filter`) into the Table widget with `EnterToConfirm` strategy.
+//! Server-side `labelSelector` is forwarded to the Network poller via
+//! `NetworkMessage::Filter` from `on_apply`/`on_cancel`. Typing `?` or `help`
+//! in the filter input opens the `NETWORK_FILTER_HELP_DIALOG_ID` dialog.
+
+mod parser;
+
+use crossbeam::channel::Sender;
+
+use crate::{
+    features::{component_id::NETWORK_FILTER_HELP_DIALOG_ID, network::message::NetworkMessage},
+    message::Message,
+    ui::{
+        widget::{
+            ApplyStrategy,
+            OnFilterApply,
+            OnFilterCancel,
+            TableFilterApplicator,
+            TableFilterParser,
+        },
+        Window,
+    },
+};
+
+pub use parser::parse_network_filter;
+
+/// Build the Network tab's filter applicator.
+///
+/// `tx` is captured by `on_apply`/`on_cancel` to forward the parsed
+/// `label_selector` to the Network poller via `NetworkMessage::Filter`.
+///
+/// The applicator uses `EnterToConfirm` so the parser only runs on Enter
+/// (avoids server-side roundtrips mid-typing across the many sub-fetchers
+/// the Network tab aggregates).
+pub fn network_filter_applicator(tx: Sender<Message>) -> TableFilterApplicator {
+    let parser: TableFilterParser = (move |input: &str| parse_network_filter(input)).into();
+
+    let tx_apply = tx.clone();
+    let tx_cancel = tx;
+
+    let on_apply: OnFilterApply = (move |predicate: &crate::ui::widget::TableFilterPredicate,
+                                         _window: &mut Window| {
+        tx_apply
+            .send(NetworkMessage::Filter(predicate.label_selector.clone()).into())
+            .expect("Failed to send NetworkMessage::Filter");
+    })
+    .into();
+
+    let on_cancel: OnFilterCancel = (move |_window: &mut Window| {
+        tx_cancel
+            .send(NetworkMessage::Filter(None).into())
+            .expect("Failed to send NetworkMessage::Filter(None) on cancel");
+    })
+    .into();
+
+    TableFilterApplicator::new(parser, ApplyStrategy::EnterToConfirm)
+        .with_help_dialog(NETWORK_FILTER_HELP_DIALOG_ID)
+        .with_on_apply(on_apply)
+        .with_on_cancel(on_cancel)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn applicator_constructs_without_panic() {
+        let (tx, _rx) = crossbeam::channel::bounded(1);
+        let _ = network_filter_applicator(tx);
+    }
+}

--- a/src/features/network/filter/parser.rs
+++ b/src/features/network/filter/parser.rs
@@ -1,0 +1,126 @@
+//! Network filter parser.
+//!
+//! Delegates tokenization/quoting/predicate-building to the shared
+//! `parse_table_filter`. The Network-specific part is the column validator:
+//! `namespace:` returns a guidance message (namespace is a scope, not a
+//! column-level filter — use the namespace selector); other unknown columns
+//! return `unknown column '<x>'`; the builtin Network columns (`name`, `kind`,
+//! `age`) are accepted.
+
+use std::collections::HashSet;
+
+use crate::ui::widget::{normalize_column_name, parse_table_filter, TableFilterPredicate};
+
+/// Builtin Network columns (header form). The Network tab aggregates many
+/// resource types (Service, Ingress, NetworkPolicy, Pod, Gateway, HTTPRoute)
+/// into a single table; all columns are fixed in code.
+const BUILTIN_COLUMNS: &[&str] = &["NAME", "KIND", "AGE"];
+
+/// Parse a Network-filter input string into a `TableFilterPredicate`.
+///
+/// `namespace:` is rejected with a guidance message that points users to the
+/// namespace selector (namespace is a scope, not a row attribute). This check
+/// fires *before* the builtin lookup. Other columns are validated against
+/// `BUILTIN_COLUMNS`; a column not in that set produces `unknown column '<x>'`.
+pub fn parse_network_filter(input: &str) -> Result<TableFilterPredicate, String> {
+    let valid: HashSet<String> = BUILTIN_COLUMNS
+        .iter()
+        .map(|c| normalize_column_name(c))
+        .collect();
+    parse_table_filter(input, |column| {
+        let normalized = normalize_column_name(column);
+        if normalized == "namespace" {
+            return Err(
+                "namespace is selected via the namespace selector, not the filter".to_string(),
+            );
+        }
+        if valid.contains(&normalized) {
+            Ok(())
+        } else {
+            Err(format!("unknown column '{}'", column))
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn empty_input_yields_empty_predicate() {
+        let p = parse_network_filter("").unwrap();
+        assert!(p.column_includes.is_empty());
+        assert!(p.column_excludes.is_empty());
+        assert_eq!(p.label_selector, None);
+    }
+
+    #[test]
+    fn bare_value_becomes_name_include() {
+        let p = parse_network_filter("my-svc").unwrap();
+        let patterns = p.column_includes.get("name").expect("name column");
+        assert!(patterns[0].is_match("my-svc-abc"));
+    }
+
+    #[test]
+    fn builtin_columns_are_accepted() {
+        let p = parse_network_filter("kind:Service !kind:Pod").unwrap();
+        assert!(p.column_includes.contains_key("kind"));
+        assert!(p.column_excludes.contains_key("kind"));
+    }
+
+    #[test]
+    fn age_column_is_accepted() {
+        let p = parse_network_filter("age:1d").unwrap();
+        assert!(p.column_includes.contains_key("age"));
+    }
+
+    #[test]
+    fn label_selector_is_captured() {
+        let p = parse_network_filter("label:app=nginx").unwrap();
+        assert_eq!(p.label_selector.as_deref(), Some("app=nginx"));
+    }
+
+    #[test]
+    fn unknown_column_produces_parse_error() {
+        let err = parse_network_filter("staus:Active").unwrap_err();
+        assert!(
+            err.contains("unknown column") && err.contains("staus"),
+            "got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn namespace_returns_guidance_message_not_unknown_column() {
+        let err = parse_network_filter("namespace:default").unwrap_err();
+        assert_eq!(
+            err,
+            "namespace is selected via the namespace selector, not the filter"
+        );
+        let err2 = parse_network_filter("NAMESPACE:default").unwrap_err();
+        assert_eq!(
+            err2,
+            "namespace is selected via the namespace selector, not the filter"
+        );
+    }
+
+    #[test]
+    fn label_keyword_is_not_treated_as_a_column_lookup() {
+        assert!(parse_network_filter("label:app=nginx").is_ok());
+    }
+
+    #[test]
+    fn quoted_value_with_whitespace() {
+        let p = parse_network_filter(r#"name:"my svc""#).unwrap();
+        let patterns = p.column_includes.get("name").unwrap();
+        assert!(patterns[0].is_match("my svc"));
+    }
+
+    #[test]
+    fn data_column_is_not_accepted_unlike_config() {
+        // Config has DATA column; Network does not. Confirm validator rejects it.
+        let err = parse_network_filter("data:0").unwrap_err();
+        assert!(err.contains("unknown column") && err.contains("data"));
+    }
+}

--- a/src/features/network/kube/network.rs
+++ b/src/features/network/kube/network.rs
@@ -12,6 +12,7 @@ use k8s_openapi::{
     Resource,
 };
 use kube::Resource as _;
+use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 
 use crate::{
     features::{
@@ -29,7 +30,7 @@ use crate::{
     },
     logger,
     message::Message,
-    workers::kube::{InfiniteWorker, SharedTargetNamespaces},
+    workers::kube::{InfiniteWorker, SharedNetworkFilter, SharedTargetNamespaces},
 };
 
 #[derive(Debug, Default, Clone)]
@@ -155,8 +156,13 @@ impl TargetResource {
         }
     }
 
-    async fn fetch_table(&self, client: &KubeClient, ns: &str) -> Result<Table> {
-        let path = match self {
+    async fn fetch_table(
+        &self,
+        client: &KubeClient,
+        ns: &str,
+        label_selector: Option<&str>,
+    ) -> Result<Table> {
+        let base_path = match self {
             Self::Ingress => Ingress::url_path(&Default::default(), Some(ns)),
             Self::Service => Service::url_path(&Default::default(), Some(ns)),
             Self::Pod => Pod::url_path(&Default::default(), Some(ns)),
@@ -173,6 +179,17 @@ impl TargetResource {
             Self::HTTPRoute(HTTPRouteVersion::V1Beta1) => {
                 v1beta1::HTTPRoute::url_path(&Default::default(), Some(ns))
             }
+        };
+
+        let path = match label_selector.filter(|s| !s.is_empty()) {
+            Some(sel) => {
+                format!(
+                    "{}?labelSelector={}",
+                    base_path,
+                    utf8_percent_encode(sel, NON_ALPHANUMERIC)
+                )
+            }
+            None => base_path,
         };
 
         client.request_table(&path).await.with_context(|| {
@@ -196,6 +213,7 @@ impl std::fmt::Display for TargetResource {
 pub struct NetworkPoller {
     tx: Sender<Message>,
     shared_target_namespaces: SharedTargetNamespaces,
+    shared_network_filter: SharedNetworkFilter,
     kube_client: KubeClient,
     api_resources: SharedApiResources,
 }
@@ -204,12 +222,14 @@ impl NetworkPoller {
     pub fn new(
         tx: Sender<Message>,
         shared_target_namespaces: SharedTargetNamespaces,
+        shared_network_filter: SharedNetworkFilter,
         kube_client: KubeClient,
         api_resources: SharedApiResources,
     ) -> Self {
         Self {
             tx,
             shared_target_namespaces,
+            shared_network_filter,
             kube_client,
             api_resources,
         }
@@ -284,7 +304,11 @@ impl InfiniteWorker for NetworkPoller {
                 target_resources(&apis)
             };
 
-            let table = self.polling(&target_resources).await;
+            let label_selector = self.shared_network_filter.read().await.clone();
+
+            let table = self
+                .polling(&target_resources, label_selector.as_deref())
+                .await;
 
             if let Err(e) = tx.send(NetworkResponse::List(table).into()) {
                 logger!(error, "Failed to send NetworkResponse::List: {}", e);
@@ -297,13 +321,17 @@ impl InfiniteWorker for NetworkPoller {
 const TARGET_COLUMNS: [&str; 2] = ["Name", "Age"];
 
 impl NetworkPoller {
-    async fn polling(&self, target_resources: &[TargetResource]) -> Result<KubeTable> {
+    async fn polling(
+        &self,
+        target_resources: &[TargetResource],
+        label_selector: Option<&str>,
+    ) -> Result<KubeTable> {
         let target_namespaces = self.shared_target_namespaces.read().await;
 
         let rows: Vec<_> = join_all(
             target_resources
                 .iter()
-                .map(|kind| self.fetch_resource(kind, &target_namespaces)),
+                .map(|kind| self.fetch_resource(kind, &target_namespaces, label_selector)),
         )
         .await
         .into_iter()
@@ -327,14 +355,13 @@ impl NetworkPoller {
         &self,
         kind: &TargetResource,
         namespaces: &[String],
+        label_selector: Option<&str>,
     ) -> Result<Vec<NetworkTableRow>> {
         let client = &self.kube_client;
 
-        let jobs = try_join_all(
-            namespaces
-                .iter()
-                .map(|ns| fetch_resource_per_namespace(client, kind, ns, &TARGET_COLUMNS)),
-        )
+        let jobs = try_join_all(namespaces.iter().map(|ns| {
+            fetch_resource_per_namespace(client, kind, ns, &TARGET_COLUMNS, label_selector)
+        }))
         .await?;
 
         Ok(jobs.into_iter().flatten().collect())
@@ -346,8 +373,9 @@ async fn fetch_resource_per_namespace(
     kind: &TargetResource,
     ns: &str,
     target_columns: &[&str],
+    label_selector: Option<&str>,
 ) -> Result<Vec<NetworkTableRow>> {
-    let table = kind.fetch_table(client, ns).await?;
+    let table = kind.fetch_table(client, ns, label_selector).await?;
 
     let indexes = table.find_indexes(target_columns)?;
 

--- a/src/features/network/message.rs
+++ b/src/features/network/message.rs
@@ -46,6 +46,9 @@ pub enum NetworkResponse {
 pub enum NetworkMessage {
     Request(NetworkRequest),
     Response(NetworkResponse),
+    /// Replace the active labelSelector value. `None` clears it (the poller
+    /// stops sending `?labelSelector=` in its sub-fetch URLs).
+    Filter(Option<String>),
 }
 
 impl NetworkRequest {

--- a/src/features/network/view/tab.rs
+++ b/src/features/network/view/tab.rs
@@ -8,17 +8,19 @@ use crate::{
     config::theme::WidgetThemeConfig,
     features::{
         component_id::NETWORK_TAB_ID,
-        network::view::widgets::{description_widget, network_widget},
+        network::view::widgets::{description_widget, network_filter_help_widget, network_widget},
     },
     message::Message,
     ui::{
         tab::{LayoutElement, NestedLayoutElement, NestedWidgetLayout, TabLayout},
+        widget::Widget,
         Tab,
     },
 };
 
 pub struct NetworkTab {
     pub tab: Tab<'static>,
+    pub network_filter_help_dialog: Widget<'static>,
 }
 
 impl NetworkTab {
@@ -32,7 +34,8 @@ impl NetworkTab {
         let error_theme = theme.error.clone().into();
 
         let network_widget = network_widget(tx, theme.clone());
-        let description_widget = description_widget(clipboard, theme);
+        let description_widget = description_widget(clipboard, theme.clone());
+        let network_filter_help_dialog = network_filter_help_widget(theme);
 
         let layout = TabLayout::new(layout, split_direction);
 
@@ -44,6 +47,7 @@ impl NetworkTab {
                 layout,
             )
             .error_theme(error_theme),
+            network_filter_help_dialog,
         }
     }
 }

--- a/src/features/network/view/widgets.rs
+++ b/src/features/network/view/widgets.rs
@@ -1,5 +1,7 @@
 mod description;
 mod network;
+mod network_filter_help;
 
 pub(super) use description::*;
 pub(super) use network::*;
+pub(super) use network_filter_help::*;

--- a/src/features/network/view/widgets/network.rs
+++ b/src/features/network/view/widgets/network.rs
@@ -11,14 +11,16 @@ use crate::{
     config::theme::WidgetThemeConfig,
     features::{
         component_id::{NETWORK_DESCRIPTION_WIDGET_ID, NETWORK_WIDGET_ID},
-        network::message::{NetworkRequest, NetworkRequestTargetParams},
+        network::{
+            message::{NetworkRequest, NetworkRequestTargetParams},
+            network_filter_applicator,
+        },
     },
     kube::apis::networking::gateway::v1::{Gateway, HTTPRoute},
     message::Message,
     ui::{
         event::EventResult,
         widget::{
-            substring_applicator,
             FilterForm,
             FilterFormTheme,
             Table,
@@ -53,7 +55,7 @@ pub fn network_widget(tx: &Sender<Message>, theme: WidgetThemeConfig) -> Widget<
         .widget_base(widget_base)
         .filter_form(filter_form)
         .theme(table_theme)
-        .filter_applicator(substring_applicator("NAME"))
+        .filter_applicator(network_filter_applicator(tx.clone()))
         .block_injection(block_injection())
         .on_select(on_select(tx))
         .build()

--- a/src/features/network/view/widgets/network_filter_help.rs
+++ b/src/features/network/view/widgets/network_filter_help.rs
@@ -1,0 +1,89 @@
+use indoc::indoc;
+use ratatui::crossterm::event::KeyCode;
+
+use crate::{
+    config::theme::WidgetThemeConfig,
+    features::component_id::NETWORK_FILTER_HELP_DIALOG_ID,
+    message::UserEvent,
+    ui::{
+        event::EventResult,
+        widget::{SearchForm, SearchFormTheme, Text, TextTheme, Widget, WidgetBase, WidgetTheme},
+        Window,
+    },
+};
+
+pub fn network_filter_help_widget(theme: WidgetThemeConfig) -> Widget<'static> {
+    let widget_theme = WidgetTheme::from(theme.clone());
+    let text_theme = TextTheme::from(theme.clone());
+    let search_theme = SearchFormTheme::from(theme);
+
+    let widget_base = WidgetBase::builder()
+        .title("Network Filter Help")
+        .theme(widget_theme)
+        .build();
+
+    let search_form = SearchForm::builder().theme(search_theme).build();
+
+    Text::builder()
+        .id(NETWORK_FILTER_HELP_DIALOG_ID)
+        .widget_base(widget_base)
+        .search_form(search_form)
+        .theme(text_theme)
+        .items(content())
+        .action(UserEvent::from(KeyCode::Enter), close_dialog())
+        .build()
+        .into()
+}
+
+fn content() -> Vec<String> {
+    indoc! {r#"
+        Usage: TERM [ TERM ]...
+
+        Terms:
+           <value>            Plain value: NAME include (regex).
+           NAME:<regex>       Include rows where NAME matches.
+           KIND:<regex>       Include where KIND matches (Service, Ingress,
+                              NetworkPolicy, Pod, Gateway, HTTPRoute).
+                              Multiple same-column includes are OR (in-list).
+           !<COL>:<regex>     Exclude rows whose COL matches.
+           label:<selector>   Kubernetes labelSelector, applied
+                              server-side (e.g. app=nginx,env=prod).
+                              Last 'label:' wins if repeated.
+
+        Quoting (values with spaces):
+           "value with spaces"           Double-quoted value
+           'value with spaces'           Single-quoted value
+           \" \' \\                      Literal " ' \ inside quotes
+           \<other>                      Backslash preserved (regex \s etc.)
+
+        Combining:
+           Same column, multiple includes  ->  OR (in-list)
+           Different columns, includes     ->  AND across columns
+           Any matching exclude            ->  row excluded
+           Bare values                     ->  treated as NAME includes
+
+        Examples
+           nginx                           NAME contains 'nginx'
+           KIND:Service                    Only Services
+           !KIND:Pod                       Exclude Pods
+           KIND:Service NAME:web           AND across columns
+           KIND:Ingress KIND:HTTPRoute     KIND in (Ingress, HTTPRoute)
+           label:app=nginx                 Server-side label filter
+
+        Columns are the builtin Network columns (NAME / KIND / AGE);
+        unknown columns produce an error. Column names ignore case, spaces,
+        '-' and '_'. The 'namespace' column is not filterable — use the
+        namespace selector. Press Enter to apply, Esc to cancel. Type ? or
+        help in the filter input to open this help.
+    "# }
+    .lines()
+    .map(ToString::to_string)
+    .collect()
+}
+
+fn close_dialog() -> impl Fn(&mut Window) -> EventResult {
+    move |w: &mut Window| {
+        w.close_dialog();
+        EventResult::Nop
+    }
+}

--- a/src/ui/widget/table.rs
+++ b/src/ui/widget/table.rs
@@ -50,7 +50,6 @@ pub use filter::{FilterForm, FilterFormTheme};
 #[allow(unused_imports)]
 pub use filter_applicator::{
     normalize_column_name,
-    substring_applicator,
     ApplyStrategy,
     OnFilterApply,
     OnFilterCancel,

--- a/src/ui/widget/table/filter_applicator.rs
+++ b/src/ui/widget/table/filter_applicator.rs
@@ -228,42 +228,6 @@ impl TableFilterApplicator {
 #[allow(unused_imports)]
 use EventResult as _;
 
-/// 既存タブが使う「単一列の部分一致」フィルタを構成する。
-/// `column` は対象列名（大小区別なし、内部で小文字化）。
-///
-/// 挙動は既存の `filtered_key + split(' ').any(contains)` と等価:
-/// - 空入力 → フィルタなし（全行 pass）
-/// - スペース区切りの複数 pattern → OR
-/// - 各 pattern は `regex::escape` でリテラル化（ユーザーは regex を
-///   意識しなくていい、`.` `*` 等が混入しても安全）
-pub fn substring_applicator(column: &str) -> TableFilterApplicator {
-    let col = column.to_string().to_lowercase();
-    let parser: TableFilterParser = (move |input: &str| {
-        let raw = input.to_string();
-        let patterns: Result<Vec<Regex>, _> = input
-            .split_whitespace()
-            .map(regex::escape)
-            .map(|p| Regex::new(&p))
-            .collect();
-        let patterns = patterns.map_err(|e| e.to_string())?;
-
-        let mut column_includes = HashMap::new();
-        if !patterns.is_empty() {
-            column_includes.insert(col.clone(), patterns);
-        }
-
-        Ok(TableFilterPredicate {
-            column_includes,
-            column_excludes: HashMap::new(),
-            label_selector: None,
-            raw,
-        })
-    })
-    .into();
-
-    TableFilterApplicator::new(parser, ApplyStrategy::Live)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -501,74 +465,6 @@ mod tests {
             ..TableFilterPredicate::default()
         };
         assert!(!pred.is_empty());
-    }
-
-    fn invoke_parser(a: &TableFilterApplicator, input: &str) -> TableFilterPredicate {
-        (a.parser.closure)(input).expect("test input must parse")
-    }
-
-    #[test]
-    fn substring_applicator_empty_input_matches_everything() {
-        let a = substring_applicator("NAME");
-        let p = invoke_parser(&a, "");
-        let h = header(&["NAME"]);
-        assert!(p.matches(&make_item(&["nginx"]), &h));
-        assert!(p.matches(&make_item(&[""]), &h));
-        assert!(p.is_empty());
-    }
-
-    #[test]
-    fn substring_applicator_single_pattern_substring_match() {
-        let a = substring_applicator("NAME");
-        let p = invoke_parser(&a, "nginx");
-        let h = header(&["NAME"]);
-        assert!(p.matches(&make_item(&["abc-nginx-prod"]), &h));
-        assert!(!p.matches(&make_item(&["web-server"]), &h));
-    }
-
-    #[test]
-    fn substring_applicator_space_separated_is_or() {
-        // 既存挙動と等価: "nginx web" は NAME に nginx OR web
-        let a = substring_applicator("NAME");
-        let p = invoke_parser(&a, "nginx web");
-        let h = header(&["NAME"]);
-        assert!(p.matches(&make_item(&["nginx-x"]), &h));
-        assert!(p.matches(&make_item(&["web-y"]), &h));
-        assert!(!p.matches(&make_item(&["api-z"]), &h));
-    }
-
-    #[test]
-    fn substring_applicator_special_chars_are_escaped() {
-        // "a.b" がリテラルとして扱われる（regex の `.` ではない）
-        let a = substring_applicator("NAME");
-        let p = invoke_parser(&a, "a.b");
-        let h = header(&["NAME"]);
-        assert!(p.matches(&make_item(&["x-a.b-y"]), &h));
-        assert!(!p.matches(&make_item(&["x-a_b-y"]), &h)); // regex の . なら通るがリテラルなので落ちる
-    }
-
-    #[test]
-    fn substring_applicator_strategy_is_live() {
-        let a = substring_applicator("NAME");
-        assert_eq!(a.strategy, ApplyStrategy::Live);
-    }
-
-    #[test]
-    fn substring_applicator_help_dialog_id_is_none() {
-        let a = substring_applicator("NAME");
-        assert_eq!(a.help_dialog_id, None);
-    }
-
-    #[test]
-    fn substring_applicator_on_apply_is_none() {
-        let a = substring_applicator("NAME");
-        assert!(a.on_apply.is_none());
-    }
-
-    #[test]
-    fn substring_applicator_on_cancel_is_none() {
-        let a = substring_applicator("NAME");
-        assert!(a.on_cancel.is_none());
     }
 
     #[test]

--- a/src/workers/kube/controller.rs
+++ b/src/workers/kube/controller.rs
@@ -69,6 +69,7 @@ pub type StyledTargetApiResources = Vec<StyledApiResource>;
 pub type SharedPodColumns = Arc<RwLock<PodColumns>>;
 pub type SharedPodFilter = Arc<RwLock<Option<String>>>;
 pub type SharedConfigFilter = Arc<RwLock<Option<String>>>;
+pub type SharedNetworkFilter = Arc<RwLock<Option<String>>>;
 
 /// APIタブのダイアログで表示されるAPIリソースのスタイル設定
 #[derive(Debug, Clone)]
@@ -311,6 +312,7 @@ impl KubeController {
             ));
             let shared_node_filter: SharedNodeFilter = Arc::new(RwLock::new(None));
             let shared_config_filter: SharedConfigFilter = Arc::new(RwLock::new(None));
+            let shared_network_filter: SharedNetworkFilter = Arc::new(RwLock::new(None));
 
             let contexts = kubeconfig
                 .contexts
@@ -331,6 +333,7 @@ impl KubeController {
                 shared_node_columns: shared_node_columns.clone(),
                 shared_node_filter: shared_node_filter.clone(),
                 shared_config_filter: shared_config_filter.clone(),
+                shared_network_filter: shared_network_filter.clone(),
                 apis_config: apis_config.clone(),
                 yaml_config: yaml_config.clone(),
                 fallback_namespaces: fallback_namespaces.clone(),
@@ -367,6 +370,7 @@ impl KubeController {
             let network_handle = NetworkPoller::new(
                 tx.clone(),
                 shared_target_namespaces.clone(),
+                shared_network_filter.clone(),
                 client.clone(),
                 shared_api_resources.clone(),
             )
@@ -452,6 +456,7 @@ struct EventControllerArgs {
     shared_node_columns: SharedNodeColumns,
     shared_node_filter: SharedNodeFilter,
     shared_config_filter: SharedConfigFilter,
+    shared_network_filter: SharedNetworkFilter,
     apis_config: ApisConfig,
     yaml_config: YamlConfig,
     fallback_namespaces: Option<Vec<String>>,
@@ -471,6 +476,7 @@ struct EventController {
     shared_node_columns: SharedNodeColumns,
     shared_node_filter: SharedNodeFilter,
     shared_config_filter: SharedConfigFilter,
+    shared_network_filter: SharedNetworkFilter,
     apis_config: ApisConfig,
     yaml_config: YamlConfig,
     fallback_namespaces: Option<Vec<String>>,
@@ -491,6 +497,7 @@ impl EventController {
             shared_node_columns: args.shared_node_columns,
             shared_node_filter: args.shared_node_filter,
             shared_config_filter: args.shared_config_filter,
+            shared_network_filter: args.shared_network_filter,
             apis_config: args.apis_config,
             yaml_config: args.yaml_config,
             fallback_namespaces: args.fallback_namespaces,
@@ -542,6 +549,7 @@ impl Worker for EventController {
             shared_node_columns,
             shared_node_filter,
             shared_config_filter,
+            shared_network_filter,
             apis_config,
             yaml_config,
             fallback_namespaces,
@@ -834,6 +842,10 @@ impl Worker for EventController {
                             );
 
                             task::yield_now().await;
+                        }
+
+                        Kube::Network(NetworkMessage::Filter(sel)) => {
+                            *shared_network_filter.write().await = sel;
                         }
 
                         Kube::NodeDetail(NodeDetailMessage::Request { name }) => {

--- a/src/workers/render/window.rs
+++ b/src/workers/render/window.rs
@@ -242,7 +242,10 @@ impl WindowInit {
             self.theme.component.clone(),
         );
 
-        let NetworkTab { tab: network_tab } = NetworkTab::new(
+        let NetworkTab {
+            tab: network_tab,
+            network_filter_help_dialog,
+        } = NetworkTab::new(
             "Network",
             &self.tx,
             &clipboard,
@@ -325,6 +328,7 @@ impl WindowInit {
             pod_columns_dialog,
             pod_filter_help_dialog,
             config_filter_help_dialog,
+            network_filter_help_dialog,
             node_columns_dialog,
             node_filter_help_dialog,
             yaml_dialog,


### PR DESCRIPTION
## Summary

Migrate the Network tab from `substring_applicator("NAME")` to the column-aware filter framework, completing the migration started in PR #992 (Pod) and PR #997 (Config). The Network view aggregates six+ resource types (Ingress, Service, Pod, NetworkPolicy, Gateway, HTTPRoute), so `kind:` becomes the most useful new filter dimension.

Since this PR removes the last consumer-facing use of `substring_applicator`, the function and its tests are deleted as proximate cleanup.

## New filter capabilities

| Syntax | Meaning |
|---|---|
| `nginx` | bare value → `NAME` include (regex) — same as before |
| `kind:Service` | only Services |
| `!kind:Pod` | exclude Pods |
| `kind:Ingress kind:HTTPRoute` | KIND in (Ingress, HTTPRoute) — same-column OR |
| `kind:Service name:web` | AND across columns |
| `age:1d` | filter by AGE value |
| `label:app=nginx` | server-side labelSelector, applied to **every** sub-fetch URL (per namespace × resource type) |

## NAMESPACE Z-model

Mirrors Pod #992 / Config #997. `namespace:default` returns the guidance message `"namespace is selected via the namespace selector, not the filter"` rather than the generic unknown-column error. Namespace is a scope, not a row attribute.

## Plumbing

- `NetworkMessage::Filter(Option<String>)` added
- `SharedNetworkFilter = Arc<RwLock<Option<String>>>` added to `workers/kube/controller.rs`, wired into `NetworkPoller` alongside `shared_target_namespaces` and `api_resources`
- Controller's main loop routes `Kube::Network(NetworkMessage::Filter(sel))` into `shared_network_filter`
- `fetch_table` now takes `label_selector: Option<&str>`; `polling` and `fetch_resource` thread it through; the URL is built per-resource with the encoded labelSelector appended when non-empty
- Per-sub-fetch URL: `?labelSelector=<percent_encoding::utf8_percent_encode(_, NON_ALPHANUMERIC)>` (consistent with PR #996)
- `network_filter_help_widget` new dialog (Network-specific examples), registered in `window.rs`
- `NetworkTab` grows `network_filter_help_dialog: Widget<'static>` field

## substring_applicator cleanup (in-scope)

Before this PR, `substring_applicator` was the legacy filter API used by Config / Network (Pod migrated in #992). With Network switching to `network_filter_applicator`, it is no longer used anywhere. Removed:

- `pub fn substring_applicator(column: &str) -> TableFilterApplicator` in `src/ui/widget/table/filter_applicator.rs`
- 8 unit tests for `substring_applicator`
- `invoke_parser` test helper (used only by those tests)
- The `pub use` re-export in `src/ui/widget/table.rs`

This is bundled here because this PR is the proximate cause of the dead-code condition; leaving it for a follow-up would mean shipping a warning in the next main commit.

## Test plan

- [x] `cargo build`: clean (only pre-existing `try_from_kubeconfig` warning)
- [x] `cargo test --all`: 701 passed / 0 failed (was 698 + 11 new Network tests − 8 removed substring tests = 701)
- [x] `cargo clippy --all-targets`: no new warnings
- [x] `cargo +nightly fmt --check`: clean
- [x] Manual GKE smoke verified:
  - [x] Bare value `bbt-cafe` in the Network tab narrows rows whose NAME contains `bbt-cafe` (mixed kinds, no regression)
  - [x] `kind:Service` shows Services only (58/179)
  - [x] `!kind:Pod` excludes Pods (86/179 → Services + HTTPRoutes)
  - [x] `kind:Service kind:HTTPRoute` applies OR-in-list (86/179, same as the previous exclusion)
  - [x] `kind:Service name:bbt-cafe` applies AND across columns (3/179)
  - [x] `namespace:default` returns the guidance message
  - [x] `label:app=bbt-cafe-api` applies the server-side filter per sub-fetcher — kubetui returns the same set as `kubectl get pod,svc,httproute -n latest -l app=bbt-cafe-api` (Pod-only in this case, since only the Pod carries the label; confirms the server-side filter is applied independently to each kind)
  - [x] `?` or `help` in the filter input opens the Network Filter Help dialog (title, terms, examples, namespace notice all present)
  - [x] Filter persists across the 1-second poll loop
  - [x] Esc clears the filter and the table returns to the full set

## Test coverage added

10 cases for `parse_network_filter`:
- empty input
- bare value → NAME include
- builtin columns (kind: include / !kind: exclude)
- age accepted
- label selector capture
- unknown column → error
- namespace → guidance message (NOT generic unknown-column)
- label keyword bypass (`label:` is not treated as a column lookup)
- quoted value with whitespace
- data: rejected (regression case — DATA belongs to Config, not Network)

1 case for `network_filter_applicator`:
- constructs without panic

## Related

- PR #992 — Pod column-aware filter
- PR #996 — labelSelector URL encoding (same `utf8_percent_encode` applied here)
- PR #997 — Config column-aware filter
- This PR completes the column-aware filter migration for all aggregated-view tabs